### PR TITLE
Kart turn params and rotation

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -10,7 +10,7 @@ Test Case                                                 | Frames      |     | 
 [`tf-ng-rta-1-49-039`](https://youtu.be/mqQa_1Cq1bw)      | 690 / 6947  | ❌ | Moving road
 [`mc-rta-0-46-553`](https://youtu.be/1F2xfHYrkXM)         | 634 / 3202  | ❌ | Wallclip
 [`mc-ng-rta-1-20-357`](https://youtu.be/kG8PvG8K1ZA)      | 1223 / 4228 | ❌ | KMP
-[`cm-rta-0-25-145`](https://youtu.be/F_RUQVghmuA)         | 4 / 1919    | ❌ | Unknown
+[`cm-rta-0-25-145`](https://youtu.be/F_RUQVghmuA)         | 582 / 1919  | ❌ | HWG
 [`cm-ng-rta-1-55-264`](https://youtu.be/XxKG3IYWduE)      | 638 / 7320  | ❌ | KMP
 [`dks-rta-1-44-568`](https://youtu.be/b9hacHlifcw)        | 620 / 6679  | ❌ | Cannon
 [`wgm-rta-0-31-678`](https://youtu.be/VVFXP639DRY)        | 563 / 2310  | ❌ | KMP
@@ -23,12 +23,12 @@ Test Case                                                 | Frames      |     | 
 [`gv-rta-0-15-425`](https://youtu.be/bB0oUzdCHTA)         | 488 / 1336  | ❌ | KMP?
 [`gv-ng-rta-1-32-914`](https://youtu.be/J55Fo2ZMz9M)      | 571 / 5981  | ❌ | KMP?
 [`gv-nosc-rta-1-50-927`](https://youtu.be/R7oK3U7iZrk)    | 482 / 7060  | ❌ | KMP?
-[`ddr-rta-1-46-400`](https://youtu.be/nVcVbd4n3yM)        | 4 / 6789    | ❌ | KCL
+[`ddr-rta-1-46-400`](https://youtu.be/nVcVbd4n3yM)        | 494 / 6789  | ❌ | Sand drift?
 [`mh-rta-1-42-872`](https://youtu.be/CellUlOYgnc)         | 6578 / 6578 | ✔️ | 
 [`bc-rta-2-08-697`](https://youtu.be/1DEReKemoeI)         | 809 / 8126  | ❌ | KMP
 [`bc-ng-rta-2-20-001`](https://youtu.be/028nClzy7B4)      | 809 / 8803  | ❌ | KMP
 [`rr-rta-1-24-751`](https://youtu.be/dgNMHyFda14)         | 349 / 5491  | ❌ | Outward-drifting bike
-[`rr-ng-rta-2-24-281`](https://youtu.be/O-BtWWsq82o)      | `SEGFAULT`  | ❌ | Karts
+[`rr-ng-rta-2-24-281`](https://youtu.be/O-BtWWsq82o)      | 467 / 9060  | ❌ | Outward-drifting kart
 [`rpb-rta-0-59-978`](https://youtu.be/Z-lVl-7B-So)        | 1079 / 4007 | ❌ | Moving water
 [`rpb-ng-rta-1-12-656`](https://youtu.be/LujU0kJx-hU)     | 2492 / 4767 | ❌ | Moving water
 [`ryf-rta-0-58-648`](https://youtu.be/3IKzbmawUbk)        | 584 / 3927  | ❌ | Water
@@ -40,10 +40,10 @@ Test Case                                                 | Frames      |     | 
 [`rsgb-rta-1-14-513`](https://youtu.be/lgfw-zswqIM)       | 356 / 4878  | ❌ | Outward-drifting bike
 [`rsgb-ng-rta-1-21-363`](https://youtu.be/SjXUPXT8n8g)    | 5288 / 5288 | ✔️ | 
 [`rds-rta-2-03-525`](https://youtu.be/a9Mnd2W7JXI)        | 1943 / 7816 | ❌ | Taildive slipdrift
-[`rws-rta-1-31-987`](https://youtu.be/2rDSx5pgQ9A)        | 4 / 5925    | ❌ | Unknown
+[`rws-rta-1-31-987`](https://youtu.be/2rDSx5pgQ9A)        | 826 / 5925  | ❌ | HWG
 [`rws-ng-rta-1-48-193`](https://youtu.be/4PU4zpCU_q4)     | 770 / 6897  | ❌ | Unknown
-[`rdh-rta-1-30-425`](https://youtu.be/v5Qj0DnqVo0)        | 3 / 5832    | ❌ | KCL
-[`rdh-ng-rta-1-34-237`](https://youtu.be/4Lp-ehOOiGo)     | 3 / 6060    | ❌ | KCL
+[`rdh-rta-1-30-425`](https://youtu.be/v5Qj0DnqVo0)        | 664 / 5832  | ❌ | Wall clip
+[`rdh-ng-rta-1-34-237`](https://youtu.be/4Lp-ehOOiGo)     | 1476 / 6060 | ❌ | Trick landing
 [`rbc3-rta-1-55-715`](https://youtu.be/vSbSADDEzEs)       | 7347 / 7347 | ✔️ | 
 [`rbc3-ng-rta-2-16-183`](https://youtu.be/xZwlaonIBws)    | 2006 / 8574 | ❌ | KMP
 [`rdkjp-rta-0-40-105`](https://youtu.be/bkinW1UZK6M)      | 581 / 2815  | ❌ | Offroad rotation

--- a/source/egg/math/Matrix.cc
+++ b/source/egg/math/Matrix.cc
@@ -218,11 +218,12 @@ Vector3f Matrix34f::multVector33(const Vector3f &vec) const {
 /// @details Unlike a typical matrix inversion, if the determinant is 0, then this function returns
 /// the identity matrix.
 Matrix34f Matrix34f::inverseTo33() const {
-    f32 determinant = (((mtx[2][1] * mtx[0][2] * mtx[1][0] + mtx[2][2] * mtx[0][0] * mtx[1][1] +
-                                mtx[2][0] * mtx[0][1] * mtx[1][2]) -
-                               mtx[0][2] * mtx[2][0] * mtx[1][1]) -
-                              mtx[2][2] * mtx[1][0] * mtx[0][1]) -
-            mtx[1][2] * mtx[0][0] * mtx[2][1];
+    f32 determinant = ((((mtx[2][1] * (mtx[0][2] * mtx[1][0])) +
+                                ((mtx[2][2] * (mtx[0][0] * mtx[1][1])) +
+                                        (mtx[2][0] * (mtx[0][1] * mtx[1][2])))) -
+                               (mtx[0][2] * (mtx[2][0] * mtx[1][1]))) -
+                              (mtx[2][2] * (mtx[1][0] * mtx[0][1]))) -
+            (mtx[1][2] * (mtx[0][0] * mtx[2][1]));
 
     if (determinant == 0.0f) {
         return Matrix34f::ident;

--- a/source/game/kart/KartBody.cc
+++ b/source/game/kart/KartBody.cc
@@ -10,9 +10,11 @@ KartBody::KartBody(KartPhysics *physics) : m_physics(physics) {
 }
 
 /// @addr{0x8056C604}
-/// @todo: Implement for karts
+/// @brief Computes a matrix to represent wheel rotation. For Karts, this is wheel-agnostic.
 EGG::Matrix34f KartBody::wheelMatrix(u16) {
-    return EGG::Matrix34f::ident;
+    EGG::Matrix34f mat;
+    mat.makeQT(fullRot(), pos());
+    return mat;
 }
 
 /// @addr{0x8056C4B4}

--- a/source/game/kart/KartDynamics.hh
+++ b/source/game/kart/KartDynamics.hh
@@ -15,7 +15,7 @@ public:
     virtual ~KartDynamics();
 
     virtual void forceUpright() {}
-    virtual void stabilize() {}
+    virtual void stabilize();
 
     void init();
     void resetInternalVelocity();

--- a/source/game/kart/KartMove.hh
+++ b/source/game/kart/KartMove.hh
@@ -12,7 +12,7 @@ public:
     KartMove();
     virtual ~KartMove();
 
-    virtual void createSubsystems() {}
+    virtual void createSubsystems();
     virtual void calcTurn();
     virtual void calcWheelie() {}
     virtual void setTurnParams();
@@ -49,7 +49,7 @@ public:
     void calcDive();
     void calcSsmtStart();
     void calcHopPhysics();
-    virtual void calcVehicleRotation(f32 /*turn*/) {}
+    virtual void calcVehicleRotation(f32 turn);
     virtual void hop();
     virtual void onHop() {}
     virtual void onWallCollision() {}
@@ -124,6 +124,14 @@ protected:
         f32 velY;
     };
 
+    /// @brief Houses parameters that vary between the drift type (inward bike, outward bike, kart).
+    struct DriftingParameters {
+        f32 hopVelY;
+        f32 stabilizationFactor;
+        f32 _8;
+        f32 boostRotFactor;
+    };
+
     f32 m_baseSpeed;      ///< The speed associated with the current character/vehicle stats.
     f32 m_softSpeedLimit; ///< Base speed + boosts + wheelies, restricted to the hard speed limit.
     f32 m_speed;          ///< Current speed, restricted to the soft speed limit.
@@ -181,6 +189,7 @@ protected:
     bool m_bSsmtLeeway;  ///< If set, activates SSMT when not pressing A or B.
     bool m_bWallBounce;  ///< Set when our speed loss from wall collision is > 30.0f.
     KartJump *m_jump;
+    const DriftingParameters *m_driftingParams; ///< Drift-type-specific parameters.
     f32 m_rawTurn; ///< Float in range [-1, 1]. Represents stick magnitude + direction.
 };
 

--- a/source/game/kart/KartObject.cc
+++ b/source/game/kart/KartObject.cc
@@ -33,6 +33,46 @@ KartObject::~KartObject() {
     }
 }
 
+/// @addr{0x8058EA0C}
+void KartObject::createTires() {
+    constexpr u16 BSP_WHEEL_INDICES[8] = {0, 0, 1, 1, 2, 2, 3, 3};
+    constexpr KartSuspensionPhysics::TireType X_MIRRORED_TIRE[8] = {
+            KartSuspensionPhysics::TireType::Kart,
+            KartSuspensionPhysics::TireType::KartReflected,
+            KartSuspensionPhysics::TireType::Kart,
+            KartSuspensionPhysics::TireType::KartReflected,
+            KartSuspensionPhysics::TireType::Kart,
+            KartSuspensionPhysics::TireType::KartReflected,
+            KartSuspensionPhysics::TireType::Kart,
+            KartSuspensionPhysics::TireType::KartReflected,
+    };
+
+    auto bodyType = m_pointers.param->stats().body;
+    u32 tireCount = m_pointers.param->tireCount();
+
+    if (bodyType == KartParam::Stats::Body::Three_Wheel_Kart) {
+        tireCount = 4;
+    }
+
+    for (u16 wheelIdx = 0; wheelIdx < tireCount; ++wheelIdx) {
+        if (bodyType == KartParam::Stats::Body::Three_Wheel_Kart && wheelIdx == 0) {
+            continue;
+        }
+
+        u16 bspWheelIdx = BSP_WHEEL_INDICES[wheelIdx];
+        KartSuspensionPhysics::TireType tireType = X_MIRRORED_TIRE[wheelIdx];
+
+        KartSuspension *sus = new KartSuspension;
+        KartTire *tire = (bspWheelIdx == 0) ? new KartTireFront(tireType, bspWheelIdx) :
+                                              new KartTire(tireType, bspWheelIdx);
+
+        m_pointers.suspensions.push_back(sus);
+        m_pointers.tires.push_back(tire);
+
+        sus->init(wheelIdx, tireType, bspWheelIdx);
+    }
+}
+
 /// @addr{0x8058E5F8}
 KartBody *KartObject::createBody(KartPhysics *physics) {
     return new KartBodyKart(physics);
@@ -180,16 +220,16 @@ void KartObjectBike::createTires() {
 
         if (wheelIdx == 0 || wheelIdx == 2) {
             sus = new KartSuspensionFrontBike;
-            tire = new KartTireFrontBike(0);
+            tire = new KartTireFrontBike(KartSuspensionPhysics::TireType::Bike, 0);
         } else {
             sus = new KartSuspensionRearBike;
-            tire = new KartTireRearBike(1);
+            tire = new KartTireRearBike(KartSuspensionPhysics::TireType::Bike, 1);
         }
 
         m_pointers.suspensions.push_back(sus);
         m_pointers.tires.push_back(tire);
 
-        sus->init(wheelIdx, wheelIdx);
+        sus->init(wheelIdx, KartSuspensionPhysics::TireType::Bike, wheelIdx);
     }
 }
 } // namespace Kart

--- a/source/game/kart/KartObject.hh
+++ b/source/game/kart/KartObject.hh
@@ -13,7 +13,7 @@ public:
     KartObject(KartParam *param);
     virtual ~KartObject();
     [[nodiscard]] virtual KartBody *createBody(KartPhysics *physics);
-    virtual void createTires() {}
+    virtual void createTires();
 
     void init();
     void initImpl();

--- a/source/game/kart/KartObjectProxy.cc
+++ b/source/game/kart/KartObjectProxy.cc
@@ -272,6 +272,10 @@ const EGG::Vector3f &KartObjectProxy::intVel() const {
     return dynamics()->intVel();
 }
 
+const EGG::Vector3f &KartObjectProxy::velocity() const {
+    return dynamics()->velocity();
+}
+
 /// @addr{0x80590CF8}
 f32 KartObjectProxy::speed() const {
     return move()->speed();

--- a/source/game/kart/KartObjectProxy.hh
+++ b/source/game/kart/KartObjectProxy.hh
@@ -112,6 +112,7 @@ public:
     [[nodiscard]] const EGG::Quatf &fullRot() const;
     [[nodiscard]] const EGG::Vector3f &extVel() const;
     [[nodiscard]] const EGG::Vector3f &intVel() const;
+    [[nodiscard]] const EGG::Vector3f &velocity() const;
     [[nodiscard]] f32 speed() const;
     [[nodiscard]] f32 acceleration() const;
     [[nodiscard]] f32 softSpeedLimit() const;

--- a/source/game/kart/KartSuspension.cc
+++ b/source/game/kart/KartSuspension.cc
@@ -11,8 +11,8 @@ KartSuspension::~KartSuspension() {
 }
 
 /// @addr{0x80598B60}
-void KartSuspension::init(u16 wheelIdx, u16 bspWheelIdx) {
-    m_physics = new KartSuspensionPhysics(wheelIdx, bspWheelIdx);
+void KartSuspension::init(u16 wheelIdx, KartSuspensionPhysics::TireType tireType, u16 bspWheelIdx) {
+    m_physics = new KartSuspensionPhysics(wheelIdx, tireType, bspWheelIdx);
 }
 
 /// @addr{0x80598BD4}

--- a/source/game/kart/KartSuspension.hh
+++ b/source/game/kart/KartSuspension.hh
@@ -11,7 +11,7 @@ public:
     KartSuspension();
     virtual ~KartSuspension();
 
-    void init(u16 wheelIdx, u16 bspWheelIdx);
+    void init(u16 wheelIdx, KartSuspensionPhysics::TireType tireType, u16 bspWheelIdx);
     void initPhysics();
 
     /// @beginSetters

--- a/source/game/kart/KartSuspensionPhysics.hh
+++ b/source/game/kart/KartSuspensionPhysics.hh
@@ -65,7 +65,14 @@ private:
 /// @brief Physics for a single wheel's suspension.
 class KartSuspensionPhysics : KartObjectProxy {
 public:
-    KartSuspensionPhysics(u16 wheelIdx, u16 bspWheelIdx);
+    /// @brief Every other kart tire is a mirror of the first. Bikes do not leverage this.
+    enum class TireType {
+        Kart,
+        KartReflected,
+        Bike,
+    };
+
+    KartSuspensionPhysics(u16 wheelIdx, TireType TireType, u16 bspWheelIdx);
     ~KartSuspensionPhysics();
 
     void init();
@@ -79,6 +86,7 @@ public:
 private:
     const BSP::Wheel *m_bspWheel;
     WheelPhysics *m_tirePhysics;
+    TireType m_tireType;
     u16 m_bspWheelIdx;
     u16 m_wheelIdx;
     EGG::Vector3f m_topmostPos;

--- a/source/game/kart/KartTire.cc
+++ b/source/game/kart/KartTire.cc
@@ -3,7 +3,8 @@
 namespace Kart {
 
 /// @addr{0x8059AA44}
-KartTire::KartTire(u16 bspWheelIdx) : m_bspWheelIdx(bspWheelIdx) {}
+KartTire::KartTire(KartSuspensionPhysics::TireType tireType, u16 bspWheelIdx)
+    : m_tireType(tireType), m_bspWheelIdx(bspWheelIdx) {}
 
 /// @addr{0x8058EC08}
 KartTire::~KartTire() {
@@ -30,7 +31,20 @@ WheelPhysics *KartTire::wheelPhysics() {
     return m_wheelPhysics;
 }
 
-KartTireFrontBike::KartTireFrontBike(u16 bspWheelIdx) : KartTire(bspWheelIdx) {}
+/// @addr{Inlined in 0x8058EA0C}
+KartTireFront::KartTireFront(KartSuspensionPhysics::TireType tireType, u16 bspWheelIdx)
+    : KartTire(tireType, bspWheelIdx) {}
+
+/// @addr{0x8058F4AC}
+KartTireFront::~KartTireFront() = default;
+
+/// @addr{0x8059AC1C}
+void KartTireFront::createPhysics(u16 tireIdx) {
+    m_wheelPhysics = new WheelPhysics(tireIdx, 0);
+}
+
+KartTireFrontBike::KartTireFrontBike(KartSuspensionPhysics::TireType tireType, u16 bspWheelIdx)
+    : KartTire(tireType, bspWheelIdx) {}
 
 /// @addr{0x8058F4EC}
 KartTireFrontBike::~KartTireFrontBike() = default;
@@ -40,7 +54,8 @@ void KartTireFrontBike::createPhysics(u16 tireIdx) {
     m_wheelPhysics = new WheelPhysics(tireIdx, 0);
 }
 
-KartTireRearBike::KartTireRearBike(u16 bspWheelIdx) : KartTire(bspWheelIdx) {}
+KartTireRearBike::KartTireRearBike(KartSuspensionPhysics::TireType tireType, u16 bspWheelIdx)
+    : KartTire(tireType, bspWheelIdx) {}
 
 /// @addr{0x8059B564}
 KartTireRearBike::~KartTireRearBike() = default;

--- a/source/game/kart/KartTire.hh
+++ b/source/game/kart/KartTire.hh
@@ -8,7 +8,7 @@ namespace Kart {
 /// @nosubgrouping
 class KartTire {
 public:
-    KartTire(u16 bspWheelIdx);
+    KartTire(KartSuspensionPhysics::TireType tireType, u16 bspWheelIdx);
     virtual ~KartTire();
 
     virtual void createPhysics(u16 tireIdx);
@@ -21,14 +21,24 @@ public:
     /// @endGetters
 
 protected:
+    KartSuspensionPhysics::TireType m_tireType;
     u16 m_bspWheelIdx;
     WheelPhysics *m_wheelPhysics;
+};
+
+/// @brief A holder for a kart's front tire's physics data.
+class KartTireFront : public KartTire {
+public:
+    KartTireFront(KartSuspensionPhysics::TireType tireType, u16 bspWheelIdx);
+    ~KartTireFront();
+
+    void createPhysics(u16 tireIdx) override;
 };
 
 /// @brief A holder for a bike's front tire's physics data.
 class KartTireFrontBike : public KartTire {
 public:
-    KartTireFrontBike(u16 bspWheelIdx);
+    KartTireFrontBike(KartSuspensionPhysics::TireType tireType, u16 bspWheelIdx);
     ~KartTireFrontBike();
 
     void createPhysics(u16 tireIdx) override;
@@ -37,7 +47,7 @@ public:
 /// @brief A holder for a bike's rear tire's physics data.
 class KartTireRearBike : public KartTire {
 public:
-    KartTireRearBike(u16 bspWheelIdx);
+    KartTireRearBike(KartSuspensionPhysics::TireType tireType, u16 bspWheelIdx);
     ~KartTireRearBike();
 
     void createPhysics(u16 tireIdx) override;

--- a/source/game/render/KartModel.cc
+++ b/source/game/render/KartModel.cc
@@ -59,7 +59,7 @@ void KartModel::vf_1c() {
             dVar13 = m_isInsideDrift ? 5.0f : 20.0f;
         }
     } else {
-        K_PANIC("NOT IMPLEMENTED FOR KARTS YET");
+        dVar13 = 15.0f;
     }
 
     f32 dVar12 = 0.0f;
@@ -69,22 +69,16 @@ void KartModel::vf_1c() {
         dVar12 = -_58 * dVar13;
 
         if (m_somethingLeft) {
-            if (m_isInsideDrift) {
-                dVar12 += 5.0f;
-            } else {
-                dVar12 += 10.0f;
-            }
-        } else {
-            if (m_somethingRight) {
-                if (m_isInsideDrift) {
-                    dVar12 -= 5.0f;
-                } else {
-                    dVar12 -= 10.0f;
-                }
-            }
+            dVar12 += m_isInsideDrift ? 5.0f : 10.0f;
+        } else if (m_somethingRight) {
+            dVar12 -= m_isInsideDrift ? 5.0f : 10.0f;
         }
     } else {
-        K_PANIC("NOT IMPLEMENTED FOR KARTS YET");
+        if (!m_somethingLeft && m_somethingRight) {
+            dVar12 -= 5.0f;
+        } else {
+            dVar12 += 5.0f;
+        }
     }
 
     if (dVar12 <= _5c) {

--- a/testCases.json
+++ b/testCases.json
@@ -1,4 +1,9 @@
 {
+    "Flare RR NG RTA WR": {
+        "rkgPath": "samples/rr-ng-rta-2-24-281.rkg",
+        "krkgPath": "samples/rr-ng-rta-2-24-281.krkg",
+        "targetFrame": 467
+    },
     "Logan rMC NG RTA WR": {
         "rkgPath": "samples/rmc-ng-rta-1-30-272.rkg",
         "krkgPath": "samples/rmc-ng-rta-1-30-272.krkg",


### PR DESCRIPTION
Thanks to @KooShnoo for a lot of the initial work for this branch!
Fixed #90 

This syncs the first 452 frames of the only kart RTA world record. Specifically the following issues had to be addressed to make this possible:
- In `Matrix34f::inverseTo33`, FP associativity caused off-by-one inaccuracies that eventually led to incorrect rotation.
- Implements `wheelMatrix()` for karts
- Implements `KartDynamics::stabilize()` base class vfunc which is used by karts
- Fixed incorrect `multVector` call in `KartDynamics::calc` (this didn't cause a desync, but for posterity's sake I want to fix it now)
- Added missing `EGG::Mathf::abs()` call in `KartDynamics::calc` (no desync, just posterity's sake)
- Implement KartMoveSub284 renamed as `DriftingParameters` to avoid using hard-coded values that no longer work given the different drift type.
- Implements the base class's `KartMove::calcVehicleRotation()` for karts.
- Adds kart tire axis mirroring, which is relevant for cancelling out torque.