### PR TITLE
Sync drift cancel due to wall bonk

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -47,7 +47,7 @@ Test Case                                                 | Frames      |     | 
 [`rbc3-rta-1-55-715`](https://youtu.be/vSbSADDEzEs)       | 7347 / 7347 | ✔️ |
 [`rbc3-ng-rta-2-16-183`](https://youtu.be/xZwlaonIBws)    | 8574 / 8574 | ✔️ |
 [`rdkjp-rta-0-40-105`](https://youtu.be/bkinW1UZK6M)      | 800 / 2815  | ❌ | KMP tree wall clip
-[`rdkjp-ng-rta-2-09-321`](https://youtu.be/WRXMrAUnOLo)   | 904 / 8163  | ❌ | Wall bonk spin drift
+[`rdkjp-ng-rta-2-09-321`](https://youtu.be/WRXMrAUnOLo)   | 1089 / 8163 | ❌ | Boost panel hop
 [`rdkjp-nosc-rta-2-10-546`](https://youtu.be/ovFBMmhFioA) | 8236 / 8236 | ✔️ |
 [`rmc-rta-1-29-945`](https://youtu.be/QwWEFaiOquI)        | 5803 / 5803 | ✔️ |
 [`rmc-ng-rta-1-30-272`](https://youtu.be/HSatgyRolcI)     | 5822 / 5822 | ✔️ |

--- a/source/game/kart/KartMove.hh
+++ b/source/game/kart/KartMove.hh
@@ -210,6 +210,7 @@ protected:
     bool m_bPadBoost; ///< Caches whether the player is currently interacting with a boost pad.
     bool m_bRampBoost;
     bool m_bPadJump;
+    bool m_bDriftReset;       ///< Set when a wall bonk should cancel your drift.
     bool m_bSsmtCharged;      ///< Set after holding a stand-still mini-turbo for 75 frames.
     bool m_bSsmtLeeway;       ///< If set, activates SSMT when not pressing A or B.
     bool m_bTrickableSurface; ///< Set when driving on a trickable surface.


### PR DESCRIPTION
This syncs the wall bonk on rDKJP NG by cancelling our drift due to the wall bonk.