### PR TITLE
Clean up KCL collision functions

### DIFF
--- a/source/game/field/CourseColMgr.cc
+++ b/source/game/field/CourseColMgr.cc
@@ -37,7 +37,7 @@ bool CourseColMgr::checkSphereFullPush(f32 scalar, f32 radius, KColData *data,
     data->lookupSphere(radius, scaled_position, vStack88, flags);
 
     if (info) {
-        return doCheckWithFullInfoPush(data, &KColData::checkSphere, info, kcl_flags_out);
+        return doCheckWithFullInfoPush(data, &KColData::checkSphereCollision, info, kcl_flags_out);
     }
     return doCheckMaskOnlyPush(data, &KColData::checkSphereCollision, kcl_flags_out);
 }

--- a/source/game/field/KColData.hh
+++ b/source/game/field/KColData.hh
@@ -11,6 +11,12 @@ namespace Field {
 
 class KColData {
 public:
+    enum class CollisionCheckType {
+        Edge,
+        Plane,
+        Movement,
+    };
+
     struct KCollisionPrism {
         KCollisionPrism();
         KCollisionPrism(f32 height, u16 posIndex, u16 faceNormIndex, u16 edge1NormIndex,
@@ -54,10 +60,8 @@ public:
     u16 prismCache(u32 idx) const;
 
 private:
-    bool checkSphereTriCollision(const KCollisionPrism &prism, f32 *distOut, EGG::Vector3f *fnrmOut,
-            u16 *flagsOut);
-    bool checkSphereMovementCollision(const KCollisionPrism &prism, f32 *distOut,
-            EGG::Vector3f *fnrmOut, u16 *flagsOut);
+    bool checkCollision(const KCollisionPrism &prism, f32 *distOut, EGG::Vector3f *fnrmOut,
+            u16 *flagsOut, CollisionCheckType type);
     bool checkSphereMovement(f32 *distOut, EGG::Vector3f *fnrmOut, u16 *attributeOut);
 
     const void *m_posData;


### PR DESCRIPTION
Right now (and by right now I mean in a future PR where we sync rBC), we make use of three sphere collision check functions. They are 95% the same, differing only by certain if-statements based on the TYPE of check performed (at least colliding with an edge, colliding beyond the edge, and colliding while moving towards).

The functions are ugly in Ghidra. Keeping them separate in Kinoko does not make debugging any easier (from a LOT of experience). I will argue that conjoining them here helps readability, as we can distinguish between what types of checks are being performed on a given collision check.