### PR TITLE
Implement multidimensional subscript operator

### DIFF
--- a/source/egg/math/Matrix.cc
+++ b/source/egg/math/Matrix.cc
@@ -142,23 +142,23 @@ void Matrix34f::makeZero() {
 Matrix34f Matrix34f::multiplyTo(const Matrix34f &rhs) const {
     Matrix34f mat;
 
-    mat(0, 0) = fma(rhs(2, 0), mtx[0][2], fma(rhs(1, 0), mtx[0][1], rhs(0, 0) * mtx[0][0]));
-    mat(0, 1) = fma(rhs(2, 1), mtx[0][2], fma(rhs(1, 1), mtx[0][1], rhs(0, 1) * mtx[0][0]));
-    mat(1, 0) = fma(rhs(2, 0), mtx[1][2], fma(rhs(1, 0), mtx[1][1], rhs(0, 0) * mtx[1][0]));
-    mat(1, 1) = fma(rhs(2, 1), mtx[1][2], fma(rhs(1, 1), mtx[1][1], rhs(0, 1) * mtx[1][0]));
-    mat(0, 2) = fma(rhs(2, 2), mtx[0][2], fma(rhs(1, 2), mtx[0][1], rhs(0, 2) * mtx[0][0]));
-    mat(0, 3) = fma(1.0f, mtx[0][3],
-            fma(rhs(2, 3), mtx[0][2], fma(rhs(1, 3), mtx[0][1], rhs(0, 3) * mtx[0][0])));
-    mat(1, 2) =
-            mtx[1][3] + fma(rhs(2, 2), mtx[1][2], fma(rhs(1, 2), mtx[1][1], rhs(0, 2) * mtx[1][0]));
-    mat(1, 3) = fma(1.0f, mtx[1][3],
-            fma(rhs(2, 3), mtx[1][2], fma(rhs(1, 3), mtx[1][1], rhs(0, 3) * mtx[1][0])));
-    mat(2, 0) = fma(rhs(2, 0), mtx[2][2], fma(rhs(1, 0), mtx[2][1], rhs(0, 0) * mtx[2][0]));
-    mat(2, 1) = fma(rhs(2, 1), mtx[2][2], fma(rhs(1, 1), mtx[2][1], rhs(0, 1) * mtx[2][0]));
-    mat(2, 2) =
-            mtx[2][3] + fma(rhs(2, 2), mtx[2][2], fma(rhs(1, 2), mtx[2][1], rhs(0, 2) * mtx[2][0]));
-    mat(2, 3) = fma(1.0f, mtx[2][3],
-            fma(rhs(2, 3), mtx[2][2], fma(rhs(1, 3), mtx[2][1], rhs(0, 3) * mtx[2][0])));
+    mat[0, 0] = fma(rhs[2, 0], mtx[0][2], fma(rhs[1, 0], mtx[0][1], rhs[0, 0] * mtx[0][0]));
+    mat[0, 1] = fma(rhs[2, 1], mtx[0][2], fma(rhs[1, 1], mtx[0][1], rhs[0, 1] * mtx[0][0]));
+    mat[1, 0] = fma(rhs[2, 0], mtx[1][2], fma(rhs[1, 0], mtx[1][1], rhs[0, 0] * mtx[1][0]));
+    mat[1, 1] = fma(rhs[2, 1], mtx[1][2], fma(rhs[1, 1], mtx[1][1], rhs[0, 1] * mtx[1][0]));
+    mat[0, 2] = fma(rhs[2, 2], mtx[0][2], fma(rhs[1, 2], mtx[0][1], rhs[0, 2] * mtx[0][0]));
+    mat[0, 3] = fma(1.0f, mtx[0][3],
+            fma(rhs[2, 3], mtx[0][2], fma(rhs[1, 3], mtx[0][1], rhs[0, 3] * mtx[0][0])));
+    mat[1, 2] =
+            mtx[1][3] + fma(rhs[2, 2], mtx[1][2], fma(rhs[1, 2], mtx[1][1], rhs[0, 2] * mtx[1][0]));
+    mat[1, 3] = fma(1.0f, mtx[1][3],
+            fma(rhs[2, 3], mtx[1][2], fma(rhs[1, 3], mtx[1][1], rhs[0, 3] * mtx[1][0])));
+    mat[2, 0] = fma(rhs[2, 0], mtx[2][2], fma(rhs[1, 0], mtx[2][1], rhs[0, 0] * mtx[2][0]));
+    mat[2, 1] = fma(rhs[2, 1], mtx[2][2], fma(rhs[1, 1], mtx[2][1], rhs[0, 1] * mtx[2][0]));
+    mat[2, 2] =
+            mtx[2][3] + fma(rhs[2, 2], mtx[2][2], fma(rhs[1, 2], mtx[2][1], rhs[0, 2] * mtx[2][0]));
+    mat[2, 3] = fma(1.0f, mtx[2][3],
+            fma(rhs[2, 3], mtx[2][2], fma(rhs[1, 3], mtx[2][1], rhs[0, 3] * mtx[2][0])));
 
     return mat;
 }
@@ -209,15 +209,15 @@ Matrix34f Matrix34f::inverseTo() const {
 
     Matrix34f ret;
 
-    ret(0, 2) = (mtx[0][1] * mtx[1][2] - mtx[1][1] * mtx[0][2]) * invDet;
-    ret(1, 2) = -(mtx[0][0] * mtx[1][2] - mtx[0][2] * mtx[1][0]) * invDet;
-    ret(2, 1) = -(mtx[0][0] * mtx[2][1] - mtx[2][0] * mtx[0][1]) * invDet;
-    ret(2, 2) = (mtx[0][0] * mtx[1][1] - mtx[1][0] * mtx[0][1]) * invDet;
-    ret(2, 0) = (mtx[1][0] * mtx[2][1] - mtx[2][0] * mtx[1][1]) * invDet;
-    ret(0, 0) = (mtx[1][1] * mtx[2][2] - mtx[2][1] * mtx[1][2]) * invDet;
-    ret(0, 1) = -(mtx[0][1] * mtx[2][2] - mtx[2][1] * mtx[0][2]) * invDet;
-    ret(1, 0) = -(mtx[1][0] * mtx[2][2] - mtx[2][0] * mtx[1][2]) * invDet;
-    ret(1, 1) = (mtx[0][0] * mtx[2][2] - mtx[2][0] * mtx[0][2]) * invDet;
+    ret[0, 2] = (mtx[0][1] * mtx[1][2] - mtx[1][1] * mtx[0][2]) * invDet;
+    ret[1, 2] = -(mtx[0][0] * mtx[1][2] - mtx[0][2] * mtx[1][0]) * invDet;
+    ret[2, 1] = -(mtx[0][0] * mtx[2][1] - mtx[2][0] * mtx[0][1]) * invDet;
+    ret[2, 2] = (mtx[0][0] * mtx[1][1] - mtx[1][0] * mtx[0][1]) * invDet;
+    ret[2, 0] = (mtx[1][0] * mtx[2][1] - mtx[2][0] * mtx[1][1]) * invDet;
+    ret[0, 0] = (mtx[1][1] * mtx[2][2] - mtx[2][1] * mtx[1][2]) * invDet;
+    ret[0, 1] = -(mtx[0][1] * mtx[2][2] - mtx[2][1] * mtx[0][2]) * invDet;
+    ret[1, 0] = -(mtx[1][0] * mtx[2][2] - mtx[2][0] * mtx[1][2]) * invDet;
+    ret[1, 1] = (mtx[0][0] * mtx[2][2] - mtx[2][0] * mtx[0][2]) * invDet;
 
     return ret;
 }
@@ -226,12 +226,12 @@ Matrix34f Matrix34f::transpose() const {
     // NOTE: 4th element in each row is not meant to be used reliably
     Matrix34f ret = *this;
 
-    ret(0, 1) = mtx[1][0];
-    ret(0, 2) = mtx[2][0];
-    ret(1, 0) = mtx[0][1];
-    ret(1, 2) = mtx[2][1];
-    ret(2, 0) = mtx[0][2];
-    ret(2, 1) = mtx[1][2];
+    ret[0, 1] = mtx[1][0];
+    ret[0, 2] = mtx[2][0];
+    ret[1, 0] = mtx[0][1];
+    ret[1, 2] = mtx[2][1];
+    ret[2, 0] = mtx[0][2];
+    ret[2, 1] = mtx[1][2];
 
     return ret;
 }

--- a/source/egg/math/Matrix.hh
+++ b/source/egg/math/Matrix.hh
@@ -15,12 +15,12 @@ public:
         return mtx == rhs.mtx;
     }
 
-    f32 &operator()(int i, int j) {
-        return mtx[i][j];
+    f32 &operator[](size_t row, size_t col) {
+        return mtx[row][col];
     }
 
-    f32 operator()(int i, int j) const {
-        return mtx[i][j];
+    f32 operator[](size_t row, size_t col) const {
+        return mtx[row][col];
     }
 
     // Q for Quaternion, T for translation

--- a/source/game/kart/KartDynamics.cc
+++ b/source/game/kart/KartDynamics.cc
@@ -36,9 +36,9 @@ void KartDynamics::setBspParams(f32 rotSpeed, const EGG::Vector3f &m, const EGG:
     }
 
     m_inertiaTensor = EGG::Matrix34f::zero;
-    m_inertiaTensor(0, 0) = (m.y * m.y + m.z * m.z) * TWELFTH + n.y * n.y + n.z * n.z;
-    m_inertiaTensor(1, 1) = (m.z * m.z + m.x * m.x) * TWELFTH + n.z * n.z + n.x * n.x;
-    m_inertiaTensor(2, 2) = (m.x * m.x + m.y * m.y) * TWELFTH + n.x * n.x + n.y * n.y;
+    m_inertiaTensor[0, 0] = (m.y * m.y + m.z * m.z) * TWELFTH + n.y * n.y + n.z * n.z;
+    m_inertiaTensor[1, 1] = (m.z * m.z + m.x * m.x) * TWELFTH + n.z * n.z + n.x * n.x;
+    m_inertiaTensor[2, 2] = (m.x * m.x + m.y * m.y) * TWELFTH + n.x * n.x + n.y * n.y;
 
     m_invInertiaTensor = m_inertiaTensor.inverseTo();
 }

--- a/source/game/kart/KartObjectProxy.cc
+++ b/source/game/kart/KartObjectProxy.cc
@@ -156,12 +156,12 @@ const EGG::Matrix34f &KartObjectProxy::pose() const {
 
 EGG::Vector3f KartObjectProxy::bodyFront() const {
     const EGG::Matrix34f &mtx = pose();
-    return EGG::Vector3f(mtx(0, 2), mtx(1, 2), mtx(2, 2));
+    return EGG::Vector3f(mtx[0, 2], mtx[1, 2], mtx[2, 2]);
 }
 
 EGG::Vector3f KartObjectProxy::bodyForward() const {
     const EGG::Matrix34f &mtx = pose();
-    return EGG::Vector3f(mtx(0, 0), mtx(1, 0), mtx(2, 0));
+    return EGG::Vector3f(mtx[0, 0], mtx[1, 0], mtx[2, 0]);
 }
 
 const EGG::Vector3f &KartObjectProxy::componentXAxis() const {

--- a/source/game/kart/KartPhysics.cc
+++ b/source/game/kart/KartPhysics.cc
@@ -24,18 +24,18 @@ void KartPhysics::reset() {
     m_instantaneousExtraRot = EGG::Quatf::ident;
     m_extraRot = EGG::Quatf::ident;
     m_pose = EGG::Matrix34f::ident;
-    m_xAxis = EGG::Vector3f(m_pose(0, 0), m_pose(1, 0), m_pose(2, 0));
-    m_yAxis = EGG::Vector3f(m_pose(0, 1), m_pose(1, 1), m_pose(2, 1));
-    m_zAxis = EGG::Vector3f(m_pose(0, 2), m_pose(1, 2), m_pose(2, 2));
+    m_xAxis = EGG::Vector3f(m_pose[0, 0], m_pose[1, 0], m_pose[2, 0]);
+    m_yAxis = EGG::Vector3f(m_pose[0, 1], m_pose[1, 1], m_pose[2, 1]);
+    m_zAxis = EGG::Vector3f(m_pose[0, 2], m_pose[1, 2], m_pose[2, 2]);
     m_pos = m_dynamics->pos();
     m_velocity = m_dynamics->velocity();
 }
 
 void KartPhysics::updatePose() {
     m_pose.makeQT(m_dynamics->fullRot(), m_dynamics->pos());
-    m_xAxis = EGG::Vector3f(m_pose(0, 0), m_pose(1, 0), m_pose(2, 0));
-    m_yAxis = EGG::Vector3f(m_pose(0, 1), m_pose(1, 1), m_pose(2, 1));
-    m_zAxis = EGG::Vector3f(m_pose(0, 2), m_pose(1, 2), m_pose(2, 2));
+    m_xAxis = EGG::Vector3f(m_pose[0, 0], m_pose[1, 0], m_pose[2, 0]);
+    m_yAxis = EGG::Vector3f(m_pose[0, 1], m_pose[1, 1], m_pose[2, 1]);
+    m_zAxis = EGG::Vector3f(m_pose[0, 2], m_pose[1, 2], m_pose[2, 2]);
 }
 
 void KartPhysics::calc(f32 dt, f32 maxSpeed, const EGG::Vector3f & /*scale*/, bool air) {


### PR DESCRIPTION
Adds support for overloading `operator[]` with different number of arguments. This requires `C++23` but we are already configured to require that.
See: https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2128r6.pdf