### PR TITLE
Fix terminal velocity in calcAcceleration

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -13,7 +13,7 @@ Test Case                                                 | Frames      |     | 
 [`cm-rta-0-25-145`](https://youtu.be/F_RUQVghmuA)         | 1919 / 1919 | ✔️ |
 [`cm-ng-rta-1-55-264`](https://youtu.be/XxKG3IYWduE)      | 651 / 7320  | ❌ | KMP
 [`dks-rta-1-44-568`](https://youtu.be/b9hacHlifcw)        | 1049 / 6679 | ❌ | Zipper
-[`wgm-rta-0-31-678`](https://youtu.be/VVFXP639DRY)        | 562 / 2310  | ❌ | KMP
+[`wgm-rta-0-31-678`](https://youtu.be/VVFXP639DRY)        | 2310 / 2310 | ✔️ |
 [`wgm-ng-rta-1-49-934`](https://youtu.be/NbhzA2rtZ2A)     | 7001 / 7001 | ✔️ |
 [`dc-rta-1-28-321`](https://youtu.be/Rs5AK3iHVno)         | 1058 / 5705 | ❌ | KMP
 [`kc-rta-1-55-250`](https://youtu.be/Elb5K7woV20)         | 1520 / 7320 | ❌ | Moving water

--- a/source/game/kart/KartMove.cc
+++ b/source/game/kart/KartMove.cc
@@ -1079,6 +1079,7 @@ void KartMove::calcAcceleration() {
     constexpr f32 ROTATION_SCALAR_MIDAIR = 0.2f;
     constexpr f32 ROTATION_SCALAR_BOOST_RAMP = 4.0f;
     constexpr f32 OOB_SLOWDOWN_RATE = 0.95f;
+    constexpr f32 TERMINAL_VELOCITY = 90.0f;
 
     m_lastSpeed = m_speed;
 
@@ -1156,6 +1157,7 @@ void KartMove::calcAcceleration() {
     m_vel1Dir = local_90.multVector33(m_vel1Dir);
     m_processedSpeed = m_speed;
     EGG::Vector3f nextSpeed = m_speed * m_vel1Dir;
+    nextSpeed.y = std::min(TERMINAL_VELOCITY, nextSpeed.y);
     dynamics()->setIntVel(dynamics()->intVel() + nextSpeed);
 
     if (state()->isTouchingGround() && !state()->isDriftManual() && !state()->isHop()) {


### PR DESCRIPTION
This syncs the WGM glitch 3lap RTA WR. There was a missing check to restrict y speed to 90.0f in `KartMove::calcAcceleration`.