### PR TITLE
Add support for host controllers

### DIFF
--- a/source/game/system/KPadDirector.cc
+++ b/source/game/system/KPadDirector.cc
@@ -11,6 +11,7 @@ void KPadDirector::calc() {
 /// @addr{0x805237E8}
 void KPadDirector::calcPads() {
     m_ghostController->calc();
+    m_hostController->calc();
 }
 
 /// @addr{0x80523724}
@@ -40,6 +41,10 @@ void KPadDirector::setGhostPad(const u8 *inputs, bool driftIsAuto) {
     m_playerInput.setGhostController(m_ghostController, inputs, driftIsAuto);
 }
 
+void KPadDirector::setHostPad(bool driftIsAuto) {
+    m_playerInput.setHostController(m_hostController, driftIsAuto);
+}
+
 /// @addr{0x8052313C}
 KPadDirector *KPadDirector::CreateInstance() {
     ASSERT(!s_instance);
@@ -61,6 +66,7 @@ KPadDirector *KPadDirector::Instance() {
 /// @addr{0x805232F0}
 KPadDirector::KPadDirector() {
     m_ghostController = new KPadGhostController;
+    m_hostController = new KPadHostController;
 }
 
 /// @addr{0x805231DC}

--- a/source/game/system/KPadDirector.hh
+++ b/source/game/system/KPadDirector.hh
@@ -18,6 +18,7 @@ public:
     [[nodiscard]] const KPadPlayer &playerInput() const;
 
     void setGhostPad(const u8 *inputs, bool driftIsAuto);
+    void setHostPad(bool driftIsAuto);
 
     static KPadDirector *CreateInstance();
     static void DestroyInstance();
@@ -29,6 +30,7 @@ private:
 
     KPadPlayer m_playerInput;
     KPadGhostController *m_ghostController;
+    KPadHostController *m_hostController;
 
     static KPadDirector *s_instance; ///< @addr{0x809BD70C}
 };

--- a/source/game/system/RaceConfig.hh
+++ b/source/game/system/RaceConfig.hh
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <Common.hh>
-
 #include "game/system/GhostFile.hh"
+
+#include <functional>
 
 namespace System {
 
@@ -25,6 +25,7 @@ public:
         Character character;
         Vehicle vehicle;
         Type type;
+        bool driftIsAuto;
     };
 
     struct Scenario {
@@ -41,13 +42,26 @@ public:
         Course course;
     };
 
+    typedef std::function<void(RaceConfig *, void *)> InitCallback;
+
     void init();
     void initRace();
-    void initControllers(const GhostFile &ghost);
+    void initControllers();
+    void initGhost();
 
     [[nodiscard]] const Scenario &raceScenario() const {
         return m_raceScenario;
     }
+
+    [[nodiscard]] Scenario &raceScenario() {
+        return m_raceScenario;
+    }
+
+    void setGhost(const u8 *rkg) {
+        m_ghost = rkg;
+    }
+
+    static void RegisterInitCallback(const InitCallback &callback, void *arg);
 
     static RaceConfig *CreateInstance();
     static void DestroyInstance();
@@ -61,6 +75,8 @@ private:
     RawGhostFile m_ghost;
 
     static RaceConfig *s_instance; ///< @addr{0x809BD728}
+    static InitCallback s_onInitCallback;
+    static void *s_onInitCallbackArg;
 };
 
 } // namespace System

--- a/source/host/System.cc
+++ b/source/host/System.cc
@@ -105,6 +105,9 @@ void KSystem::init() {
     m_sceneMgr = new EGG::SceneManager(sceneCreator);
     m_testDirector = new Test::TestDirector(m_suiteData);
     delete[] m_suiteData.data();
+
+    // Register the RaceConfig callback
+    System::RaceConfig::RegisterInitCallback(m_testDirector->OnInit, nullptr);
 }
 
 /// @addr{0x80242504}

--- a/source/test/TestDirector.cc
+++ b/source/test/TestDirector.cc
@@ -3,8 +3,7 @@
 #include <game/kart/KartObjectManager.hh>
 
 #include <abstract/File.hh>
-
-#include <egg/util/Stream.hh>
+#include <host/System.hh>
 
 #include <format>
 
@@ -225,6 +224,16 @@ const TestCase &TestDirector::testCase() const {
 
 bool TestDirector::sync() const {
     return m_sync;
+}
+
+void TestDirector::OnInit(System::RaceConfig *config, void * /* arg */) {
+    size_t size;
+    const auto *testDirector = Host::KSystem::Instance().testDirector();
+    u8 *rkg = Abstract::File::Load(testDirector->testCase().rkgPath.data(), size);
+    config->setGhost(rkg);
+    delete[] rkg;
+
+    config->raceScenario().players[0].type = System::RaceConfig::Player::Type::Ghost;
 }
 
 void TestDirector::readHeader() {

--- a/source/test/TestDirector.hh
+++ b/source/test/TestDirector.hh
@@ -2,7 +2,7 @@
 
 #include "test/Test.hh"
 
-#include <egg/util/Stream.hh>
+#include <game/system/RaceConfig.hh>
 
 #include <queue>
 #include <span>
@@ -41,6 +41,8 @@ public:
     [[nodiscard]] const TestCase &testCase() const;
 
     [[nodiscard]] bool sync() const;
+
+    static void OnInit(System::RaceConfig *config, void *arg);
 
 private:
     void readHeader();


### PR DESCRIPTION
This removes a dependency on the host system from RaceConfig, allowing external applications to interface with Kinoko in a much simpler way.

Closes #157.