### PR TITLE
Barrel roll

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -18,7 +18,7 @@ Test Case                                                 | Frames      |     | 
 [`dc-rta-1-28-321`](https://youtu.be/Rs5AK3iHVno)         | 1058 / 5705 | ❌ | KMP
 [`kc-rta-1-55-250`](https://youtu.be/Elb5K7woV20)         | 1520 / 7320 | ❌ | Moving water
 [`kc-ng-rta-2-17-176`](https://youtu.be/UgSQj6RpDYM)      | 1424 / 8634 | ❌ | Moving water
-[`mt-rta-1-33-239`](https://youtu.be/FX89203m2iE)         | 764 / 6000  | ❌ | Offroad slowdown mid-air
+[`mt-rta-1-33-239`](https://youtu.be/FX89203m2iE)         | 1305 / 6000 | ❌ | Unknown
 [`mt-ng-rta-2-13-126`](https://youtu.be/igcHE0-OV0g)      | 1199 / 8391 | ❌ | Reject road
 [`gv-rta-0-15-425`](https://youtu.be/bB0oUzdCHTA)         | 487 / 1336  | ❌ | KMP?
 [`gv-ng-rta-1-32-914`](https://youtu.be/J55Fo2ZMz9M)      | 570 / 5981  | ❌ | KMP?
@@ -45,7 +45,7 @@ Test Case                                                 | Frames      |     | 
 [`rdh-rta-1-30-425`](https://youtu.be/v5Qj0DnqVo0)        | 5832 / 5832 | ✔️ |
 [`rdh-ng-rta-1-34-237`](https://youtu.be/4Lp-ehOOiGo)     | 6060 / 6060 | ✔️ |
 [`rbc3-rta-1-55-715`](https://youtu.be/vSbSADDEzEs)       | 7347 / 7347 | ✔️ |
-[`rbc3-ng-rta-2-16-183`](https://youtu.be/xZwlaonIBws)    | 2006 / 8574 | ❌ | KMP
+[`rbc3-ng-rta-2-16-183`](https://youtu.be/xZwlaonIBws)    | 8574 / 8574 | ✔️ |
 [`rdkjp-rta-0-40-105`](https://youtu.be/bkinW1UZK6M)      | 800 / 2815  | ❌ | KMP tree wall clip
 [`rdkjp-ng-rta-2-09-321`](https://youtu.be/WRXMrAUnOLo)   | 904 / 8163  | ❌ | Wall bonk spin drift
 [`rdkjp-nosc-rta-2-10-546`](https://youtu.be/ovFBMmhFioA) | 8236 / 8236 | ✔️ |

--- a/STATUS.md
+++ b/STATUS.md
@@ -55,5 +55,5 @@ Test Case                                                 | Frames      |     | 
 [`rpg-rta-1-58-890`](https://youtu.be/vu0vpmTmcbg)        | 7538 / 7538 | ✔️ |
 [`rdkm-rta-1-58-133`](https://youtu.be/s3uqTaxr_4A)       | 2094 / 7492 | ❌ | Zipper
 [`rdkm-ng-rta-2-04-775`](https://youtu.be/jk5NIcHWQ-Y)    | 2717 / 7890 | ❌ | KMP bridge object
-[`rbc-rta-2-17-997`](https://youtu.be/6Wri7nBtZMk)        | 711 / 8683  | ❌ | Unknown
+[`rbc-rta-2-17-997`](https://youtu.be/6Wri7nBtZMk)        | 1168 / 8683 | ❌ | Respawn position
 [`rbc-ng-rta-2-30-459`](https://youtu.be/twZes-RI6Sc)     | 9430 / 9430 | ✔️ |

--- a/source/game/kart/KartDynamics.cc
+++ b/source/game/kart/KartDynamics.cc
@@ -257,6 +257,10 @@ void KartDynamics::setTop_(const EGG::Vector3f &v) {
     m_top_ = v;
 }
 
+void KartDynamics::setForceUpright(bool isSet) {
+    m_forceUpright = isSet;
+}
+
 const EGG::Matrix34f &KartDynamics::invInertiaTensor() const {
     return m_invInertiaTensor;
 }

--- a/source/game/kart/KartDynamics.hh
+++ b/source/game/kart/KartDynamics.hh
@@ -45,6 +45,7 @@ public:
     void setAngVel2(const EGG::Vector3f &v);
     void setAngVel0YFactor(f32 val);
     void setTop_(const EGG::Vector3f &v);
+    void setForceUpright(bool isSet);
     /// @endSetters
 
     /// @beginGetters

--- a/source/game/kart/KartMove.cc
+++ b/source/game/kart/KartMove.cc
@@ -777,7 +777,8 @@ void KartMove::calcManualDrift() {
             }
         }
     } else {
-        if (!state()->isDriftInput() || !state()->isAccelerate()) {
+        if (!state()->isDriftInput() || !state()->isAccelerate() || state()->isWall3Collision() ||
+                state()->isWallCollision() || !canStartDrift()) {
             releaseMt();
             resetDriftManual();
         } else {
@@ -1550,6 +1551,13 @@ bool KartMove::canHop() const {
     return true;
 }
 
+/// @addr{0x8057EA94}
+bool KartMove::canStartDrift() const {
+    constexpr f32 MINIMUM_DRIFT_THRESOLD = 0.55f;
+
+    return m_speed > MINIMUM_DRIFT_THRESOLD * m_baseSpeed;
+}
+
 /// @addr{Inlined at 0x80587590}
 void KartMove::tryStartBoostPanel() {
     constexpr s16 BOOST_PANEL_DURATION = 60;
@@ -1893,13 +1901,7 @@ void KartMove::setPadJump(bool isSet) {
 /// @addr{0x8057EFF8}
 /// @return 0.0f if we are too slow to drift, otherwise the hop direction.
 s32 KartMove::getAppliedHopStickX() const {
-    constexpr f32 MIN_DRIFT_THRESHOLD = 0.55f;
-
-    if (MIN_DRIFT_THRESHOLD * m_baseSpeed > m_speed) {
-        return 0;
-    }
-
-    return m_hopStickX;
+    return canStartDrift() ? m_hopStickX : 0;
 }
 
 f32 KartMove::softSpeedLimit() const {

--- a/source/game/kart/KartMove.hh
+++ b/source/game/kart/KartMove.hh
@@ -65,6 +65,7 @@ public:
     [[nodiscard]] virtual f32 getWheelieSoftSpeedLimitBonus() const;
     virtual bool canWheelie() const;
     virtual bool canHop() const;
+    bool canStartDrift() const;
 
     void tryStartBoostPanel();
     void tryStartBoostRamp();

--- a/source/game/kart/KartState.cc
+++ b/source/game/kart/KartState.cc
@@ -2,6 +2,7 @@
 
 #include "game/kart/CollisionGroup.hh"
 #include "game/kart/KartCollide.hh"
+#include "game/kart/KartDynamics.hh"
 #include "game/kart/KartJump.hh"
 #include "game/kart/KartMove.hh"
 
@@ -256,7 +257,7 @@ void KartState::calcCollisions() {
         m_bUNK2 = true;
         m_softWallSpeed = wallNrm;
         m_softWallSpeed.normalise();
-        if (!m_bHop) {
+        if (softWallCount > 0 && !m_bHop) {
             m_bSoftWallDrift = true;
         }
 
@@ -298,6 +299,7 @@ void KartState::calcCollisions() {
 
         if (m_bInATrick && jump()->cooldown() == 0) {
             move()->landTrick();
+            dynamics()->setForceUpright(true);
             jump()->end();
         }
 

--- a/source/game/kart/KartSub.cc
+++ b/source/game/kart/KartSub.cc
@@ -306,6 +306,8 @@ void KartSub::tryEndHWG() {
             state()->setHWG(false);
         }
     }
+
+    dynamics()->setForceUpright(!state()->isSoftWallDrift());
 }
 
 f32 KartSub::someScale() {


### PR DESCRIPTION
Dependent on #120 #126 and #127

Adds a missing setter for `KartDynamics::m_forceUpright`.
During debugging, I also observed a missing `softWallCount` check in `KartState::calcCollisions`, so I've decided to add that in this PR given the sufficiently small scope, and the fact it's closely associated.