### PR TITLE
Fix AngleProperties typo and treat moving water as sticky road

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -14,10 +14,10 @@ Test Case                                                 | Frames      |     | 
 [`cm-ng-rta-1-55-264`](https://youtu.be/XxKG3IYWduE)      | 651 / 7320  | ❌ | KMP
 [`dks-rta-1-44-568`](https://youtu.be/b9hacHlifcw)        | 960 / 6679  | ❌ | Landing out of cannon
 [`wgm-rta-0-31-678`](https://youtu.be/VVFXP639DRY)        | 562 / 2310  | ❌ | KMP
-[`wgm-ng-rta-1-49-934`](https://youtu.be/NbhzA2rtZ2A)     | 1098 / 7001 | ❌ | Sticky road wheelie drop
+[`wgm-ng-rta-1-49-934`](https://youtu.be/NbhzA2rtZ2A)     | 7001 / 7001 | ✔️ |
 [`dc-rta-1-28-321`](https://youtu.be/Rs5AK3iHVno)         | 1058 / 5705 | ❌ | KMP
-[`kc-rta-1-55-250`](https://youtu.be/Elb5K7woV20)         | 640 / 7320  | ❌ | Boost ramp trick
-[`kc-ng-rta-2-17-176`](https://youtu.be/UgSQj6RpDYM)      | 643 / 8634  | ❌ | Boost ramp
+[`kc-rta-1-55-250`](https://youtu.be/Elb5K7woV20)         | 1520 / 7320 | ❌ | Moving water
+[`kc-ng-rta-2-17-176`](https://youtu.be/UgSQj6RpDYM)      | 1424 / 8634 | ❌ | Moving water
 [`mt-rta-1-33-239`](https://youtu.be/FX89203m2iE)         | 764 / 6000  | ❌ | Offroad slowdown mid-air
 [`mt-ng-rta-2-13-126`](https://youtu.be/igcHE0-OV0g)      | 1199 / 8391 | ❌ | Reject road
 [`gv-rta-0-15-425`](https://youtu.be/bB0oUzdCHTA)         | 487 / 1336  | ❌ | KMP?

--- a/source/game/kart/KartJump.cc
+++ b/source/game/kart/KartJump.cc
@@ -152,7 +152,7 @@ void KartJump::setAngle(const EGG::Vector3f &left) {
             {{
                     {32.0f, 11.0f},
                     {39.0f, 16.0f},
-                    {16.0f, 1.0f},
+                    {39.0f, 16.0f},
             }},
     }};
 

--- a/source/game/kart/KartMove.cc
+++ b/source/game/kart/KartMove.cc
@@ -461,9 +461,11 @@ void KartMove::calcDirs() {
 /// @addr{0x80583B88}
 void KartMove::calcStickyRoad() {
     constexpr f32 STICKY_RADIUS = 200.0f;
-    constexpr Field::KCLTypeMask STICKY_MASK = KCL_TYPE_BIT(COL_TYPE_STICKY_ROAD);
+    constexpr Field::KCLTypeMask STICKY_MASK =
+            KCL_TYPE_BIT(COL_TYPE_STICKY_ROAD) | KCL_TYPE_BIT(COL_TYPE_MOVING_WATER);
 
-    if (!state()->isStickyRoad() || EGG::Mathf::abs(m_speed) <= 20.0f) {
+    if ((!state()->isStickyRoad() && !collide()->isTrickable()) ||
+            EGG::Mathf::abs(m_speed) <= 20.0f) {
         return;
     }
 


### PR DESCRIPTION
I accidentally typo'd the trick parameter array. Also moving water is treated as sticky road. This snippet from Tockdom is relevant, in regards to sticky road:

> A type of road that attaches players to the road if they are within 200 units of the road with a correction of up to 200 units/frame. Moving water shares this code internally. The game logic does not care if player is also colliding with a different surface; as long as the player within 200 units of a surface with this attribute, the player's position will be corrected. This effect does not stack; layering on moving water will not make it more intense. The variant controls the terrain type. 