### PR TITLE
Kart namespace: Limit function visibility

### DIFF
--- a/source/game/kart/CollisionGroup.cc
+++ b/source/game/kart/CollisionGroup.cc
@@ -149,38 +149,6 @@ f32 CollisionGroup::initHitboxes(const std::array<BSP::Hitbox, 16> &hitboxes) {
     return computeCollisionLimits();
 }
 
-/// @brief Sets the bounding radius
-/// @addr{0x805B883C}
-/// @return The furthest point of all the hitboxes' spheres
-f32 CollisionGroup::computeCollisionLimits() {
-    EGG::Vector3f max;
-
-    for (const auto &hitbox : m_hitboxes) {
-        const BSP::Hitbox *bspHitbox = hitbox.bspHitbox();
-
-        if (bspHitbox->enable == 0) {
-            continue;
-        }
-
-        max = max.maximize(bspHitbox->position.abs() + bspHitbox->radius);
-    }
-
-    // Get largest component of the vector
-    f32 maxComponent = max.z;
-
-    if (max.x <= max.y) {
-        if (max.z < max.y) {
-            maxComponent = max.y;
-        }
-    } else if (max.z < max.x) {
-        maxComponent = max.x;
-    }
-
-    m_boundingRadius = maxComponent;
-
-    return max.z * 0.5f;
-}
-
 /// @brief Creates a hitbox to represent a tire
 /// @addr{0x805B875C}
 /// @param radius The radius of the tire
@@ -237,6 +205,38 @@ CollisionData &CollisionGroup::collisionData() {
 
 const CollisionData &CollisionGroup::collisionData() const {
     return m_collisionData;
+}
+
+/// @brief Sets the bounding radius
+/// @addr{0x805B883C}
+/// @return The furthest point of all the hitboxes' spheres
+f32 CollisionGroup::computeCollisionLimits() {
+    EGG::Vector3f max;
+
+    for (const auto &hitbox : m_hitboxes) {
+        const BSP::Hitbox *bspHitbox = hitbox.bspHitbox();
+
+        if (bspHitbox->enable == 0) {
+            continue;
+        }
+
+        max = max.maximize(bspHitbox->position.abs() + bspHitbox->radius);
+    }
+
+    // Get largest component of the vector
+    f32 maxComponent = max.z;
+
+    if (max.x <= max.y) {
+        if (max.z < max.y) {
+            maxComponent = max.y;
+        }
+    } else if (max.z < max.x) {
+        maxComponent = max.x;
+    }
+
+    m_boundingRadius = maxComponent;
+
+    return max.z * 0.5f;
 }
 
 } // namespace Kart

--- a/source/game/kart/CollisionGroup.hh
+++ b/source/game/kart/CollisionGroup.hh
@@ -86,7 +86,6 @@ public:
     ~CollisionGroup();
 
     [[nodiscard]] f32 initHitboxes(const std::array<BSP::Hitbox, 16> &hitboxes);
-    [[nodiscard]] f32 computeCollisionLimits();
     void createSingleHitbox(f32 radius, const EGG::Vector3f &relPos);
 
     /// @beginSetters
@@ -103,6 +102,8 @@ public:
     /// @endGetters
 
 private:
+    [[nodiscard]] f32 computeCollisionLimits();
+
     f32 m_boundingRadius;
     CollisionData m_collisionData;
     std::span<Hitbox> m_hitboxes;

--- a/source/game/kart/KartCollide.hh
+++ b/source/game/kart/KartCollide.hh
@@ -32,28 +32,9 @@ public:
 
     void findCollision();
     void FUN_80572F4C();
-    void FUN_805B72B8(f32 param_1, f32 param_2, bool lockXZ, bool addExtVelY);
-    void calcBodyCollision(f32 totalScale, f32 sinkDepth, const EGG::Quatf &rot,
-            const EGG::Vector3f &scale);
     void calcFloorEffect();
-    void calcTriggers(Field::KCLTypeMask *mask, const EGG::Vector3f &pos, bool twoPoint);
-    void handleTriggers(Field::KCLTypeMask *mask);
-    void calcFallBoundary(Field::KCLTypeMask *mask, bool shortBoundary);
-    void activateOob(bool detachCamera, Field::KCLTypeMask *mask, bool somethingCPU,
-            bool somethingBullet);
     void calcWheelCollision(u16 wheelIdx, CollisionGroup *hitboxGroup, const EGG::Vector3f &colVel,
             const EGG::Vector3f &center, f32 radius);
-    void calcSideCollision(CollisionData &collisionData, Hitbox &hitbox,
-            Field::CourseColMgr::CollisionInfo *colInfo);
-
-    void processWheel(CollisionData &collisionData, Hitbox &hitbox,
-            Field::CourseColMgr::CollisionInfo *colInfo, Field::KCLTypeMask *maskOut);
-    void processBody(CollisionData &collisionData, Hitbox &hitbox,
-            Field::CourseColMgr::CollisionInfo *colInfo, Field::KCLTypeMask *maskOut);
-    [[nodiscard]] bool processWall(CollisionData &collisionData, Field::KCLTypeMask *maskOut);
-    void processFloor(CollisionData &collisionData, Hitbox &hitbox,
-            Field::CourseColMgr::CollisionInfo *colInfo, Field::KCLTypeMask *maskOut, bool wheel);
-
     void applySomeFloorMoment(f32 down, f32 rate, CollisionGroup *hitboxGroup,
             const EGG::Vector3f &forward, const EGG::Vector3f &nextDir, const EGG::Vector3f &speed,
             bool b1, bool b2, bool b3);
@@ -81,6 +62,24 @@ public:
     /// @endGetters
 
 private:
+    void FUN_805B72B8(f32 param_1, f32 param_2, bool lockXZ, bool addExtVelY);
+    void calcBodyCollision(f32 totalScale, f32 sinkDepth, const EGG::Quatf &rot,
+            const EGG::Vector3f &scale);
+    void calcTriggers(Field::KCLTypeMask *mask, const EGG::Vector3f &pos, bool twoPoint);
+    void handleTriggers(Field::KCLTypeMask *mask);
+    void calcFallBoundary(Field::KCLTypeMask *mask, bool shortBoundary);
+    void activateOob(bool detachCamera, Field::KCLTypeMask *mask, bool somethingCPU,
+            bool somethingBullet);
+    void calcSideCollision(CollisionData &collisionData, Hitbox &hitbox,
+            Field::CourseColMgr::CollisionInfo *colInfo);
+    void processWheel(CollisionData &collisionData, Hitbox &hitbox,
+            Field::CourseColMgr::CollisionInfo *colInfo, Field::KCLTypeMask *maskOut);
+    void processBody(CollisionData &collisionData, Hitbox &hitbox,
+            Field::CourseColMgr::CollisionInfo *colInfo, Field::KCLTypeMask *maskOut);
+    [[nodiscard]] bool processWall(CollisionData &collisionData, Field::KCLTypeMask *maskOut);
+    void processFloor(CollisionData &collisionData, Hitbox &hitbox,
+            Field::CourseColMgr::CollisionInfo *colInfo, Field::KCLTypeMask *maskOut, bool wheel);
+
     SurfaceFlags m_surfaceFlags;
     EGG::Vector3f m_movement;
     s16 m_respawnTimer;

--- a/source/game/kart/KartDynamics.cc
+++ b/source/game/kart/KartDynamics.cc
@@ -15,19 +15,6 @@ KartDynamics::KartDynamics() {
 /// @addr{0x8059F6B8}
 KartDynamics::~KartDynamics() = default;
 
-/// @addr{0x805B5B68}
-/// @brief Stabilizes the kart by rotating towards the y-axis unit vector.
-void KartDynamics::stabilize() {
-    EGG::Vector3f top = m_mainRot.rotateVector(EGG::Vector3f::ey);
-    if (EGG::Mathf::abs(top.dot(m_top)) >= 0.9999f) {
-        return;
-    }
-
-    EGG::Quatf q;
-    q.makeVectorRotation(top, m_top);
-    m_mainRot = m_mainRot.slerpTo(q.multSwap(m_mainRot), m_stabilizationFactor);
-}
-
 /// @addr{0x805B4B54}
 void KartDynamics::init() {
     m_speedNorm = 0.0f;
@@ -150,6 +137,7 @@ void KartDynamics::calc(f32 dt, f32 maxSpeed, bool /*air*/) {
 }
 
 /// @addr{0x805B4D24}
+/// @unused
 void KartDynamics::reset() {
     m_extVel.setZero();
     m_acceleration.setZero();
@@ -311,6 +299,19 @@ const EGG::Vector3f &KartDynamics::angVel2() const {
 
 f32 KartDynamics::speedFix() const {
     return m_speedFix;
+}
+
+/// @addr{0x805B5B68}
+/// @brief Stabilizes the kart by rotating towards the y-axis unit vector.
+void KartDynamics::stabilize() {
+    EGG::Vector3f top = m_mainRot.rotateVector(EGG::Vector3f::ey);
+    if (EGG::Mathf::abs(top.dot(m_top)) >= 0.9999f) {
+        return;
+    }
+
+    EGG::Quatf q;
+    q.makeVectorRotation(top, m_top);
+    m_mainRot = m_mainRot.slerpTo(q.multSwap(m_mainRot), m_stabilizationFactor);
 }
 
 KartDynamicsBike::KartDynamicsBike() = default;

--- a/source/game/kart/KartDynamics.hh
+++ b/source/game/kart/KartDynamics.hh
@@ -14,9 +14,6 @@ public:
     KartDynamics();
     virtual ~KartDynamics();
 
-    virtual void forceUpright() {}
-    virtual void stabilize();
-
     void init();
     void resetInternalVelocity();
     void setBspParams(f32 rotSpeed, const EGG::Vector3f &m, const EGG::Vector3f &n,
@@ -65,6 +62,9 @@ public:
     /// @endGetters
 
 protected:
+    virtual void forceUpright() {}
+    virtual void stabilize();
+
     EGG::Matrix34f m_inertiaTensor;    ///< Resistance to rotational change, as a 3x3 matrix.
     EGG::Matrix34f m_invInertiaTensor; ///< The inverse of @ref m_inertiaTensor.
     f32 m_angVel0Factor;               ///< Scalar for damping angular velocity.

--- a/source/game/kart/KartJump.hh
+++ b/source/game/kart/KartJump.hh
@@ -44,14 +44,9 @@ public:
     KartJump(KartMove *move);
     virtual ~KartJump();
 
-    virtual void calcRot() {}
-
-    void setupProperties();
     void reset();
     void tryStart(const EGG::Vector3f &left);
     void calc();
-    bool someFlagCheck();
-    void calcInput();
     void end();
 
     void setAngle(const EGG::Vector3f &left);
@@ -69,6 +64,12 @@ public:
     /// @endGetters
 
 protected:
+    virtual void calcRot() {}
+
+    void setupProperties();
+    bool someFlagCheck();
+    void calcInput();
+
     TrickType m_type;
     SurfaceVariant m_variant;
     System::Trick m_nextTrick;
@@ -96,9 +97,9 @@ public:
     KartJumpBike(KartMove *move);
     ~KartJumpBike();
 
+private:
     void calcRot() override;
 
-private:
     void start(const EGG::Vector3f &left) override;
     void init() override;
 };

--- a/source/game/kart/KartMove.hh
+++ b/source/game/kart/KartMove.hh
@@ -23,67 +23,18 @@ public:
     virtual ~KartMove();
 
     virtual void createSubsystems();
-    virtual void calcTurn();
-    virtual void calcWheelie() {}
     virtual void setTurnParams();
     virtual void init(bool b1, bool b2);
     [[nodiscard]] virtual f32 leanRot() const;
 
     void setInitialPhysicsValues(const EGG::Vector3f &position, const EGG::Vector3f &angles);
     void setKartSpeedLimit();
-    void resetDriftManual();
 
     void calc();
-    void calcTop();
-    void calcAirtimeTop();
-    void calcSpecialFloor();
-    void calcDirs();
-    void calcStickyRoad();
-    void calcOffroad();
-    void calcBoost();
-    void calcRampBoost();
-    void calcDisableBackwardsAccel();
-    void calcSsmt();
-    bool calcPreDrift();
-    void calcManualDrift();
-    void startManualDrift();
-    void clearDrift();
-    void clearJumpPad();
-    void clearRampBoost();
-    void clearBoost();
-    void clearSsmt();
-    void clearOffroadInvincibility();
-    void releaseMt();
-    void controlOutsideDriftAngle();
-    void calcRotation();
-    void calcVehicleSpeed();
-    void calcDeceleration();
-    [[nodiscard]] f32 calcVehicleAcceleration() const;
-    void calcAcceleration();
-    [[nodiscard]] f32 calcWallCollisionSpeedFactor(f32 &f1);
-    void calcWallCollisionStart(f32 param_2);
-    void calcStandstillBoostRot();
-    void calcDive();
-    void calcSsmtStart();
     void calcHopPhysics();
-    virtual void calcVehicleRotation(f32 turn);
-    virtual void hop();
-    virtual void onHop() {}
-    virtual void onWallCollision() {}
-    virtual void calcMtCharge();
+
     virtual void initOob() {}
-    [[nodiscard]] virtual f32 getWheelieSoftSpeedLimitBonus() const;
-    virtual bool canWheelie() const;
-    virtual bool canHop() const;
-    bool canStartDrift() const;
 
-    void tryStartBoostPanel();
-    void tryStartBoostRamp();
-    void tryStartJumpPad();
-    void tryEndJumpPad();
-    void cancelJumpPad();
-
-    void activateBoost(KartBoost::Type type, s16 frames);
     void applyStartBoost(s16 frames);
     void activateMushroom();
     void setOffroadInvincibility(s16 timer);
@@ -164,6 +115,15 @@ protected:
         f32 boostRotFactor;
     };
 
+protected:
+    void clearRampBoost();
+    void clearBoost();
+    void clearSsmt();
+    void clearOffroadInvincibility();
+    void calcStandstillBoostRot();
+    void calcDive();
+    void cancelJumpPad();
+
     f32 m_baseSpeed;      ///< The speed associated with the current character/vehicle stats.
     f32 m_softSpeedLimit; ///< Base speed + boosts + wheelies, restricted to the hard speed limit.
     f32 m_speed;          ///< Current speed, restricted to the soft speed limit.
@@ -229,6 +189,50 @@ protected:
     KartJump *m_jump;
     const DriftingParameters *m_driftingParams; ///< Drift-type-specific parameters.
     f32 m_rawTurn; ///< Float in range [-1, 1]. Represents stick magnitude + direction.
+
+private:
+    virtual void calcTurn();
+    virtual void calcWheelie() {}
+    virtual void calcVehicleRotation(f32 turn);
+    virtual void hop();
+    virtual void onHop() {}
+    virtual void onWallCollision() {}
+    virtual void calcMtCharge();
+    [[nodiscard]] virtual f32 getWheelieSoftSpeedLimitBonus() const;
+    [[nodiscard]] virtual bool canWheelie() const;
+    [[nodiscard]] virtual bool canHop() const;
+
+    void resetDriftManual();
+    void calcTop();
+    void calcAirtimeTop();
+    void calcSpecialFloor();
+    void calcDirs();
+    void calcStickyRoad();
+    void calcOffroad();
+    void calcBoost();
+    void calcRampBoost();
+    void calcDisableBackwardsAccel();
+    void calcSsmt();
+    bool calcPreDrift();
+    void calcManualDrift();
+    void startManualDrift();
+    void clearDrift();
+    void releaseMt();
+    void controlOutsideDriftAngle();
+    void calcRotation();
+    void calcVehicleSpeed();
+    void calcDeceleration();
+    [[nodiscard]] f32 calcVehicleAcceleration() const;
+    void calcAcceleration();
+    [[nodiscard]] f32 calcWallCollisionSpeedFactor(f32 &f1);
+    void calcWallCollisionStart(f32 param_2);
+    void calcSsmtStart();
+    void tryStartBoostPanel();
+    void tryStartBoostRamp();
+    void tryStartJumpPad();
+    void tryEndJumpPad();
+    void activateBoost(KartBoost::Type type, s16 frames);
+    [[nodiscard]] bool canStartDrift() const;
 };
 
 /// @brief Responsible for reacting to player inputs and moving the bike.

--- a/source/game/kart/KartObject.cc
+++ b/source/game/kart/KartObject.cc
@@ -33,51 +33,6 @@ KartObject::~KartObject() {
     }
 }
 
-/// @addr{0x8058EA0C}
-void KartObject::createTires() {
-    constexpr u16 BSP_WHEEL_INDICES[8] = {0, 0, 1, 1, 2, 2, 3, 3};
-    constexpr KartSuspensionPhysics::TireType X_MIRRORED_TIRE[8] = {
-            KartSuspensionPhysics::TireType::Kart,
-            KartSuspensionPhysics::TireType::KartReflected,
-            KartSuspensionPhysics::TireType::Kart,
-            KartSuspensionPhysics::TireType::KartReflected,
-            KartSuspensionPhysics::TireType::Kart,
-            KartSuspensionPhysics::TireType::KartReflected,
-            KartSuspensionPhysics::TireType::Kart,
-            KartSuspensionPhysics::TireType::KartReflected,
-    };
-
-    auto bodyType = m_pointers.param->stats().body;
-    u32 tireCount = m_pointers.param->tireCount();
-
-    if (bodyType == KartParam::Stats::Body::Three_Wheel_Kart) {
-        tireCount = 4;
-    }
-
-    for (u16 wheelIdx = 0; wheelIdx < tireCount; ++wheelIdx) {
-        if (bodyType == KartParam::Stats::Body::Three_Wheel_Kart && wheelIdx == 0) {
-            continue;
-        }
-
-        u16 bspWheelIdx = BSP_WHEEL_INDICES[wheelIdx];
-        KartSuspensionPhysics::TireType tireType = X_MIRRORED_TIRE[wheelIdx];
-
-        KartSuspension *sus = new KartSuspension;
-        KartTire *tire = (bspWheelIdx == 0) ? new KartTireFront(tireType, bspWheelIdx) :
-                                              new KartTire(tireType, bspWheelIdx);
-
-        m_pointers.suspensions.push_back(sus);
-        m_pointers.tires.push_back(tire);
-
-        sus->init(wheelIdx, tireType, bspWheelIdx);
-    }
-}
-
-/// @addr{0x8058E5F8}
-KartBody *KartObject::createBody(KartPhysics *physics) {
-    return new KartBodyKart(physics);
-}
-
 /// @addr{0x8058E22C}
 void KartObject::init() {
     prepareTiresAndSuspensions();
@@ -195,6 +150,51 @@ KartObject *KartObject::Create(Character character, Vehicle vehicle, u8 playerId
     }
 
     return object;
+}
+
+/// @addr{0x8058E5F8}
+KartBody *KartObject::createBody(KartPhysics *physics) {
+    return new KartBodyKart(physics);
+}
+
+/// @addr{0x8058EA0C}
+void KartObject::createTires() {
+    constexpr u16 BSP_WHEEL_INDICES[8] = {0, 0, 1, 1, 2, 2, 3, 3};
+    constexpr KartSuspensionPhysics::TireType X_MIRRORED_TIRE[8] = {
+            KartSuspensionPhysics::TireType::Kart,
+            KartSuspensionPhysics::TireType::KartReflected,
+            KartSuspensionPhysics::TireType::Kart,
+            KartSuspensionPhysics::TireType::KartReflected,
+            KartSuspensionPhysics::TireType::Kart,
+            KartSuspensionPhysics::TireType::KartReflected,
+            KartSuspensionPhysics::TireType::Kart,
+            KartSuspensionPhysics::TireType::KartReflected,
+    };
+
+    auto bodyType = m_pointers.param->stats().body;
+    u32 tireCount = m_pointers.param->tireCount();
+
+    if (bodyType == KartParam::Stats::Body::Three_Wheel_Kart) {
+        tireCount = 4;
+    }
+
+    for (u16 wheelIdx = 0; wheelIdx < tireCount; ++wheelIdx) {
+        if (bodyType == KartParam::Stats::Body::Three_Wheel_Kart && wheelIdx == 0) {
+            continue;
+        }
+
+        u16 bspWheelIdx = BSP_WHEEL_INDICES[wheelIdx];
+        KartSuspensionPhysics::TireType tireType = X_MIRRORED_TIRE[wheelIdx];
+
+        KartSuspension *sus = new KartSuspension;
+        KartTire *tire = (bspWheelIdx == 0) ? new KartTireFront(tireType, bspWheelIdx) :
+                                              new KartTire(tireType, bspWheelIdx);
+
+        m_pointers.suspensions.push_back(sus);
+        m_pointers.tires.push_back(tire);
+
+        sus->init(wheelIdx, tireType, bspWheelIdx);
+    }
 }
 
 /// @addr{0x8058F20C}

--- a/source/game/kart/KartObject.hh
+++ b/source/game/kart/KartObject.hh
@@ -12,8 +12,6 @@ class KartObject : public KartObjectProxy {
 public:
     KartObject(KartParam *param);
     virtual ~KartObject();
-    [[nodiscard]] virtual KartBody *createBody(KartPhysics *physics);
-    virtual void createTires();
 
     void init();
     void initImpl();
@@ -32,6 +30,10 @@ public:
 
 protected:
     KartAccessor m_pointers;
+
+private:
+    [[nodiscard]] virtual KartBody *createBody(KartPhysics *physics);
+    virtual void createTires();
 };
 
 /// @brief The highest level abstraction for a bike.
@@ -39,6 +41,8 @@ class KartObjectBike : public KartObject {
 public:
     KartObjectBike(KartParam *param);
     ~KartObjectBike() override;
+
+private:
     [[nodiscard]] KartBody *createBody(KartPhysics *physics) override;
     void createTires() override;
 };

--- a/source/game/kart/KartParam.cc
+++ b/source/game/kart/KartParam.cc
@@ -190,10 +190,6 @@ void KartParam::Stats::applyCharacterBonus(EGG::RamStream &stream) {
 BSP::BSP() = default;
 
 BSP::BSP(EGG::RamStream &stream) {
-    read(stream);
-}
-
-void BSP::read(EGG::RamStream &stream) {
     initialYPos = stream.read_f32();
 
     for (auto &hitbox : hitboxes) {

--- a/source/game/kart/KartParam.hh
+++ b/source/game/kart/KartParam.hh
@@ -33,8 +33,6 @@ struct BSP {
     BSP();
     BSP(EGG::RamStream &stream);
 
-    void read(EGG::RamStream &stream);
-
     f32 initialYPos;
     std::array<Hitbox, 16> hitboxes; ///< Array of vehicle hitboxes, not all of which are active.
     EGG::Vector3f cuboids[2];        ///< Mask cuboids for computing moment of inertia.

--- a/source/game/kart/KartState.cc
+++ b/source/game/kart/KartState.cc
@@ -134,6 +134,230 @@ void KartState::calc() {
     calcCollisions();
 }
 
+bool KartState::isDrifting() const {
+    return m_bDriftManual || m_bDriftAuto;
+}
+
+bool KartState::isAccelerate() const {
+    return m_bAccelerate;
+}
+
+bool KartState::isBrake() const {
+    return m_bBrake;
+}
+
+bool KartState::isDriftInput() const {
+    return m_bDriftInput;
+}
+
+bool KartState::isDriftManual() const {
+    return m_bDriftManual;
+}
+
+bool KartState::isBeforeRespawn() const {
+    return m_bBeforeRespawn;
+}
+
+bool KartState::isWall3Collision() const {
+    return m_bWall3Collision;
+}
+
+bool KartState::isWallCollision() const {
+    return m_bWallCollision;
+}
+
+bool KartState::isHopStart() const {
+    return m_bHopStart;
+}
+
+bool KartState::isGroundStart() const {
+    return m_bGroundStart;
+}
+
+bool KartState::isVehicleBodyFloorCollision() const {
+    return m_bVehicleBodyFloorCollision;
+}
+
+bool KartState::isAnyWheelCollision() const {
+    return m_bAnyWheelCollision;
+}
+
+bool KartState::isAllWheelsCollision() const {
+    return m_bAllWheelsCollision;
+}
+
+bool KartState::isStickLeft() const {
+    return m_bStickLeft;
+}
+
+bool KartState::isWallCollisionStart() const {
+    return m_bWallCollisionStart;
+}
+
+bool KartState::isAirtimeOver20() const {
+    return m_bAirtimeOver20;
+}
+
+bool KartState::isStickyRoad() const {
+    return m_bStickyRoad;
+}
+
+bool KartState::isTouchingGround() const {
+    return m_bTouchingGround;
+}
+
+bool KartState::isHop() const {
+    return m_bHop;
+}
+
+bool KartState::isSoftWallDrift() const {
+    return m_bSoftWallDrift;
+}
+
+bool KartState::isHWG() const {
+    return m_bHWG;
+}
+
+bool KartState::isChargeStartBoost() const {
+    return m_bChargeStartBoost;
+}
+
+bool KartState::isBoost() const {
+    return m_bBoost;
+}
+
+bool KartState::isStickRight() const {
+    return m_bStickRight;
+}
+
+bool KartState::isMushroomBoost() const {
+    return m_bMushroomBoost;
+}
+
+bool KartState::isDriftAuto() const {
+    return m_bDriftAuto;
+}
+
+bool KartState::isSlipdriftCharge() const {
+    return m_bSlipdriftCharge;
+}
+
+bool KartState::isWheelie() const {
+    return m_bWheelie;
+}
+
+bool KartState::isJumpPad() const {
+    return m_bJumpPad;
+}
+
+bool KartState::isRampBoost() const {
+    return m_bRampBoost;
+}
+
+bool KartState::isCannonStart() const {
+    return m_bCannonStart;
+}
+
+bool KartState::isInCannon() const {
+    return m_bInCannon;
+}
+
+bool KartState::isTrickStart() const {
+    return m_bTrickStart;
+}
+
+bool KartState::isInATrick() const {
+    return m_bInATrick;
+}
+
+bool KartState::isBoostOffroadInvincibility() const {
+    return m_bBoostOffroadInvincibility;
+}
+
+bool KartState::isDisableBackwardsAccel() const {
+    return m_bDisableBackwardsAccel;
+}
+
+bool KartState::isTrickRot() const {
+    return m_bTrickRot;
+}
+
+bool KartState::isChargingSsmt() const {
+    return m_bChargingSsmt;
+}
+
+bool KartState::isTrickable() const {
+    return m_bTrickable;
+}
+
+bool KartState::isWheelieRot() const {
+    return m_bWheelieRot;
+}
+
+bool KartState::isJumpPadDisableYsusForce() const {
+    return m_bJumpPadDisableYsusForce;
+}
+
+bool KartState::isSkipWheelCalc() const {
+    return m_bSkipWheelCalc;
+}
+
+bool KartState::isUNK2() const {
+    return m_bUNK2;
+}
+
+bool KartState::isSomethingWallCollision() const {
+    return m_bSomethingWallCollision;
+}
+
+bool KartState::isAutoDrift() const {
+    return m_bAutoDrift;
+}
+
+u16 KartState::cannonPointId() const {
+    return m_cannonPointId;
+}
+
+s32 KartState::boostRampType() const {
+    return m_boostRampType;
+}
+
+s32 KartState::jumpPadVariant() const {
+    return m_jumpPadVariant;
+}
+
+f32 KartState::stickX() const {
+    return m_stickX;
+}
+
+f32 KartState::stickY() const {
+    return m_stickY;
+}
+
+u32 KartState::airtime() const {
+    return m_airtime;
+}
+
+const EGG::Vector3f &KartState::top() const {
+    return m_top;
+}
+
+const EGG::Vector3f &KartState::softWallSpeed() const {
+    return m_softWallSpeed;
+}
+
+f32 KartState::startBoostCharge() const {
+    return m_startBoostCharge;
+}
+
+s16 KartState::wallBonkTimer() const {
+    return m_wallBonkTimer;
+}
+
+s16 KartState::trickableTimer() const {
+    return m_trickableTimer;
+}
+
 /// @stage All
 /// @brief Each frame, checks for collision and saves relevant bit flags.
 /// @addr{0x80594BD4}
@@ -372,230 +596,6 @@ void KartState::handleStartBoost(size_t idx) {
         K_PANIC("More burnout RE required. See KartMoveSub264 function 0x805890b0.");
     }
     move()->applyStartBoost(START_BOOST_ENTRIES[idx].frames);
-}
-
-bool KartState::isDrifting() const {
-    return m_bDriftManual || m_bDriftAuto;
-}
-
-bool KartState::isAccelerate() const {
-    return m_bAccelerate;
-}
-
-bool KartState::isBrake() const {
-    return m_bBrake;
-}
-
-bool KartState::isDriftInput() const {
-    return m_bDriftInput;
-}
-
-bool KartState::isDriftManual() const {
-    return m_bDriftManual;
-}
-
-bool KartState::isBeforeRespawn() const {
-    return m_bBeforeRespawn;
-}
-
-bool KartState::isWall3Collision() const {
-    return m_bWall3Collision;
-}
-
-bool KartState::isWallCollision() const {
-    return m_bWallCollision;
-}
-
-bool KartState::isHopStart() const {
-    return m_bHopStart;
-}
-
-bool KartState::isGroundStart() const {
-    return m_bGroundStart;
-}
-
-bool KartState::isVehicleBodyFloorCollision() const {
-    return m_bVehicleBodyFloorCollision;
-}
-
-bool KartState::isAnyWheelCollision() const {
-    return m_bAnyWheelCollision;
-}
-
-bool KartState::isAllWheelsCollision() const {
-    return m_bAllWheelsCollision;
-}
-
-bool KartState::isStickLeft() const {
-    return m_bStickLeft;
-}
-
-bool KartState::isWallCollisionStart() const {
-    return m_bWallCollisionStart;
-}
-
-bool KartState::isAirtimeOver20() const {
-    return m_bAirtimeOver20;
-}
-
-bool KartState::isStickyRoad() const {
-    return m_bStickyRoad;
-}
-
-bool KartState::isTouchingGround() const {
-    return m_bTouchingGround;
-}
-
-bool KartState::isHop() const {
-    return m_bHop;
-}
-
-bool KartState::isSoftWallDrift() const {
-    return m_bSoftWallDrift;
-}
-
-bool KartState::isHWG() const {
-    return m_bHWG;
-}
-
-bool KartState::isChargeStartBoost() const {
-    return m_bChargeStartBoost;
-}
-
-bool KartState::isBoost() const {
-    return m_bBoost;
-}
-
-bool KartState::isStickRight() const {
-    return m_bStickRight;
-}
-
-bool KartState::isMushroomBoost() const {
-    return m_bMushroomBoost;
-}
-
-bool KartState::isDriftAuto() const {
-    return m_bDriftAuto;
-}
-
-bool KartState::isSlipdriftCharge() const {
-    return m_bSlipdriftCharge;
-}
-
-bool KartState::isWheelie() const {
-    return m_bWheelie;
-}
-
-bool KartState::isJumpPad() const {
-    return m_bJumpPad;
-}
-
-bool KartState::isRampBoost() const {
-    return m_bRampBoost;
-}
-
-bool KartState::isCannonStart() const {
-    return m_bCannonStart;
-}
-
-bool KartState::isInCannon() const {
-    return m_bInCannon;
-}
-
-bool KartState::isTrickStart() const {
-    return m_bTrickStart;
-}
-
-bool KartState::isInATrick() const {
-    return m_bInATrick;
-}
-
-bool KartState::isBoostOffroadInvincibility() const {
-    return m_bBoostOffroadInvincibility;
-}
-
-bool KartState::isDisableBackwardsAccel() const {
-    return m_bDisableBackwardsAccel;
-}
-
-bool KartState::isTrickRot() const {
-    return m_bTrickRot;
-}
-
-bool KartState::isChargingSsmt() const {
-    return m_bChargingSsmt;
-}
-
-bool KartState::isTrickable() const {
-    return m_bTrickable;
-}
-
-bool KartState::isWheelieRot() const {
-    return m_bWheelieRot;
-}
-
-bool KartState::isJumpPadDisableYsusForce() const {
-    return m_bJumpPadDisableYsusForce;
-}
-
-bool KartState::isSkipWheelCalc() const {
-    return m_bSkipWheelCalc;
-}
-
-bool KartState::isUNK2() const {
-    return m_bUNK2;
-}
-
-bool KartState::isSomethingWallCollision() const {
-    return m_bSomethingWallCollision;
-}
-
-bool KartState::isAutoDrift() const {
-    return m_bAutoDrift;
-}
-
-u16 KartState::cannonPointId() const {
-    return m_cannonPointId;
-}
-
-s32 KartState::boostRampType() const {
-    return m_boostRampType;
-}
-
-s32 KartState::jumpPadVariant() const {
-    return m_jumpPadVariant;
-}
-
-f32 KartState::stickX() const {
-    return m_stickX;
-}
-
-f32 KartState::stickY() const {
-    return m_stickY;
-}
-
-u32 KartState::airtime() const {
-    return m_airtime;
-}
-
-const EGG::Vector3f &KartState::top() const {
-    return m_top;
-}
-
-const EGG::Vector3f &KartState::softWallSpeed() const {
-    return m_softWallSpeed;
-}
-
-f32 KartState::startBoostCharge() const {
-    return m_startBoostCharge;
-}
-
-s16 KartState::wallBonkTimer() const {
-    return m_wallBonkTimer;
-}
-
-s16 KartState::trickableTimer() const {
-    return m_trickableTimer;
 }
 
 /// @brief Helper function to clear all bit flags at 0x4-0x7 in KartState.

--- a/source/game/kart/KartState.hh
+++ b/source/game/kart/KartState.hh
@@ -18,16 +18,8 @@ public:
 
     void calcInput();
     void calc();
-    void calcCollisions();
-    void calcStartBoost();
-    void calcHandleStartBoost();
-    void handleStartBoost(size_t idx);
 
     /// @beginSetters
-    void clearBitfield0();
-    void clearBitfield1();
-    void clearBitfield3();
-
     void setAccelerate(bool isSet);
     void setDriftInput(bool isSet);
     void setDriftManual(bool isSet);
@@ -128,6 +120,14 @@ public:
     /// @endGetters
 
 private:
+    void calcCollisions();
+    void calcStartBoost();
+    void calcHandleStartBoost();
+    void handleStartBoost(size_t idx);
+    void clearBitfield0();
+    void clearBitfield1();
+    void clearBitfield3();
+
     // Bits from the base game's bitfields are marked with prefix 'b'
 
     /// @name bitfield0

--- a/source/game/kart/KartSub.cc
+++ b/source/game/kart/KartSub.cc
@@ -54,25 +54,6 @@ void KartSub::initPhysicsValues() {
     collide()->resetHitboxes();
 }
 
-/// @addr{0x8059617C}
-void KartSub::resetPhysics() {
-    physics()->reset();
-    physics()->updatePose();
-    collide()->resetHitboxes();
-
-    for (u16 wheelIdx = 0; wheelIdx < suspCount(); ++wheelIdx) {
-        suspensionPhysics(wheelIdx)->reset();
-    }
-    for (u16 tireIdx = 0; tireIdx < tireCount(); ++tireIdx) {
-        tirePhysics(tireIdx)->reset();
-    }
-    m_move->setKartSpeedLimit();
-    m_sideCollisionTimer = 0;
-    m_someScale = 1.0f;
-    m_maxSuspOvertravel.setZero();
-    m_minSuspOvertravel.setZero();
-}
-
 /// @stage All
 /// @brief The first phase of physics computations on each frame.
 /// @addr{0x80596480}
@@ -277,15 +258,38 @@ void KartSub::calcPass1() {
     // calcRotation() is only ever used for gfx rendering, so skip
 }
 
-/// @addr{0x805980D8}
-void KartSub::addFloor(const CollisionData &, bool) {
-    ++m_floorCollisionCount;
-}
-
 /// @addr{0x805979EC}
 void KartSub::updateSuspOvertravel(const EGG::Vector3f &suspOvertravel) {
     m_maxSuspOvertravel = m_maxSuspOvertravel.minimize(suspOvertravel);
     m_minSuspOvertravel = m_minSuspOvertravel.maximize(suspOvertravel);
+}
+
+f32 KartSub::someScale() {
+    return m_someScale;
+}
+
+/// @addr{0x8059617C}
+void KartSub::resetPhysics() {
+    physics()->reset();
+    physics()->updatePose();
+    collide()->resetHitboxes();
+
+    for (u16 wheelIdx = 0; wheelIdx < suspCount(); ++wheelIdx) {
+        suspensionPhysics(wheelIdx)->reset();
+    }
+    for (u16 tireIdx = 0; tireIdx < tireCount(); ++tireIdx) {
+        tirePhysics(tireIdx)->reset();
+    }
+    m_move->setKartSpeedLimit();
+    m_sideCollisionTimer = 0;
+    m_someScale = 1.0f;
+    m_maxSuspOvertravel.setZero();
+    m_minSuspOvertravel.setZero();
+}
+
+/// @addr{0x805980D8}
+void KartSub::addFloor(const CollisionData &, bool) {
+    ++m_floorCollisionCount;
 }
 
 /// @addr{0x80598744}
@@ -308,10 +312,6 @@ void KartSub::tryEndHWG() {
     }
 
     dynamics()->setForceUpright(!state()->isSoftWallDrift());
-}
-
-f32 KartSub::someScale() {
-    return m_someScale;
 }
 
 } // namespace Kart

--- a/source/game/kart/KartSub.hh
+++ b/source/game/kart/KartSub.hh
@@ -16,19 +16,20 @@ public:
 
     void init();
     void initPhysicsValues();
-    void resetPhysics();
 
     void calcPass0();
     void calcPass1();
-    void addFloor(const CollisionData &, bool);
     void updateSuspOvertravel(const EGG::Vector3f &suspOvertravel);
-    void tryEndHWG();
 
     /// @beginGetters
     [[nodiscard]] f32 someScale();
     /// @endGetters
 
 private:
+    void resetPhysics();
+    void addFloor(const CollisionData &, bool);
+    void tryEndHWG();
+
     KartMove *m_move;
     KartCollide *m_collide;
     KartState *m_state;

--- a/source/game/kart/KartTire.cc
+++ b/source/game/kart/KartTire.cc
@@ -11,11 +11,6 @@ KartTire::~KartTire() {
     delete m_wheelPhysics;
 }
 
-/// @addr{0x8059AB14}
-void KartTire::createPhysics(u16 tireIdx) {
-    m_wheelPhysics = new WheelPhysics(tireIdx, 1);
-}
-
 /// @addr{0x8059AAB0}
 void KartTire::init(u16 tireIdx) {
     createPhysics(tireIdx);
@@ -29,6 +24,11 @@ void KartTire::initBsp() {
 
 WheelPhysics *KartTire::wheelPhysics() {
     return m_wheelPhysics;
+}
+
+/// @addr{0x8059AB14}
+void KartTire::createPhysics(u16 tireIdx) {
+    m_wheelPhysics = new WheelPhysics(tireIdx, 1);
 }
 
 /// @addr{Inlined in 0x8058EA0C}

--- a/source/game/kart/KartTire.hh
+++ b/source/game/kart/KartTire.hh
@@ -11,8 +11,6 @@ public:
     KartTire(KartSuspensionPhysics::TireType tireType, u16 bspWheelIdx);
     virtual ~KartTire();
 
-    virtual void createPhysics(u16 tireIdx);
-
     void init(u16 tireIdx);
     void initBsp();
 
@@ -21,6 +19,8 @@ public:
     /// @endGetters
 
 protected:
+    virtual void createPhysics(u16 tireIdx);
+
     KartSuspensionPhysics::TireType m_tireType;
     u16 m_bspWheelIdx;
     WheelPhysics *m_wheelPhysics;
@@ -32,6 +32,7 @@ public:
     KartTireFront(KartSuspensionPhysics::TireType tireType, u16 bspWheelIdx);
     ~KartTireFront();
 
+private:
     void createPhysics(u16 tireIdx) override;
 };
 
@@ -41,6 +42,7 @@ public:
     KartTireFrontBike(KartSuspensionPhysics::TireType tireType, u16 bspWheelIdx);
     ~KartTireFrontBike();
 
+private:
     void createPhysics(u16 tireIdx) override;
 };
 
@@ -50,6 +52,7 @@ public:
     KartTireRearBike(KartSuspensionPhysics::TireType tireType, u16 bspWheelIdx);
     ~KartTireRearBike();
 
+private:
     void createPhysics(u16 tireIdx) override;
 };
 


### PR DESCRIPTION
Fixes #103

- Got rid of `KartMove::clearJumpPad` as this was a duplicate of `cancelJumpPad`
- Got rid of `BSP::read` since all the ctor does is call that function