### PR TITLE
Sync frame 0.5

### DIFF
--- a/source/egg/math/Math.cc
+++ b/source/egg/math/Math.cc
@@ -324,4 +324,8 @@ f32 cos(f32 x) {
     return CosFIdx(x * RAD2FIDX);
 }
 
+f32 acos(f32 x) {
+    return std::acos(x);
+}
+
 } // namespace EGG::Mathf

--- a/source/egg/math/Math.hh
+++ b/source/egg/math/Math.hh
@@ -16,6 +16,7 @@ f32 SinFIdx(f32 fidx);
 f32 CosFIdx(f32 fidx);
 f32 sin(f32 x);
 f32 cos(f32 x);
+f32 acos(f32 x);
 
 // sin/cos struct
 struct SinCosEntry {

--- a/source/egg/math/Quat.cc
+++ b/source/egg/math/Quat.cc
@@ -4,9 +4,11 @@
 
 namespace EGG {
 
-Quatf::Quatf() = default;
+Quatf::Quatf() : w(1.0f) {}
 
 Quatf::Quatf(f32 w_, const Vector3f &v_) : v(v_), w(w_) {}
+
+Quatf::Quatf(f32 w_, f32 x_, f32 y_, f32 z_) : v(x_, y_, z_), w(w_) {}
 
 Quatf::~Quatf() = default;
 
@@ -24,6 +26,16 @@ void Quatf::setRPY(const Vector3f &rpy) {
     v.z = sz * cy * cx - cz * sy * sx;
 }
 
+void Quatf::normalise() {
+    f32 len = dot() > FLT_EPSILON ? Mathf::sqrt(dot()) : 0.0f;
+
+    if (len != 0.0f) {
+        f32 inv = 1.0f / len;
+        w *= inv;
+        v *= inv;
+    }
+}
+
 Quatf Quatf::conjugate() const {
     return Quatf(w, -v);
 }
@@ -34,5 +46,40 @@ Vector3f Quatf::rotateVector(const Vector3f &vec) const {
     res *= conj;
     return res.v;
 }
+
+Quatf Quatf::slerpTo(const Quatf &q1, f32 t) const {
+    f32 dot_ = std::max(-1.0f, std::min(1.0f, dot(q1)));
+    bool bDot = dot_ < 0.0f;
+    dot_ = std::abs(dot_);
+
+    f32 acos = Mathf::acos(dot_);
+    f32 sin = Mathf::sin(acos);
+
+    f32 s;
+    if (std::abs(sin) < 0.00001f) {
+        s = 1.0f - t;
+    } else {
+        f32 invSin = 1.0f / sin;
+        f32 tmp0 = t * acos;
+        s = invSin * Mathf::sin(acos - tmp0);
+        t = invSin * Mathf::sin(tmp0);
+    }
+
+    if (bDot) {
+        t = -t;
+    }
+
+    return Quatf(s * w + t * q1.w, s * v + t * q1.v);
+}
+
+f32 Quatf::dot() const {
+    return w * w + v.dot();
+}
+
+f32 Quatf::dot(const Quatf &q) const {
+    return w * q.w + v.dot(q.v);
+}
+
+const Quatf Quatf::ident = Quatf(1.0f, Vector3f::zero);
 
 } // namespace EGG

--- a/source/egg/math/Quat.hh
+++ b/source/egg/math/Quat.hh
@@ -7,6 +7,7 @@ namespace EGG {
 struct Quatf {
     Quatf();
     Quatf(f32 w_, const Vector3f &v_);
+    Quatf(f32 w_, f32 x_, f32 y_, f32 z_);
     ~Quatf();
 
     Quatf &operator=(const Quatf &q) {
@@ -35,11 +36,17 @@ struct Quatf {
     }
 
     void setRPY(const Vector3f &rpy);
+    void normalise();
     Quatf conjugate() const;
     Vector3f rotateVector(const Vector3f &vec) const;
+    Quatf slerpTo(const Quatf &q2, f32 t) const;
+    f32 dot() const;
+    f32 dot(const Quatf &q) const;
 
     Vector3f v;
     f32 w;
+
+    static const Quatf ident;
 };
 
 } // namespace EGG

--- a/source/egg/math/Vector.cc
+++ b/source/egg/math/Vector.cc
@@ -37,7 +37,7 @@ f32 Vector2f::normalise() {
 
 Vector3f::Vector3f(f32 x_, f32 y_, f32 z_) : x(x_), y(y_), z(z_) {}
 
-Vector3f::Vector3f() = default;
+Vector3f::Vector3f() : x(0.0f), y(0.0f), z(0.0f) {}
 
 Vector3f::~Vector3f() = default;
 

--- a/source/egg/math/Vector.hh
+++ b/source/egg/math/Vector.hh
@@ -75,12 +75,20 @@ struct Vector3f {
         return Vector3f(x * scalar, y * scalar, z * scalar);
     }
 
+    friend Vector3f operator*(f32 scalar, const Vector3f &rhs) {
+        return rhs * scalar;
+    }
+
     Vector3f &operator*=(f32 scalar) {
         return *this = *this * scalar;
     }
 
     Vector3f operator/(f32 scalar) const {
         return Vector3f(x / scalar, y / scalar, z / scalar);
+    }
+
+    Vector3f &operator/=(f32 scalar) {
+        return *this = *this / scalar;
     }
 
     Vector3f cross(const EGG::Vector3f &rhs) const;

--- a/source/game/kart/KartDynamics.hh
+++ b/source/game/kart/KartDynamics.hh
@@ -8,24 +8,39 @@ class KartDynamics {
 public:
     KartDynamics();
     void init();
+    void resetInternalVelocity();
 
-    const EGG::Vector3f &getPos() const;
-    const EGG::Vector3f &getSpeed() const;
-    const EGG::Vector3f &getTop() const;
-    const EGG::Quatf &getFullRot() const;
+    void calc(f32 dt, f32 maxSpeed, bool air);
+
+    const EGG::Vector3f &pos() const;
+    const EGG::Vector3f &velocity() const;
+    const EGG::Quatf &fullRot() const;
 
     void setPos(const EGG::Vector3f &pos);
-    void setTop(const EGG::Vector3f &top);
+    void setGravity(f32 gravity);
     void setMainRot(const EGG::Quatf &q);
     void setFullRot(const EGG::Quatf &q);
+    void setSpecialRot(const EGG::Quatf &q);
+    void setExtraRot(const EGG::Quatf &q);
 
 private:
     // These are the only vars needed in setInitialPhysicsValues
     EGG::Vector3f m_pos;
-    EGG::Vector3f m_speed;
-    EGG::Vector3f m_top;
+    EGG::Vector3f m_extVel;
+    EGG::Vector3f m_acceleration0;
+    EGG::Vector3f m_movingObjVel;
+    EGG::Vector3f m_movingRoadVel;
+    EGG::Vector3f m_velocity;
+    f32 m_speedNorm;
     EGG::Quatf m_mainRot;
     EGG::Quatf m_fullRot;
+    EGG::Vector3f m_totalForce;
+    EGG::Quatf m_specialRot;
+    EGG::Quatf m_extraRot;
+    f32 m_gravity;
+    EGG::Vector3f m_intVel;
+    bool m_forceUpright;
+    bool m_noGravity;
 };
 
 class KartDynamicsBike : public KartDynamics {};

--- a/source/game/kart/KartMove.cc
+++ b/source/game/kart/KartMove.cc
@@ -1,5 +1,6 @@
 #include "KartMove.hh"
 
+#include "game/kart/KartDynamics.hh"
 #include "game/kart/KartParam.hh"
 #include "game/kart/KartSub.hh"
 
@@ -11,7 +12,7 @@
 
 namespace Kart {
 
-KartMove::KartMove() = default;
+KartMove::KartMove() : m_scale(1.0f, 1.0f, 1.0f) {}
 
 void KartMove::setInitialPhysicsValues(const EGG::Vector3f &pos, const EGG::Vector3f &angles) {
     EGG::Quatf quaternion;
@@ -33,6 +34,23 @@ void KartMove::setInitialPhysicsValues(const EGG::Vector3f &pos, const EGG::Vect
     setRot(quaternion);
 
     sub()->initPhysicsValues();
+}
+
+void KartMove::setKartSpeedLimit() {
+    constexpr f32 limit = 120.0f;
+    m_hardSpeedLimit = limit;
+}
+
+void KartMove::calc() {
+    dynamics()->resetInternalVelocity();
+}
+
+const EGG::Vector3f &KartMove::scale() const {
+    return m_scale;
+}
+
+f32 KartMove::hardSpeedLimit() const {
+    return m_hardSpeedLimit;
 }
 
 } // namespace Kart

--- a/source/game/kart/KartMove.hh
+++ b/source/game/kart/KartMove.hh
@@ -9,6 +9,16 @@ public:
     KartMove();
 
     void setInitialPhysicsValues(const EGG::Vector3f &pos, const EGG::Vector3f &angles);
+    void setKartSpeedLimit();
+
+    void calc();
+
+    const EGG::Vector3f &scale() const;
+    f32 hardSpeedLimit() const;
+
+private:
+    EGG::Vector3f m_scale;
+    f32 m_hardSpeedLimit;
 };
 
 class KartMoveBike : public KartMove {};

--- a/source/game/kart/KartObject.cc
+++ b/source/game/kart/KartObject.cc
@@ -42,6 +42,10 @@ void KartObject::createSub() {
     m_pointers.m_sub->createSubsystems(m_pointers.m_param->isBike());
 }
 
+void KartObject::calcSub() {
+    m_pointers.m_sub->calcPass0();
+}
+
 KartObject *KartObject::Create(Character character, Vehicle vehicle, u8 playerIdx) {
     Abstract::List list;
     s_list = &list;

--- a/source/game/kart/KartObject.hh
+++ b/source/game/kart/KartObject.hh
@@ -19,6 +19,8 @@ public:
 
     void createSub();
 
+    void calcSub();
+
     static KartObject *Create(Character character, Vehicle vehicle, u8 playerIdx);
 
 protected:

--- a/source/game/kart/KartObjectManager.cc
+++ b/source/game/kart/KartObjectManager.cc
@@ -12,7 +12,11 @@ void KartObjectManager::init() {
     }
 }
 
-void KartObjectManager::calc() {}
+void KartObjectManager::calc() {
+    for (size_t i = 0; i < m_count; ++i) {
+        m_objects[i]->calcSub();
+    }
+}
 
 KartObjectManager *KartObjectManager::CreateInstance() {
     assert(!s_instance);

--- a/source/game/kart/KartObjectProxy.cc
+++ b/source/game/kart/KartObjectProxy.cc
@@ -57,12 +57,24 @@ const KartDynamics *KartObjectProxy::dynamics() const {
     return physics()->getDynamics();
 }
 
+KartState *KartObjectProxy::state() {
+    return m_accessor->m_state;
+}
+
+const KartState *KartObjectProxy::state() const {
+    return m_accessor->m_state;
+}
+
 KartSub *KartObjectProxy::sub() {
     return m_accessor->m_sub;
 }
 
 const KartSub *KartObjectProxy::sub() const {
     return m_accessor->m_sub;
+}
+
+const EGG::Vector3f &KartObjectProxy::scale() const {
+    return m_accessor->m_move->scale();
 }
 
 void KartObjectProxy::setPos(const EGG::Vector3f &pos) {

--- a/source/game/kart/KartObjectProxy.hh
+++ b/source/game/kart/KartObjectProxy.hh
@@ -12,6 +12,7 @@ class KartMove;
 class KartParam;
 struct BSP;
 class KartPhysics;
+class KartState;
 class KartSub;
 
 struct KartAccessor {
@@ -19,6 +20,7 @@ struct KartAccessor {
     KartBody *m_body;
     KartSub *m_sub;
     KartMove *m_move;
+    KartState *m_state;
 };
 
 class KartObjectProxy {
@@ -39,8 +41,12 @@ public:
     const KartPhysics *physics() const;
     KartDynamics *dynamics();
     const KartDynamics *dynamics() const;
+    KartState *state();
+    const KartState *state() const;
     KartSub *sub();
     const KartSub *sub() const;
+
+    const EGG::Vector3f &scale() const;
 
     void setPos(const EGG::Vector3f &pos);
     void setRot(const EGG::Quatf &q);

--- a/source/game/kart/KartPhysics.cc
+++ b/source/game/kart/KartPhysics.cc
@@ -9,10 +9,41 @@ KartPhysics::KartPhysics(bool isBike) {
 
 void KartPhysics::reset() {
     m_dynamics->init();
+    m_decayingStuntRot = EGG::Quatf::ident;
+    m_instantaneousStuntRot = EGG::Quatf::ident;
+    m_specialRot = EGG::Quatf::ident;
+    m_decayingExtraRot = EGG::Quatf::ident;
+    m_instantaneousExtraRot = EGG::Quatf::ident;
+    m_extraRot = EGG::Quatf::ident;
     m_pose = EGG::Matrix34f::ident;
     m_xAxis = EGG::Vector3f(m_pose(0, 0), m_pose(1, 0), m_pose(2, 0));
     m_yAxis = EGG::Vector3f(m_pose(0, 1), m_pose(1, 1), m_pose(2, 1));
     m_zAxis = EGG::Vector3f(m_pose(0, 2), m_pose(1, 2), m_pose(2, 2));
+    m_pos = m_dynamics->pos();
+    m_velocity = m_dynamics->velocity();
+}
+
+void KartPhysics::updatePose() {
+    m_pose.makeQT(m_dynamics->fullRot(), m_dynamics->pos());
+    m_xAxis = EGG::Vector3f(m_pose(0, 0), m_pose(1, 0), m_pose(2, 0));
+    m_yAxis = EGG::Vector3f(m_pose(0, 1), m_pose(1, 1), m_pose(2, 1));
+    m_zAxis = EGG::Vector3f(m_pose(0, 2), m_pose(1, 2), m_pose(2, 2));
+}
+
+void KartPhysics::calc(f32 dt, f32 maxSpeed, const EGG::Vector3f & /*scale*/, bool air) {
+    m_specialRot = m_instantaneousStuntRot * m_decayingStuntRot;
+    m_extraRot = m_instantaneousExtraRot * m_decayingExtraRot;
+
+    m_dynamics->setSpecialRot(m_specialRot);
+    m_dynamics->setExtraRot(m_extraRot);
+
+    m_dynamics->calc(dt, maxSpeed, air);
+
+    m_decayingStuntRot = m_decayingStuntRot.slerpTo(EGG::Quatf::ident, 0.1f);
+    m_decayingExtraRot = m_decayingExtraRot.slerpTo(EGG::Quatf::ident, 0.1f);
+
+    m_instantaneousStuntRot = EGG::Quatf::ident;
+    m_instantaneousExtraRot = EGG::Quatf::ident;
 }
 
 KartDynamics *KartPhysics::getDynamics() {
@@ -27,11 +58,12 @@ const EGG::Matrix34f &KartPhysics::getPose() const {
     return m_pose;
 }
 
-void KartPhysics::updatePose() {
-    m_pose.makeQT(m_dynamics->getFullRot(), m_dynamics->getPos());
-    m_xAxis = EGG::Vector3f(m_pose(0, 0), m_pose(1, 0), m_pose(2, 0));
-    m_yAxis = EGG::Vector3f(m_pose(0, 1), m_pose(1, 1), m_pose(2, 1));
-    m_zAxis = EGG::Vector3f(m_pose(0, 2), m_pose(1, 2), m_pose(2, 2));
+void KartPhysics::setPos(const EGG::Vector3f &pos) {
+    m_pos = pos;
+}
+
+void KartPhysics::setVelocity(const EGG::Vector3f &vel) {
+    m_velocity = vel;
 }
 
 KartPhysics *KartPhysics::Create(const KartParam &param) {

--- a/source/game/kart/KartPhysics.hh
+++ b/source/game/kart/KartPhysics.hh
@@ -14,18 +14,31 @@ public:
     void reset();
     void updatePose();
 
+    void calc(f32 dt, f32 maxSpeed, const EGG::Vector3f &scale, bool air);
+
     KartDynamics *getDynamics();
     const KartDynamics *getDynamics() const;
     const EGG::Matrix34f &getPose() const;
+
+    void setPos(const EGG::Vector3f &pos);
+    void setVelocity(const EGG::Vector3f &vel);
 
     static KartPhysics *Create(const KartParam &param);
 
 private:
     KartDynamics *m_dynamics;
+    EGG::Vector3f m_pos;
+    EGG::Quatf m_decayingStuntRot;
+    EGG::Quatf m_instantaneousStuntRot;
+    EGG::Quatf m_specialRot;
+    EGG::Quatf m_decayingExtraRot;
+    EGG::Quatf m_instantaneousExtraRot;
+    EGG::Quatf m_extraRot;
     EGG::Matrix34f m_pose;
     EGG::Vector3f m_xAxis;
     EGG::Vector3f m_yAxis;
     EGG::Vector3f m_zAxis;
+    EGG::Vector3f m_velocity;
 };
 
 } // namespace Kart

--- a/source/game/kart/KartState.cc
+++ b/source/game/kart/KartState.cc
@@ -1,0 +1,21 @@
+#include "KartState.hh"
+
+namespace Kart {
+
+KartState::KartState() {
+    m_ground = false;
+}
+
+void KartState::init() {
+    reset();
+}
+
+void KartState::reset() {
+    m_ground = false;
+}
+
+bool KartState::isGround() const {
+    return m_ground;
+}
+
+} // namespace Kart

--- a/source/game/kart/KartState.hh
+++ b/source/game/kart/KartState.hh
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "game/kart/KartObjectProxy.hh"
+
+namespace Kart {
+
+class KartState : KartObjectProxy {
+public:
+    KartState();
+
+    void init();
+    void reset();
+
+    bool isGround() const;
+
+private:
+    bool m_ground;
+};
+
+} // namespace Kart

--- a/source/game/kart/KartSub.cc
+++ b/source/game/kart/KartSub.cc
@@ -2,6 +2,7 @@
 
 #include "game/kart/KartBody.hh"
 #include "game/kart/KartMove.hh"
+#include "game/kart/KartState.hh"
 
 namespace Kart {
 
@@ -9,15 +10,18 @@ KartSub::KartSub() = default;
 
 void KartSub::createSubsystems(bool isBike) {
     m_move = isBike ? new KartMoveBike : new KartMove;
+    m_state = new KartState;
 }
 
 void KartSub::copyPointers(KartAccessor &pointers) {
     pointers.m_move = m_move;
+    pointers.m_state = m_state;
 }
 
 void KartSub::init() {
     resetPhysics();
     body()->reset();
+    m_state->init();
 }
 
 void KartSub::initPhysicsValues() {
@@ -27,6 +31,18 @@ void KartSub::initPhysicsValues() {
 void KartSub::resetPhysics() {
     physics()->reset();
     physics()->updatePose();
+    m_move->setKartSpeedLimit();
+}
+
+void KartSub::calcPass0() {
+    physics()->setPos(dynamics()->pos());
+    physics()->setVelocity(dynamics()->velocity());
+    dynamics()->setGravity(-1.3f);
+
+    move()->calc();
+
+    f32 maxSpeed = move()->hardSpeedLimit();
+    physics()->calc(DT, maxSpeed, scale(), !state()->isGround());
 }
 
 } // namespace Kart

--- a/source/game/kart/KartSub.hh
+++ b/source/game/kart/KartSub.hh
@@ -15,8 +15,13 @@ public:
     void initPhysicsValues();
     void resetPhysics();
 
+    void calcPass0();
+
 private:
     KartMove *m_move;
+    KartState *m_state;
+
+    static constexpr f32 DT = 1.0f;
 };
 
 } // namespace Kart

--- a/source/game/scene/RaceScene.cc
+++ b/source/game/scene/RaceScene.cc
@@ -28,9 +28,8 @@ void RaceScene::initEngines() {
 }
 
 void RaceScene::calcEngines() {
-    // auto *raceMgr = System::RaceManager::Instance();
-    // raceMgr->calc();
-    // if (!raceMgr->spectatorMode())
+    auto *raceMgr = System::RaceManager::Instance();
+    raceMgr->calc();
     Kart::KartObjectManager::Instance()->calc();
     // if (raceMgr->isStateReached(State::Countdown)) {
     //     Item::ItemDirector::Instance()->calc();

--- a/source/game/system/RaceManager.cc
+++ b/source/game/system/RaceManager.cc
@@ -22,6 +22,16 @@ void RaceManager::findKartStartPoint(EGG::Vector3f &pos, EGG::Vector3f &angles) 
     }
 }
 
+void RaceManager::calc() {
+    if (m_stage == Stage::Intro) {
+        ++m_introTimer;
+    }
+}
+
+RaceManager::Stage RaceManager::stage() const {
+    return m_stage;
+}
+
 RaceManager *RaceManager::CreateInstance() {
     assert(!s_instance);
     s_instance = new RaceManager;
@@ -38,7 +48,7 @@ void RaceManager::DestroyInstance() {
     s_instance = nullptr;
 }
 
-RaceManager::RaceManager() = default;
+RaceManager::RaceManager() : m_stage(Stage::Intro), m_introTimer(0) {}
 
 RaceManager::~RaceManager() = default;
 

--- a/source/game/system/RaceManager.hh
+++ b/source/game/system/RaceManager.hh
@@ -6,7 +6,19 @@ namespace System {
 
 class RaceManager {
 public:
+    enum class Stage {
+        Intro = 0,
+        Countdown = 1,
+        Race = 2,
+        FinishLocal = 3,
+        FinishGlobal = 4,
+    };
+
     void findKartStartPoint(EGG::Vector3f &pos, EGG::Vector3f &angles);
+
+    void calc();
+
+    Stage stage() const;
 
     static RaceManager *CreateInstance();
     static RaceManager *Instance();
@@ -15,6 +27,9 @@ public:
 private:
     RaceManager();
     ~RaceManager();
+
+    Stage m_stage;
+    u32 m_introTimer;
 
     static RaceManager *s_instance;
 };


### PR DESCRIPTION
This matches the expected values of `KartDynamics::m_pos` and `KartDynamics::m_fullRot` after the call to `KartObject::calcSub`. Only variables which are dependent on the synchronization of these two variables have been implemented.

Further additions in the functions added in this PR may be required in order to sync the second pass.