### PR TITLE
Fix TestDirector framecount off-by-one

### DIFF
--- a/source/host/System.cc
+++ b/source/host/System.cc
@@ -7,9 +7,6 @@ namespace Host {
 int KSystem::main() {
     init();
     m_sceneMgr->changeScene(0);
-    if (!m_testDirector->init()) {
-        return 1;
-    }
     return run() ? 0 : 1;
 }
 
@@ -21,9 +18,9 @@ void KSystem::init() {
 }
 
 bool KSystem::run() {
-    do {
+    while (m_testDirector->calc()) {
         m_sceneMgr->calc();
-    } while (m_testDirector->calc());
+    }
 
     return m_testDirector->sync();
 }

--- a/source/test/TestDirector.cc
+++ b/source/test/TestDirector.cc
@@ -22,14 +22,11 @@ TestDirector::TestDirector() {
     m_stream.setEndian(endian);
 
     readHeader();
+
+    assert(m_stream.read_u32() == m_stream.index());
 }
 
 TestDirector::~TestDirector() = default;
-
-bool TestDirector::init() {
-    assert(m_stream.read_u32() == m_stream.index());
-    return calc();
-}
 
 bool TestDirector::calc() {
     // Check if we're out of frames

--- a/source/test/TestDirector.hh
+++ b/source/test/TestDirector.hh
@@ -11,7 +11,6 @@ public:
     TestDirector();
     ~TestDirector();
 
-    bool init();
     bool calc();
     bool test(const TestData &data);
 


### PR DESCRIPTION
Due to the `do-while` loop in `KSystem::run`, a frame would be computed before checking to see if it is within the number of frames we want to simulate, defined by `TARGET_FRAME`.

Note that I've also changed `TestDirector::m_currentFrame` to effectively become 1-indexed. If we want to keep it 0-indexed, then we should change the frame comparison in `calc()` to `++m_currentFrame >= TARGET_FRAME`