### PR TITLE
Sink bounce

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -12,7 +12,7 @@ Test Case                                                 | Frames      |     | 
 [`mc-ng-rta-1-20-357`](https://youtu.be/kG8PvG8K1ZA)      | 1222 / 4228 | ❌ | KMP
 [`cm-rta-0-25-145`](https://youtu.be/F_RUQVghmuA)         | 1919 / 1919 | ✔️ |
 [`cm-ng-rta-1-55-264`](https://youtu.be/XxKG3IYWduE)      | 651 / 7320  | ❌ | KMP
-[`dks-rta-1-44-568`](https://youtu.be/b9hacHlifcw)        | 960 / 6679  | ❌ | Landing out of cannon
+[`dks-rta-1-44-568`](https://youtu.be/b9hacHlifcw)        | 1049 / 6679 | ❌ | Zipper
 [`wgm-rta-0-31-678`](https://youtu.be/VVFXP639DRY)        | 562 / 2310  | ❌ | KMP
 [`wgm-ng-rta-1-49-934`](https://youtu.be/NbhzA2rtZ2A)     | 7001 / 7001 | ✔️ |
 [`dc-rta-1-28-321`](https://youtu.be/Rs5AK3iHVno)         | 1058 / 5705 | ❌ | KMP
@@ -23,7 +23,7 @@ Test Case                                                 | Frames      |     | 
 [`gv-rta-0-15-425`](https://youtu.be/bB0oUzdCHTA)         | 487 / 1336  | ❌ | KMP?
 [`gv-ng-rta-1-32-914`](https://youtu.be/J55Fo2ZMz9M)      | 570 / 5981  | ❌ | KMP?
 [`gv-nosc-rta-1-50-927`](https://youtu.be/R7oK3U7iZrk)    | 567 / 7060  | ❌ | KMP?
-[`ddr-rta-1-46-400`](https://youtu.be/nVcVbd4n3yM)        | 493 / 6789  | ❌ | Sand drift?
+[`ddr-rta-1-46-400`](https://youtu.be/nVcVbd4n3yM)        | 1559 / 6789 | ❌ | Zipper
 [`mh-rta-1-42-872`](https://youtu.be/CellUlOYgnc)         | 6578 / 6578 | ✔️ |
 [`bc-rta-2-08-697`](https://youtu.be/1DEReKemoeI)         | 808 / 8126  | ❌ | KMP
 [`bc-ng-rta-2-20-001`](https://youtu.be/028nClzy7B4)      | 808 / 8803  | ❌ | KMP
@@ -42,8 +42,8 @@ Test Case                                                 | Frames      |     | 
 [`rds-rta-2-03-525`](https://youtu.be/a9Mnd2W7JXI)        | 2306 / 7816 | ❌ | Drawbridge
 [`rws-rta-1-31-987`](https://youtu.be/2rDSx5pgQ9A)        | 1297 / 5925 | ❌ | Zipper
 [`rws-ng-rta-1-48-193`](https://youtu.be/4PU4zpCU_q4)     | 1430 / 6897 | ❌ | Zipper
-[`rdh-rta-1-30-425`](https://youtu.be/v5Qj0DnqVo0)        | 663 / 5832  | ❌ | Wall clip
-[`rdh-ng-rta-1-34-237`](https://youtu.be/4Lp-ehOOiGo)     | 1475 / 6060 | ❌ | Trick landing
+[`rdh-rta-1-30-425`](https://youtu.be/v5Qj0DnqVo0)        | 5832 / 5832 | ✔️ |
+[`rdh-ng-rta-1-34-237`](https://youtu.be/4Lp-ehOOiGo)     | 6060 / 6060 | ✔️ |
 [`rbc3-rta-1-55-715`](https://youtu.be/vSbSADDEzEs)       | 7347 / 7347 | ✔️ |
 [`rbc3-ng-rta-2-16-183`](https://youtu.be/xZwlaonIBws)    | 2006 / 8574 | ❌ | KMP
 [`rdkjp-rta-0-40-105`](https://youtu.be/bkinW1UZK6M)      | 580 / 2815  | ❌ | Offroad rotation

--- a/source/game/kart/CollisionGroup.cc
+++ b/source/game/kart/CollisionGroup.cc
@@ -38,15 +38,15 @@ Hitbox::~Hitbox() {
 
 /// @brief Calculates the position of a given hitbox, both relative to the player and world
 /// @addr{0x805B7FBC}
-void Hitbox::calc(f32 param_1, f32 totalScale, const EGG::Vector3f &scale, const EGG::Quatf &rot,
+void Hitbox::calc(f32 totalScale, f32 sinkDepth, const EGG::Vector3f &scale, const EGG::Quatf &rot,
         const EGG::Vector3f &pos) {
     f32 fVar1 = 0.0f;
-    if (scale.y < param_1) {
-        fVar1 = (param_1 - scale.y) * m_bspHitbox->radius;
+    if (scale.y < totalScale) {
+        fVar1 = (totalScale - scale.y) * m_bspHitbox->radius;
     }
 
     EGG::Vector3f scaledPos = m_bspHitbox->position * scale;
-    scaledPos.y = (m_bspHitbox->position.y + totalScale) * scale.y + fVar1;
+    scaledPos.y = (m_bspHitbox->position.y + sinkDepth) * scale.y + fVar1;
 
     m_relPos = rot.rotateVector(scaledPos);
     m_worldPos = m_relPos + pos;

--- a/source/game/kart/CollisionGroup.hh
+++ b/source/game/kart/CollisionGroup.hh
@@ -48,7 +48,7 @@ public:
     Hitbox();
     ~Hitbox();
 
-    void calc(f32 param_1, f32 totalScale, const EGG::Vector3f &scale, const EGG::Quatf &rot,
+    void calc(f32 totalScale, f32 sinkDepth, const EGG::Vector3f &scale, const EGG::Quatf &rot,
             const EGG::Vector3f &pos);
 
     /// @beginSetters

--- a/source/game/kart/KartBody.cc
+++ b/source/game/kart/KartBody.cc
@@ -7,6 +7,8 @@ namespace Kart {
 /// @addr{0x8056C394}
 KartBody::KartBody(KartPhysics *physics) : m_physics(physics) {
     m_anAngle = 0.0f;
+    m_sinkDepth = 0.0f;
+    m_targetSinkDepth = 0.0f;
 }
 
 /// @addr{0x8056C604}
@@ -21,6 +23,23 @@ EGG::Matrix34f KartBody::wheelMatrix(u16) {
 void KartBody::reset() {
     m_physics->reset();
     m_anAngle = 0.0f;
+    m_sinkDepth = 0.0f;
+    m_targetSinkDepth = 0.0f;
+}
+
+/// @addr{0x8056C9C4}
+void KartBody::calcSinkDepth() {
+    m_sinkDepth += (m_targetSinkDepth - m_sinkDepth) * 0.1f;
+}
+
+/// @addr{0x8056C950}
+void KartBody::trySetTargetSinkDepth(f32 val) {
+    m_targetSinkDepth = std::max(val, m_targetSinkDepth);
+}
+
+/// @addr{0x8056C964}
+void KartBody::calcTargetSinkDepth() {
+    m_targetSinkDepth = 3.0f * static_cast<f32>(collisionData().intensity);
 }
 
 void KartBody::setAngle(f32 val) {
@@ -29,6 +48,10 @@ void KartBody::setAngle(f32 val) {
 
 KartPhysics *KartBody::physics() const {
     return m_physics;
+}
+
+f32 KartBody::sinkDepth() const {
+    return m_sinkDepth;
 }
 
 /// @addr{0x8056CCC0}

--- a/source/game/kart/KartBody.hh
+++ b/source/game/kart/KartBody.hh
@@ -14,6 +14,9 @@ public:
     [[nodiscard]] virtual EGG::Matrix34f wheelMatrix(u16);
 
     void reset();
+    void calcSinkDepth();
+    void trySetTargetSinkDepth(f32 val);
+    void calcTargetSinkDepth();
 
     /// @beginSetters
     void setAngle(f32 val);
@@ -21,11 +24,14 @@ public:
 
     /// @beginGetters
     [[nodiscard]] KartPhysics *physics() const;
+    [[nodiscard]] f32 sinkDepth() const;
     /// @endGetters
 
 protected:
     KartPhysics *m_physics;
-    f32 m_anAngle; ///< @rename
+    f32 m_anAngle;   ///< @rename
+    f32 m_sinkDepth; ///< Vehicle offset applied downward into collision
+    f32 m_targetSinkDepth;
 };
 
 class KartBodyKart : public KartBody {

--- a/source/game/kart/KartCollide.cc
+++ b/source/game/kart/KartCollide.cc
@@ -1,5 +1,6 @@
 #include "KartCollide.hh"
 
+#include "game/kart/KartBody.hh"
 #include "game/kart/KartMove.hh"
 #include "game/kart/KartPhysics.hh"
 #include "game/kart/KartState.hh"
@@ -51,14 +52,15 @@ void KartCollide::resetHitboxes() {
 void KartCollide::calcHitboxes() {
     CollisionGroup *hitboxGroup = physics()->hitboxGroup();
     for (u16 idx = 0; idx < hitboxGroup->hitboxCount(); ++idx) {
-        hitboxGroup->hitbox(idx).calc(move()->totalScale(), 0.0f, scale(), fullRot(), pos());
+        hitboxGroup->hitbox(idx).calc(move()->totalScale(), body()->sinkDepth(), scale(), fullRot(),
+                pos());
     }
 }
 
 /// @stage All
 /// @addr{0x80572C20}
 void KartCollide::findCollision() {
-    calcBodyCollision(move()->totalScale(), fullRot(), scale());
+    calcBodyCollision(move()->totalScale(), body()->sinkDepth(), fullRot(), scale());
 
     auto &colData = collisionData();
     if (colData.bWall || colData.bWall3) {
@@ -191,7 +193,7 @@ void KartCollide::FUN_805B72B8(f32 param_1, f32 param_2, bool lockXZ, bool addEx
 /// @param totalScale
 /// @param rot
 /// @param scale
-void KartCollide::calcBodyCollision(f32 totalScale, const EGG::Quatf &rot,
+void KartCollide::calcBodyCollision(f32 totalScale, f32 sinkDepth, const EGG::Quatf &rot,
         const EGG::Vector3f &scale) {
     CollisionGroup *hitboxGroup = physics()->hitboxGroup();
     CollisionData &collisionData = hitboxGroup->collisionData();
@@ -216,7 +218,7 @@ void KartCollide::calcBodyCollision(f32 totalScale, const EGG::Quatf &rot,
             Field::CourseColMgr::Instance()->setNoBounceWallInfo(&noBounceWallInfo);
         }
 
-        hitbox.calc(totalScale, 0.0f, scale, rot, pos());
+        hitbox.calc(totalScale, sinkDepth, scale, rot, pos());
 
         if (Field::CollisionDirector::Instance()->checkSphereCachedFullPush(hitbox.worldPos(),
                     hitbox.lastPos(), flags, &colInfo, &maskOut, hitbox.radius(), 0)) {

--- a/source/game/kart/KartCollide.hh
+++ b/source/game/kart/KartCollide.hh
@@ -22,7 +22,8 @@ public:
     void findCollision();
     void FUN_80572F4C();
     void FUN_805B72B8(f32 param_1, f32 param_2, bool lockXZ, bool addExtVelY);
-    void calcBodyCollision(f32 totalScale, const EGG::Quatf &rot, const EGG::Vector3f &scale);
+    void calcBodyCollision(f32 totalScale, f32 sinkDepth, const EGG::Quatf &rot,
+            const EGG::Vector3f &scale);
     void calcFloorEffect();
     void calcTriggers(Field::KCLTypeMask *mask, const EGG::Vector3f &pos, bool twoPoint);
     void handleTriggers(Field::KCLTypeMask *mask);

--- a/source/game/kart/KartSub.cc
+++ b/source/game/kart/KartSub.cc
@@ -183,11 +183,14 @@ void KartSub::calcPass1() {
 
     m_sideCollisionTimer = std::max(m_sideCollisionTimer - 1, 0);
 
+    body()->calcSinkDepth();
+
     Field::CollisionDirector::Instance()->checkCourseColNarrScLocal(250.0f, pos(),
             KCL_TYPE_VEHICLE_INTERACTABLE, 0);
 
     if (!state()->isInCannon()) {
         collide()->findCollision();
+        body()->calcTargetSinkDepth();
         const auto &colData = collisionData();
         if (colData.bWall || colData.bWall3) {
             collide()->setMovement(collide()->movement() + colData.movement);

--- a/source/game/kart/KartSuspensionPhysics.cc
+++ b/source/game/kart/KartSuspensionPhysics.cc
@@ -1,5 +1,6 @@
 #include "KartSuspensionPhysics.hh"
 
+#include "game/kart/KartBody.hh"
 #include "game/kart/KartCollide.hh"
 #include "game/kart/KartDynamics.hh"
 #include "game/kart/KartState.hh"
@@ -91,8 +92,9 @@ void WheelPhysics::updateCollision(const EGG::Vector3f &bottom, const EGG::Vecto
             if (colData.bFloor || colData.bWall || colData.bWall3) {
                 m_pos += colData.tangentOff;
                 if (colData.intensity > -1) {
-                    m_targetEffectiveRadius =
-                            m_bspWheel->wheelRadius - 3.0f * static_cast<f32>(colData.intensity);
+                    f32 sinkDepth = 3.0f * static_cast<f32>(colData.intensity);
+                    m_targetEffectiveRadius = m_bspWheel->wheelRadius - sinkDepth;
+                    body()->trySetTargetSinkDepth(sinkDepth);
                 }
             }
         }


### PR DESCRIPTION
`KartBody` stores our current `sinkDepth` and a `targetSinkDepth` such that when we bounce onto KCL having sink depth property, our hitbox's height is offset gradually.