### PR TITLE
Quacker: add `KartBodyQuacker`

### DIFF
--- a/source/game/kart/KartBody.cc
+++ b/source/game/kart/KartBody.cc
@@ -61,4 +61,14 @@ EGG::Matrix34f KartBodyBike::wheelMatrix(u16 wheelIdx) {
     return mat;
 }
 
+KartBodyQuacker::KartBodyQuacker(KartPhysics *physics) : KartBodyBike(physics) {}
+
+KartBodyQuacker::~KartBodyQuacker() = default;
+
+EGG::Matrix34f KartBodyQuacker::wheelMatrix(u16 /* wheelIdx */) {
+    EGG::Matrix34f mat;
+    mat.makeQT(fullRot(), pos());
+    return mat;
+}
+
 } // namespace Kart

--- a/source/game/kart/KartBody.hh
+++ b/source/game/kart/KartBody.hh
@@ -26,13 +26,21 @@ protected:
 class KartBodyKart : public KartBody {
 public:
     KartBodyKart(KartPhysics *physics);
-    ~KartBodyKart();
+    ~KartBodyKart() override;
 };
 
 class KartBodyBike : public KartBody {
 public:
     KartBodyBike(KartPhysics *physics);
-    ~KartBodyBike();
+    ~KartBodyBike() override;
+
+    EGG::Matrix34f wheelMatrix(u16 wheelIdx) override;
+};
+
+class KartBodyQuacker : public KartBodyBike {
+public:
+    KartBodyQuacker(KartPhysics *physics);
+    ~KartBodyQuacker() override;
 
     EGG::Matrix34f wheelMatrix(u16 wheelIdx) override;
 };

--- a/source/game/kart/KartObject.cc
+++ b/source/game/kart/KartObject.cc
@@ -149,7 +149,11 @@ KartObjectBike::KartObjectBike(KartParam *param) : KartObject(param) {}
 KartObjectBike::~KartObjectBike() = default;
 
 KartBody *KartObjectBike::createBody(KartPhysics *physics) {
-    return new KartBodyBike(physics);
+    if (m_pointers.param->isVehicleRelativeBike()) {
+        return new KartBodyQuacker(physics);
+    } else {
+        return new KartBodyBike(physics);
+    }
 }
 
 void KartObjectBike::createTires() {

--- a/source/game/kart/KartParam.cc
+++ b/source/game/kart/KartParam.cc
@@ -34,6 +34,10 @@ bool KartParam::isBike() const {
     return m_isBike;
 }
 
+bool KartParam::isVehicleRelativeBike() const {
+    return stats().body == Stats::Body::Vehicle_Relative_Bike;
+}
+
 u16 KartParam::suspCount() const {
     return m_suspCount;
 }

--- a/source/game/kart/KartParam.hh
+++ b/source/game/kart/KartParam.hh
@@ -120,6 +120,7 @@ public:
     const BikeDisp &bikeDisp() const;
     u8 playerIdx() const;
     bool isBike() const;
+    bool isVehicleRelativeBike() const;
     u16 suspCount() const;
     u16 tireCount() const;
 


### PR DESCRIPTION
closes #89

I'm not quite sure what a "Vehicle-relative bike" is, or if the Quacker is the only one.
I also don't know what to name the new test cases, please advise. for now:
```
[TestDirector.cc:112] Test Case Passed: Grumble Volcano 15s Ultra Shortcut [411 / 1336]
[TestDirector.cc:112] Test Case Passed: Mushroom Gorge 19s Ultra Shortcut [546 / 1596]
```
whereas main only syncs three frames for each.

I don't know for sure what the next desyncs are, but i can guess. GV is prolly the rock, desync shows velocity dropping to 0 in base, but not in kinoko. MG is probably the mushroom. the eh, _kinoko_, one could say.

I'm also not super sure how the `KartBodyQuacker` ctor and dtor are supposed to look. I'm not super familiar with inheritance. 