### PR TITLE
synchronize with clang

### DIFF
--- a/include/Common.hh
+++ b/include/Common.hh
@@ -255,7 +255,7 @@ static constexpr WeightClass VehicleToWeight(Vehicle vehicle) {
     }
 }
 
-static constexpr char *COURSE_NAMES[59] = {
+static constexpr const char *COURSE_NAMES[59] = {
         "castle_course",
         "farm_course",
         "kinoko_course",
@@ -317,7 +317,7 @@ static constexpr char *COURSE_NAMES[59] = {
         "ending_demo",
 };
 
-static constexpr char *VEHICLE_NAMES[36] = {
+static constexpr const char *VEHICLE_NAMES[36] = {
         "sdf_kart",
         "mdf_kart",
         "ldf_kart",
@@ -384,7 +384,7 @@ concept IntegralType = std::is_integral_v<T>;
 
 template <typename T>
 concept ParseableType =
-        std::is_integral_v<T> || std::is_floating_point_v<T> && (sizeof(T) == 4 || sizeof(T) == 8);
+        std::is_integral_v<T> || (std::is_floating_point_v<T> && (sizeof(T) == 4 || sizeof(T) == 8));
 
 // Form data into integral value
 template <IntegralType T>

--- a/source/egg/math/Vector.cc
+++ b/source/egg/math/Vector.cc
@@ -40,8 +40,6 @@ Vector3f::Vector3f(f32 x_, f32 y_, f32 z_) : x(x_), y(y_), z(z_) {}
 
 Vector3f::Vector3f() : x(0.0f), y(0.0f), z(0.0f) {}
 
-Vector3f::~Vector3f() = default;
-
 /// @brief The dot product between the vector and itself.
 f32 Vector3f::dot() const {
     return x * x + y * y + z * z;

--- a/source/egg/math/Vector.hh
+++ b/source/egg/math/Vector.hh
@@ -49,7 +49,8 @@ struct Vector2f {
 struct Vector3f {
     Vector3f(f32 x_, f32 y_, f32 z_);
     Vector3f();
-    ~Vector3f();
+    // NOTE: Defining the destructor in the header ensures the struct is trivially destructible
+    ~Vector3f() = default;
 
     inline void setZero() {
         set(0.0f);

--- a/source/game/kart/KartParam.cc
+++ b/source/game/kart/KartParam.cc
@@ -6,10 +6,12 @@ namespace Kart {
 
 KartParam::KartParam(Character character, Vehicle vehicle, u8 playerIdx) {
     initStats(character, vehicle);
-    initBikeDispParams(vehicle);
     initHitboxes(vehicle);
     m_playerIdx = playerIdx;
     m_isBike = vehicle >= Vehicle::Standard_Bike_S;
+    if (m_isBike) {
+        initBikeDispParams(vehicle);
+    }
 }
 
 KartParam::~KartParam() = default;

--- a/source/game/kart/KartParamFileManager.cc
+++ b/source/game/kart/KartParamFileManager.cc
@@ -96,7 +96,7 @@ EGG::RamStream KartParamFileManager::getHitboxStream(Vehicle vehicle) const {
 }
 
 EGG::RamStream KartParamFileManager::getBikeDispParamsStream(Vehicle vehicle) const {
-    if (vehicle < Vehicle::Standard_Bike_S && vehicle >= Vehicle::Max) {
+    if (vehicle < Vehicle::Standard_Bike_S || vehicle >= Vehicle::Max) {
         K_PANIC("Uh oh.");
     }
 

--- a/source/game/system/map/MapdataAccessorBase.hh
+++ b/source/game/system/map/MapdataAccessorBase.hh
@@ -32,7 +32,7 @@ public:
     }
 
     [[nodiscard]] TData *getData(u16 i) const {
-        return i < m_entryCount ? m_entries[i].data() : nullptr;
+        return i < m_entryCount ? m_entries[i]->data() : nullptr;
     }
 
     [[nodiscard]] u16 size() const {


### PR DESCRIPTION
clangd the c/cpp LSP suggested these changes to me. these changes should also enable Kinoko to be built with clang.

clang doesn't support flexible length arrays in the same way gcc does, so i had to add a spurious arbitrary length to  params array in `ParamFile`.