### PR TITLE
Add object blacklist

### DIFF
--- a/source/game/field/Object.cc
+++ b/source/game/field/Object.cc
@@ -6,7 +6,7 @@ namespace Field {
 
 /// @addr{0x8081F828}
 Object::Object(const System::MapdataGeoObj &params)
-    : m_id(params.id()), m_pos(params.pos()), m_rot(params.rot() * DEG2RAD),
+    : m_id(static_cast<ObjectId>(params.id())), m_pos(params.pos()), m_rot(params.rot() * DEG2RAD),
       m_scale(params.scale()) {}
 
 } // namespace Field

--- a/source/game/field/Object.hh
+++ b/source/game/field/Object.hh
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "game/field/ObjectId.hh"
+
 #include "game/system/map/MapdataGeoObj.hh"
 
 namespace Field {
@@ -9,7 +11,7 @@ public:
     Object(const System::MapdataGeoObj &params);
 
 protected:
-    u16 m_id;
+    ObjectId m_id;
     EGG::Vector3f m_pos;
     EGG::Vector3f m_rot;
     EGG::Vector3f m_scale;

--- a/source/game/field/ObjectDirector.cc
+++ b/source/game/field/ObjectDirector.cc
@@ -51,6 +51,11 @@ void ObjectDirector::createObjects() {
             continue;
         }
 
+        // Prevent construction of objects with disabled or no collision
+        if (IsObjectBlacklisted(pObj->id())) {
+            continue;
+        }
+
         m_objects.push_back(createObject(*pObj));
     }
 }

--- a/source/game/field/ObjectId.hh
+++ b/source/game/field/ObjectId.hh
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <Common.hh>
+
+namespace Field {
+
+enum class ObjectId {
+    DokanSFC = 0x12e,
+    OilSFC = 0x15d,
+};
+
+enum class BlacklistedObjectId {
+    Itembox = 0x65,
+    Hanabi = 0x16a,
+};
+
+static constexpr bool IsObjectBlacklisted(u16 id) {
+    BlacklistedObjectId objectId = static_cast<BlacklistedObjectId>(id);
+    switch (objectId) {
+    // Disabled collision
+    case BlacklistedObjectId::Itembox:
+        return true;
+
+    // No collision
+    case BlacklistedObjectId::Hanabi:
+        return true;
+
+    default:
+        return false;
+    }
+}
+
+} // namespace Field


### PR DESCRIPTION
Additions to the blacklist will be one line when we need them. The blacklist can be separated into two categories: ones where collision is disabled in TTs, and the others where there is no collision.