### PR TITLE
destructure all `std::pair`

### DIFF
--- a/source/game/kart/KartCollide.cc
+++ b/source/game/kart/KartCollide.cc
@@ -487,10 +487,10 @@ void KartCollide::applySomeFloorMoment(f32 down, f32 rate, CollisionGroup *hitbo
     f32 speedDot = std::min(0.0f, speed.dot(crossVec));
     crossVec *= ((scalar * speedDot) / velDotFloorNrm);
 
-    auto projAndRej = crossVec.projAndRej(forward);
+    auto [proj, rej] = crossVec.projAndRej(forward);
 
-    f32 projNorm = projAndRej.first.length();
-    f32 rejNorm = projAndRej.second.length();
+    f32 projNorm = proj.length();
+    f32 rejNorm = rej.length();
     f32 projNorm_ = projNorm;
     f32 rejNorm_ = rejNorm;
 
@@ -510,13 +510,13 @@ void KartCollide::applySomeFloorMoment(f32 down, f32 rate, CollisionGroup *hitbo
         }
     }
 
-    projAndRej.first.normalise();
-    projAndRej.second.normalise();
+    proj.normalise();
+    rej.normalise();
 
-    projAndRej.first *= projNorm_;
-    projAndRej.second *= rejNorm_;
+    proj *= projNorm_;
+    rej *= rejNorm_;
 
-    EGG::Vector3f projRejSum = projAndRej.first + projAndRej.second;
+    EGG::Vector3f projRejSum = proj + rej;
     EGG::Vector3f projRejSumOrig = projRejSum;
 
     if (!b1) {

--- a/source/game/kart/KartDynamics.cc
+++ b/source/game/kart/KartDynamics.cc
@@ -73,9 +73,9 @@ void KartDynamics::calc(f32 dt, f32 maxSpeed, bool /*air*/) {
 
     if (FLT_EPSILON < playerBackHoriz.dot()) {
         playerBackHoriz.normalise();
-        const auto projAndRej = m_extVel.projAndRej(playerBackHoriz);
-        const EGG::Vector3f &speedBack = projAndRej.first;
-        m_extVel = projAndRej.second;
+        const auto [proj, rej] = m_extVel.projAndRej(playerBackHoriz);
+        const EGG::Vector3f &speedBack = proj;
+        m_extVel = rej;
 
         f32 norm = speedBack.dot();
         if (FLT_EPSILON < norm) {

--- a/source/game/kart/KartMove.cc
+++ b/source/game/kart/KartMove.cc
@@ -1027,21 +1027,21 @@ void KartMove::calcWallCollisionStart(f32 param_2) {
             speedDiff = std::min(60.0f, speedDiff);
             EGG::Vector3f scaledWallNrm = speedDiff * colData.wallNrm;
 
-            auto projAndRej = scaledWallNrm.projAndRej(m_vel1Dir);
-            projAndRej.first *= 0.3f;
-            projAndRej.second *= 0.9f;
+            auto [proj, rej] = scaledWallNrm.projAndRej(m_vel1Dir);
+            proj *= 0.3f;
+            rej *= 0.9f;
 
             if (state()->isBoost()) {
-                projAndRej.first = EGG::Vector3f::zero;
-                projAndRej.second = EGG::Vector3f::zero;
+                proj = EGG::Vector3f::zero;
+                rej = EGG::Vector3f::zero;
             }
 
             if (bodyFront().dot(colData.wallNrm) > 0.0f) {
-                projAndRej.first = EGG::Vector3f::zero;
+                proj = EGG::Vector3f::zero;
             }
-            projAndRej.second *= 0.9f;
+            rej *= 0.9f;
 
-            EGG::Vector3f projRejSum = projAndRej.first + projAndRej.second;
+            EGG::Vector3f projRejSum = proj + rej;
             f32 bumpDeviation =
                     state()->isTouchingGround() ? param()->stats().bumpDeviationLevel : 0.0f;
 


### PR DESCRIPTION
use [structured binding](https://en.cppreference.com/w/cpp/language/structured_binding) to use two separate variables instead of one `std::pair`. as mentioned, this greatly improves readability.
closes #102 