### PR TITLE
Rename asset folder

### DIFF
--- a/source/game/system/ResourceManager.cc
+++ b/source/game/system/ResourceManager.cc
@@ -7,7 +7,7 @@ namespace System {
 #define ARCHIVE_COUNT 2
 
 static const char *const RESOURCE_PATHS[] = {
-        "/Kinoko/Common",
+        "/Race/Common",
         nullptr,
 };
 
@@ -46,7 +46,7 @@ MultiDvdArchive *ResourceManager::load(s32 idx, const char *filename) {
 /// @addr{0x80540760}
 MultiDvdArchive *ResourceManager::load(Course courseId) {
     char buffer[256];
-    snprintf(buffer, sizeof(buffer), "Kinoko/Course/%s", COURSE_NAMES[static_cast<s32>(courseId)]);
+    snprintf(buffer, sizeof(buffer), "Race/Course/%s", COURSE_NAMES[static_cast<s32>(courseId)]);
     m_archives[1]->load(buffer);
     return m_archives[1];
 }


### PR DESCRIPTION
renames the folder where assets are stored from `Kinoko` to `Race`, matching the naming convention of mario kart wii. 

this also helps contributors on MacOS (e.g. me) who can't have two directories/files with the same name (case insensitve) in the same directory. i also mentioned that [here](https://github.com/vabold/Kinoko/issues/14#issuecomment-2161405120) under issue #14 

the github action's runtime file will also have to be updated accordingly.