### PR TITLE
Sync drifting and quick hops

### DIFF
--- a/source/egg/math/Matrix.cc
+++ b/source/egg/math/Matrix.cc
@@ -166,9 +166,9 @@ Matrix34f Matrix34f::multiplyTo(const Matrix34f &rhs) const {
 Vector3f Matrix34f::multVector(const Vector3f &vec) const {
     Vector3f ret;
 
-    ret.x = mtx[0][2] * vec.z + mtx[0][0] * vec.x + mtx[0][3] + mtx[0][1] * vec.y;
-    ret.y = mtx[1][2] * vec.z + mtx[1][0] * vec.x + mtx[1][3] + mtx[1][1] * vec.y;
-    ret.z = mtx[2][2] * vec.z + mtx[2][0] * vec.x + mtx[2][3] + mtx[2][1] * vec.y;
+    ret.x = mtx[0][2] * vec.z + (mtx[0][0] * vec.x + mtx[0][3] + mtx[0][1] * vec.y);
+    ret.y = mtx[1][2] * vec.z + (mtx[1][0] * vec.x + mtx[1][3] + mtx[1][1] * vec.y);
+    ret.z = mtx[2][2] * vec.z + (mtx[2][0] * vec.x + mtx[2][3] + mtx[2][1] * vec.y);
 
     return ret;
 }

--- a/source/game/field/CollisionDirector.cc
+++ b/source/game/field/CollisionDirector.cc
@@ -105,7 +105,8 @@ bool CollisionDirector::findClosestCollisionEntry(KCLTypeMask * /*typeMask*/, KC
     m_closestCollisionEntry = nullptr;
     f32 minDist = -std::numeric_limits<f32>::min();
 
-    for (const auto &entry : m_entries) {
+    for (size_t i = 0; i < m_collisionEntryCount; ++i) {
+        const auto &entry = m_entries[i];
         u32 typeMask = entry.typeMask & type;
         if (typeMask != 0 && entry.dist > minDist) {
             minDist = entry.dist;

--- a/source/game/kart/KartBody.cc
+++ b/source/game/kart/KartBody.cc
@@ -4,7 +4,9 @@
 
 namespace Kart {
 
-KartBody::KartBody(KartPhysics *physics) : m_physics(physics) {}
+KartBody::KartBody(KartPhysics *physics) : m_physics(physics) {
+    m_anAngle = 0.0f;
+}
 
 // TODO LATER
 EGG::Matrix34f KartBody::wheelMatrix(u16) {
@@ -13,10 +15,15 @@ EGG::Matrix34f KartBody::wheelMatrix(u16) {
 
 void KartBody::reset() {
     m_physics->reset();
+    m_anAngle = 0.0f;
 }
 
 KartPhysics *KartBody::physics() const {
     return m_physics;
+}
+
+void KartBody::setAngle(f32 val) {
+    m_anAngle = val;
 }
 
 KartBodyKart::KartBodyKart(KartPhysics *physics) : KartBody(physics) {}
@@ -38,7 +45,7 @@ EGG::Matrix34f KartBodyBike::wheelMatrix(u16 wheelIdx) {
     handleMatrix.makeRT(rotation, position);
     EGG::Matrix34f tmp = mat.multiplyTo(handleMatrix);
 
-    EGG::Vector3f yRotation;
+    EGG::Vector3f yRotation = EGG::Vector3f(0.0f, m_anAngle * DEG2RAD, 0.0f);
     EGG::Matrix34f yRotMatrix;
     yRotMatrix.makeR(yRotation);
     mat = tmp.multiplyTo(yRotMatrix);

--- a/source/game/kart/KartBody.hh
+++ b/source/game/kart/KartBody.hh
@@ -16,8 +16,11 @@ public:
 
     KartPhysics *physics() const;
 
+    void setAngle(f32 val);
+
 protected:
     KartPhysics *m_physics;
+    f32 m_anAngle;
 };
 
 class KartBodyKart : public KartBody {

--- a/source/game/kart/KartCollide.cc
+++ b/source/game/kart/KartCollide.cc
@@ -2,6 +2,7 @@
 
 #include "game/kart/KartMove.hh"
 #include "game/kart/KartPhysics.hh"
+#include "game/kart/KartState.hh"
 
 #include "game/field/CollisionDirector.hh"
 
@@ -69,8 +70,10 @@ void KartCollide::calcBodyCollision(f32 totalScale, const EGG::Quatf &rot,
 }
 
 void KartCollide::calcFloorEffect() {
-    m_offRoad = true;
-    m_groundBoostPanelOrRamp = true;
+    if (state()->isTouchingGround()) {
+        m_offRoad = true;
+        m_groundBoostPanelOrRamp = true;
+    }
 
     Field::KCLTypeMask mask = KCL_NONE;
     calcTriggers(&mask, pos(), false);
@@ -172,8 +175,11 @@ void KartCollide::processFloor(CollisionData &collisionData, Hitbox & /*hitbox*/
         m_notTrickable = true;
     }
 
+    collisionData.speedFactor = std::min(collisionData.speedFactor,
+            param()->stats().kclSpeed[KCL_ATTRIBUTE_TYPE(attribute)]);
+
     collisionData.intensity = (attribute >> 0xb) & 3;
-    collisionData.rotFactor += param()->stats().kclRot[attribute & 0x1f];
+    collisionData.rotFactor += param()->stats().kclRot[KCL_ATTRIBUTE_TYPE(attribute)];
     collisionData.closestFloorFlags = closestColEntry->typeMask;
     collisionData.closestFloorSettings = (attribute >> 5) & 7;
 

--- a/source/game/kart/KartDynamics.cc
+++ b/source/game/kart/KartDynamics.cc
@@ -149,6 +149,10 @@ const EGG::Vector3f &KartDynamics::velocity() const {
     return m_velocity;
 }
 
+f32 KartDynamics::gravity() const {
+    return m_gravity;
+}
+
 const EGG::Vector3f &KartDynamics::intVel() const {
     return m_intVel;
 }
@@ -159,6 +163,10 @@ const EGG::Quatf &KartDynamics::mainRot() const {
 
 const EGG::Quatf &KartDynamics::fullRot() const {
     return m_fullRot;
+}
+
+const EGG::Vector3f &KartDynamics::totalForce() const {
+    return m_totalForce;
 }
 
 const EGG::Vector3f &KartDynamics::extVel() const {
@@ -203,6 +211,14 @@ void KartDynamics::setExtraRot(const EGG::Quatf &q) {
 
 void KartDynamics::setIntVel(const EGG::Vector3f &v) {
     m_intVel = v;
+}
+
+void KartDynamics::setStabilizationFactor(f32 val) {
+    m_stabilizationFactor = val;
+}
+
+void KartDynamics::setTotalForce(const EGG::Vector3f &v) {
+    m_totalForce = v;
 }
 
 void KartDynamics::setExtVel(const EGG::Vector3f &v) {

--- a/source/game/kart/KartDynamics.hh
+++ b/source/game/kart/KartDynamics.hh
@@ -24,9 +24,11 @@ public:
     const EGG::Matrix34f &invInertiaTensor() const;
     const EGG::Vector3f &pos() const;
     const EGG::Vector3f &velocity() const;
+    f32 gravity() const;
     const EGG::Vector3f &intVel() const;
     const EGG::Quatf &mainRot() const;
     const EGG::Quatf &fullRot() const;
+    const EGG::Vector3f &totalForce() const;
     const EGG::Vector3f &extVel() const;
     const EGG::Vector3f &angVel0() const;
     const EGG::Vector3f &angVel2() const;
@@ -39,6 +41,8 @@ public:
     void setSpecialRot(const EGG::Quatf &q);
     void setExtraRot(const EGG::Quatf &q);
     void setIntVel(const EGG::Vector3f &v);
+    void setStabilizationFactor(f32 val);
+    void setTotalForce(const EGG::Vector3f &v);
     void setExtVel(const EGG::Vector3f &v);
     void setAngVel0(const EGG::Vector3f &v);
     void setAngVel2(const EGG::Vector3f &v);

--- a/source/game/kart/KartMove.hh
+++ b/source/game/kart/KartMove.hh
@@ -17,25 +17,39 @@ public:
 
     void setInitialPhysicsValues(const EGG::Vector3f &position, const EGG::Vector3f &angles);
     void setKartSpeedLimit();
+    void resetDriftManual();
 
     void calc();
     void calcTop();
     void calcDirs();
     void calcOffroad();
+    bool calcPreDrift();
+    void calcManualDrift();
+    void startManualDrift();
+    void releaseMt();
+    void controlOutsideDriftAngle();
     void calcRotation();
     void calcVehicleSpeed();
     f32 calcVehicleAcceleration() const;
     void calcAcceleration();
     void calcStandstillBoostRot();
+    void calcDive();
+    void calcHopPhysics();
     virtual void calcVehicleRotation(f32 /*turn*/) {}
+    virtual void hop();
+    virtual void onHop() {}
+    virtual void calcMtCharge() {}
     virtual f32 getWheelieSoftSpeedLimitBonus() const;
     virtual bool canWheelie() const;
+    virtual bool canHop() const;
 
     void applyStartBoost(s16 frames);
 
     void setFloorCollisionCount(u16 count);
+    void setKCLWheelSpeedFactor(f32 val);
     void setKCLWheelRotFactor(f32 val);
 
+    s32 getAppliedHopStickX() const;
     f32 softSpeedLimit() const;
     f32 speed() const;
     f32 acceleration() const;
@@ -45,30 +59,54 @@ public:
     f32 totalScale() const;
     const EGG::Vector3f &dir() const;
     u16 floorCollisionCount() const;
+    s32 hopStickX() const;
 
 protected:
+    enum class DriftState {
+        NotDrifting = 0,
+        ChargingMt = 1,
+        ChargedMt = 2,
+        ChargingSmt = 2,
+        ChargedSmt = 3,
+    };
+
     f32 m_baseSpeed;
     f32 m_softSpeedLimit;
     f32 m_speed;
     f32 m_lastSpeed;
     f32 m_hardSpeedLimit;
     f32 m_acceleration;
+    f32 m_speedDragMultiplier;
     EGG::Vector3f m_smoothedUp;
     EGG::Vector3f m_up;
+    EGG::Vector3f m_landingDir;
     EGG::Vector3f m_dir;
     EGG::Vector3f m_vel1Dir;
     EGG::Vector3f m_dirDiff;
+    bool m_hasLandingDir;
+    f32 m_landingAngle;
     f32 m_speedRatioCapped;
+    f32 m_kclSpeedFactor;
     f32 m_kclRotFactor;
+    f32 m_kclWheelSpeedFactor;
     f32 m_kclWheelRotFactor;
     u16 m_floorCollisionCount;
+    s32 m_hopStickX;
+    s32 m_hopFrame;
+    EGG::Vector3f m_hopDir;
+    f32 m_divingRot;
     f32 m_standStillBoostRot;
+    DriftState m_driftState;
+    u16 m_mtCharge;
     KartBoost m_boost;
     f32 m_realTurn;
     f32 m_weightedTurn;
     f32 m_rawTurn;
     EGG::Vector3f m_scale;
     f32 m_totalScale;
+    f32 m_hopVelY;
+    f32 m_hopPosY;
+    f32 m_hopGravity;
 };
 
 class KartMoveBike : public KartMove {
@@ -77,16 +115,18 @@ public:
     ~KartMoveBike();
 
     virtual void startWheelie();
-    virtual void cancelWheelie();
 
     void calcVehicleRotation(f32 /*turn*/) override;
     void calcWheelie() override;
+    void onHop() override;
+    void calcMtCharge() override;
     void setTurnParams() override;
     void init(bool b1, bool b2) override;
     f32 getWheelieSoftSpeedLimitBonus() const override;
     f32 wheelieRotFactor() const;
 
     void tryStartWheelie();
+    void cancelWheelie();
 
     f32 leanRot() const override;
     bool canWheelie() const override;

--- a/source/game/kart/KartObject.cc
+++ b/source/game/kart/KartObject.cc
@@ -5,6 +5,8 @@
 #include "game/kart/KartSuspension.hh"
 #include "game/kart/KartTire.hh"
 
+#include "game/render/KartModel.hh"
+
 #include "game/system/RaceConfig.hh"
 #include "game/system/RaceManager.hh"
 
@@ -75,12 +77,29 @@ void KartObject::createSub() {
     m_pointers.sub->createSubsystems(m_pointers.param->isBike());
 }
 
+void KartObject::createModel() {
+    Abstract::List list;
+    s_list = &list;
+
+    if (isBike()) {
+        m_pointers.model = new Render::KartModelBike;
+    } else {
+        m_pointers.model = new Render::KartModelKart;
+    }
+
+    ApplyAll(&m_pointers);
+    s_list = nullptr;
+
+    m_pointers.model->init();
+}
+
 void KartObject::calcSub() {
     sub()->calcPass0();
 }
 
 void KartObject::calc() {
     sub()->calcPass1();
+    model()->calc();
 }
 
 KartObject *KartObject::Create(Character character, Vehicle vehicle, u8 playerIdx) {

--- a/source/game/kart/KartObject.hh
+++ b/source/game/kart/KartObject.hh
@@ -20,6 +20,7 @@ public:
     void prepareTiresAndSuspensions();
 
     void createSub();
+    void createModel();
 
     void calcSub();
     void calc();

--- a/source/game/kart/KartObjectManager.cc
+++ b/source/game/kart/KartObjectManager.cc
@@ -48,7 +48,9 @@ KartObjectManager::KartObjectManager() {
     KartParamFileManager::CreateInstance();
     for (size_t i = 0; i < m_count; ++i) {
         const auto &player = raceScenario.players[i];
-        m_objects[i] = KartObject::Create(player.character, player.vehicle, i);
+        KartObject *object = KartObject::Create(player.character, player.vehicle, i);
+        object->createModel();
+        m_objects[i] = object;
     }
 }
 

--- a/source/game/kart/KartObjectProxy.cc
+++ b/source/game/kart/KartObjectProxy.cc
@@ -138,6 +138,14 @@ const System::KPad *KartObjectProxy::inputs() const {
     return System::RaceManager::Instance()->player().inputs();
 }
 
+Render::KartModel *KartObjectProxy::model() {
+    return m_accessor->model;
+}
+
+const Render::KartModel *KartObjectProxy::model() const {
+    return m_accessor->model;
+}
+
 CollisionData &KartObjectProxy::collisionData(u16 tireIdx) {
     return tirePhysics(tireIdx)->hitboxGroup()->collisionData();
 }

--- a/source/game/kart/KartObjectProxy.hh
+++ b/source/game/kart/KartObjectProxy.hh
@@ -8,6 +8,12 @@
 
 #include <vector>
 
+namespace Render {
+
+class KartModel;
+
+} // namespace Render
+
 namespace Kart {
 
 class CollisionGroup;
@@ -29,6 +35,7 @@ class WheelPhysics;
 struct KartAccessor {
     KartParam *param;
     KartBody *body;
+    Render::KartModel *model;
     KartSub *sub;
     KartMove *move;
     KartCollide *collide;
@@ -77,6 +84,8 @@ public:
     CollisionData &collisionData(u16 tireIdx);
     const CollisionData &collisionData(u16 tireIdx) const;
     const System::KPad *inputs() const;
+    Render::KartModel *model();
+    const Render::KartModel *model() const;
 
     const EGG::Vector3f &scale() const;
     const EGG::Matrix34f &pose() const;

--- a/source/game/kart/KartState.hh
+++ b/source/game/kart/KartState.hh
@@ -21,17 +21,37 @@ public:
     bool isDrifting() const;
 
     bool isAccelerate() const;
+    bool isDriftInput() const;
+    bool isDriftManual() const;
+    bool isHopStart() const;
+    bool isGroundStart() const;
+    bool isAnyWheelCollision() const;
+    bool isAllWheelsCollision() const;
+    bool isStickLeft() const;
     bool isTouchingGround() const;
+    bool isHop() const;
     bool isChargeStartBoost() const;
     bool isBoost() const;
+    bool isStickRight() const;
+    bool isDriftAuto() const;
     bool isWheelie() const;
+    bool isMtBoost() const;
     bool isWheelieRot() const;
     bool isAutoDrift() const;
     f32 stickX() const;
+    f32 stickY() const;
+    u32 airtime() const;
     const EGG::Vector3f &top() const;
     f32 startBoostCharge() const;
 
+    void clearBitfield0();
+
     void setAccelerate(bool isSet);
+    void setDriftManual(bool isSet);
+    void setAllWheelsCollision(bool isSet);
+    void setAnyWheelCollision(bool isSet);
+    void setTouchingGround(bool isSet);
+    void setHop(bool isSet);
     void setBoost(bool isSet);
     void setWheelie(bool isSet);
     void setWheelieRot(bool isSet);
@@ -44,8 +64,12 @@ private:
     bool m_bDriftManual;
     bool m_bHopStart;
     bool m_bAccelerateStart;
+    bool m_bGroundStart;
+    bool m_bAnyWheelCollision;
+    bool m_bAllWheelsCollision;
     bool m_bStickLeft;
     bool m_bTouchingGround;
+    bool m_bHop;
     bool m_bBoost;
     bool m_bStickRight;
     bool m_bDriftAuto;
@@ -57,6 +81,7 @@ private:
 
     bool m_bAutoDrift;
 
+    u32 m_airtime;
     EGG::Vector3f m_top;
     f32 m_stickX;
     f32 m_stickY;

--- a/source/game/kart/KartSuspensionPhysics.cc
+++ b/source/game/kart/KartSuspensionPhysics.cc
@@ -62,7 +62,7 @@ void WheelPhysics::updateCollision(const EGG::Vector3f &bottom, const EGG::Vecto
     f32 scalar = m_effectiveRadius * scale().y - nextRadius * move()->totalScale();
 
     EGG::Vector3f center = m_pos + scalar * bottom;
-    scalar = 0.3f * nextRadius * move()->leanRot() * move()->totalScale();
+    scalar = 0.3f * (nextRadius * move()->leanRot()) * move()->totalScale();
     center += scalar * bodyForward();
     m_hitboxGroup->setHitboxScale(move()->totalScale());
     collide()->calcWheelCollision(m_wheelIdx, m_hitboxGroup, m_colVel, center, nextRadius);

--- a/source/game/render/KartModel.cc
+++ b/source/game/render/KartModel.cc
@@ -1,0 +1,141 @@
+#include "KartModel.hh"
+
+#include "game/kart/KartBody.hh"
+#include "game/kart/KartMove.hh"
+#include "game/kart/KartParam.hh"
+#include "game/kart/KartState.hh"
+
+#include <egg/math/Math.hh>
+
+namespace Render {
+
+KartModel::KartModel() {
+    m_somethingLeft = false;
+    m_somethingRight = false;
+    _58 = 0.0f;
+    _54 = 1.0f;
+    _5c = 0.0f;
+    _64 = 0.0f;
+}
+
+void KartModel::vf_1c() { // FUN_807CD32C
+    _58 *= 0.9f;
+    f32 xStick = inputs()->currentState().stick.x;
+    f32 fVar2 = 0.1f;
+
+    if (xStick <= 0.2f) {
+        if (xStick < -0.2f) {
+            _58 -= fVar2;
+        }
+    } else {
+        _58 += fVar2;
+    }
+
+    xStick = EGG::Mathf::abs(xStick);
+
+    _54 += fVar2 * (xStick - _54);
+
+    if (_58 < -_54 || _54 < _58) {
+        if (-_54 <= _58) {
+            if (_54 < _58) {
+                _58 -= 0.1f;
+            }
+        } else {
+            _58 += 0.1f;
+        }
+    } else if (-_54 <= _58) {
+        _58 = std::min(_54, _58);
+    } else {
+        _58 = -_54;
+    }
+
+    f32 dVar13 = _58;
+
+    if (isBike()) {
+        if (state()->isDrifting()) {
+            dVar13 = m_isInsideDrift ? 5.0f : 20.0f;
+        }
+    } else {
+        K_PANIC("NOT IMPLEMENTED FOR KARTS YET");
+    }
+
+    f32 dVar12 = 0.0f;
+    _64 = dVar13 * 0.1f;
+
+    if (isBike()) {
+        dVar12 = -_58 * dVar13;
+
+        if (m_somethingLeft) {
+            if (m_isInsideDrift) {
+                dVar12 += 5.0f;
+            } else {
+                dVar12 += 10.0f;
+            }
+        } else {
+            if (m_somethingRight) {
+                if (m_isInsideDrift) {
+                    dVar12 -= 5.0f;
+                } else {
+                    dVar12 -= 10.0f;
+                }
+            }
+        }
+    } else {
+        K_PANIC("NOT IMPLEMENTED FOR KARTS YET");
+    }
+
+    if (dVar12 <= _5c) {
+        _5c -= _64;
+        _5c = std::max(_5c, dVar12);
+    } else {
+        _5c += _64;
+        _5c = std::min(_5c, dVar12);
+    }
+
+    body()->setAngle(_5c);
+}
+
+void KartModel::init() {
+    FUN_807C7828(param()->playerIdx(), isBike());
+}
+
+void KartModel::calc() {
+    FUN_807CB530();
+}
+
+void KartModel::FUN_807CB198() {
+    m_somethingRight = false;
+    m_somethingLeft = false;
+
+    if (!state()->isDrifting()) {
+        // Unimplemented kart-related stuff
+        if (state()->isStickLeft() || state()->isStickRight()) {
+            if (move()->hopStickX() == 1) {
+                m_somethingLeft = true;
+            } else {
+                if (move()->hopStickX() == -1) {
+                    m_somethingRight = true;
+                } else if (!state()->isStickLeft()) {
+                    m_somethingRight = true;
+                } else {
+                    m_somethingLeft = true;
+                }
+            }
+        }
+    }
+}
+
+void KartModel::FUN_807CB530() {
+    FUN_807CB198();
+    vf_1c();
+}
+
+void KartModel::FUN_807C7828(u8 /*playerIdx*/, bool /*isBike*/) {
+    m_isInsideDrift = param()->stats().driftType == Kart::KartParam::Stats::DriftType::Inside_Drift_Bike;
+}
+
+KartModelKart::KartModelKart() = default;
+
+KartModelBike::KartModelBike() = default;
+
+} // namespace Kart

--- a/source/game/render/KartModel.hh
+++ b/source/game/render/KartModel.hh
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "game/kart/KartObjectProxy.hh"
+
+namespace Render {
+
+class KartModel : Kart::KartObjectProxy {
+public:
+    KartModel();
+
+    virtual void vf_1c();
+
+    void init();
+    void calc();
+
+    void FUN_807CB198();
+    void FUN_807CB530();
+    void FUN_807C7828(u8 playerIdx, bool isBike);
+
+private:
+    bool m_somethingLeft;
+    bool m_somethingRight;
+    f32 _54;
+    f32 _58;
+    f32 _5c;
+    f32 _64;
+    bool m_isInsideDrift;
+};
+
+class KartModelKart : public KartModel {
+public:
+    KartModelKart();
+};
+
+class KartModelBike : public KartModel {
+public:
+    KartModelBike();
+};
+
+} // namespace Render

--- a/source/game/system/KPadController.cc
+++ b/source/game/system/KPadController.cc
@@ -118,7 +118,7 @@ bool RaceInputState::drift() const {
 }
 
 bool RaceInputState::trickUp() const {
-    return !!(trick & 0x10);
+    return (trick >> 4) == 1;
 }
 
 KPadGhostButtonsStream::KPadGhostButtonsStream()

--- a/testCases.json
+++ b/testCases.json
@@ -2,6 +2,6 @@
     "Luke rMC3 RTA WR": {
         "rkgPath": "samples/rmc3-rta-1-17-843.rkg",
         "krkgPath": "samples/rmc3-rta-1-17-843.krkg",
-        "targetFrame": 514
+        "targetFrame": 1425
     }
 }


### PR DESCRIPTION
This syncs Luke's rMC3 RTA WR ghost until the first shroom, at frame 1425.

- Fixes an off-by-one error in `Matrix34f::multVector` by adding parentheses
- Fix an issue in `findClosestCollisionEntry` where we were iterating the entire array. This could lead to accessing uninitialized/old entries that are no longer valid.
- Implemented `PlayerModel`, as it sets `KartBody::m_anAngle` which is used when computing the wheel matrix.
- Implemented offroad slowdown factor
- Fixed `KartState::m_bStickRight` and `m_bStickLeft` being inverted