### PR TITLE
Add Checkpoints

### DIFF
--- a/source/egg/math/Vector.cc
+++ b/source/egg/math/Vector.cc
@@ -36,6 +36,12 @@ f32 Vector2f::normalise() {
     return len;
 }
 
+/// @brief Initializes a Vector2f by reading 8 bytes from the stream.
+void Vector2f::read(Stream &stream) {
+    x = stream.read_f32();
+    y = stream.read_f32();
+}
+
 /// @brief The dot product between the vector and itself.
 f32 Vector3f::dot() const {
     return x * x + y * y + z * z;
@@ -162,7 +168,7 @@ Vector3f Vector3f::perpInPlane(const EGG::Vector3f &rhs, bool normalise) const {
     return ret;
 }
 
-/// @brief Constructs a Vector3f by reading 12 bytes from the stream.
+/// @brief Initializes a Vector3f by reading 12 bytes from the stream.
 void Vector3f::read(Stream &stream) {
     x = stream.read_f32();
     y = stream.read_f32();

--- a/source/egg/math/Vector.hh
+++ b/source/egg/math/Vector.hh
@@ -32,11 +32,17 @@ struct Vector2f {
         return Vector2f(x * scalar, y * scalar);
     }
 
+    friend Vector2f operator*(f32 scalar, const Vector2f &rhs) {
+        return Vector2f(scalar * rhs.x, scalar * rhs.y);
+    }
+
     [[nodiscard]] f32 cross(const Vector2f &rhs) const;
     [[nodiscard]] f32 dot(const Vector2f &rhs) const;
     [[nodiscard]] f32 dot() const;
     [[nodiscard]] f32 length() const;
-    [[nodiscard]] f32 normalise();
+    f32 normalise();
+
+    void read(Stream &stream);
 
     f32 x;
     f32 y;

--- a/source/game/system/CourseMap.cc
+++ b/source/game/system/CourseMap.cc
@@ -1,6 +1,8 @@
 #include "CourseMap.hh"
 
 #include "game/system/map/MapdataCannonPoint.hh"
+#include "game/system/map/MapdataCheckPath.hh"
+#include "game/system/map/MapdataCheckPoint.hh"
 #include "game/system/map/MapdataFileAccessor.hh"
 #include "game/system/map/MapdataGeoObj.hh"
 #include "game/system/map/MapdataStageInfo.hh"
@@ -17,11 +19,15 @@ void CourseMap::init() {
             new MapdataFileAccessor(reinterpret_cast<const MapdataFileAccessor::SData *>(buffer));
 
     constexpr u32 CANNON_POINT_SIGNATURE = 0x434e5054;
+    constexpr u32 CHECK_PATH_SIGNATURE = 0x434b5048;
+    constexpr u32 CHECK_POINT_SIGNATURE = 0x434b5054;
     constexpr u32 GEO_OBJ_SIGNATURE = 0x474f424a;
     constexpr u32 START_POINT_SIGNATURE = 0x4b545054;
     constexpr u32 STAGE_INFO_SIGNATURE = 0x53544749;
 
     m_startPoint = parseStartPoint(START_POINT_SIGNATURE);
+    m_checkPath = parseCheckPath(CHECK_PATH_SIGNATURE);
+    m_checkPoint = parseCheckPoint(CHECK_POINT_SIGNATURE);
     m_geoObj = parseGeoObj(GEO_OBJ_SIGNATURE);
     m_cannonPoint = parseCannonPoint(CANNON_POINT_SIGNATURE);
     m_stageInfo = parseStageInfo(STAGE_INFO_SIGNATURE);
@@ -43,7 +49,7 @@ void CourseMap::init() {
 }
 
 /// @addr{0x80512FA4}
-MapdataCannonPointAccessor *CourseMap::parseCannonPoint(u32 sectionName) {
+MapdataCannonPointAccessor *CourseMap::parseCannonPoint(u32 sectionName) const {
     const MapSectionHeader *sectionPtr = m_course->findSection(sectionName);
 
     MapdataCannonPointAccessor *accessor = nullptr;
@@ -54,8 +60,32 @@ MapdataCannonPointAccessor *CourseMap::parseCannonPoint(u32 sectionName) {
     return accessor;
 }
 
+/// @addr{0x8051377C}
+MapdataCheckPathAccessor *CourseMap::parseCheckPath(u32 sectionName) const {
+    const MapSectionHeader *sectionPtr = m_course->findSection(sectionName);
+
+    MapdataCheckPathAccessor *accessor = nullptr;
+    if (sectionPtr) {
+        accessor = new MapdataCheckPathAccessor(sectionPtr);
+    }
+
+    return accessor;
+}
+
+/// @addr{0x80513640}
+MapdataCheckPointAccessor *CourseMap::parseCheckPoint(u32 sectionName) const {
+    const MapSectionHeader *sectionPtr = m_course->findSection(sectionName);
+
+    MapdataCheckPointAccessor *accessor = nullptr;
+    if (sectionPtr) {
+        accessor = new MapdataCheckPointAccessor(sectionPtr);
+    }
+
+    return accessor;
+}
+
 /// @addr{0x805134C8}
-MapdataGeoObjAccessor *CourseMap::parseGeoObj(u32 sectionName) {
+MapdataGeoObjAccessor *CourseMap::parseGeoObj(u32 sectionName) const {
     const MapSectionHeader *sectionPtr = m_course->findSection(sectionName);
 
     MapdataGeoObjAccessor *accessor = nullptr;
@@ -67,7 +97,7 @@ MapdataGeoObjAccessor *CourseMap::parseGeoObj(u32 sectionName) {
 }
 
 /// @addr{0x80512D64}
-MapdataStageInfoAccessor *CourseMap::parseStageInfo(u32 sectionName) {
+MapdataStageInfoAccessor *CourseMap::parseStageInfo(u32 sectionName) const {
     const MapSectionHeader *sectionPtr = m_course->findSection(sectionName);
 
     MapdataStageInfoAccessor *accessor = nullptr;
@@ -79,7 +109,7 @@ MapdataStageInfoAccessor *CourseMap::parseStageInfo(u32 sectionName) {
 }
 
 /// @addr{0x80513F5C}
-MapdataStartPointAccessor *CourseMap::parseStartPoint(u32 sectionName) {
+MapdataStartPointAccessor *CourseMap::parseStartPoint(u32 sectionName) const {
     const MapSectionHeader *sectionPtr = m_course->findSection(sectionName);
 
     MapdataStartPointAccessor *accessor = nullptr;
@@ -90,9 +120,19 @@ MapdataStartPointAccessor *CourseMap::parseStartPoint(u32 sectionName) {
     return accessor;
 }
 
-/// @addr{0x80518AF8}
+/// @addr{0x80518AE0}
 MapdataCannonPoint *CourseMap::getCannonPoint(u16 i) const {
     return m_cannonPoint && m_cannonPoint->size() != 0 ? m_cannonPoint->get(i) : nullptr;
+}
+
+/// @addr{0x80515C70}
+MapdataCheckPath *CourseMap::getCheckPath(u16 i) const {
+    return m_checkPath && m_checkPath->size() != 0 ? m_checkPath->get(i) : nullptr;
+}
+
+/// @addr{0x80515C24}
+MapdataCheckPoint *CourseMap::getCheckPoint(u16 i) const {
+    return m_checkPoint && m_checkPoint->size() != 0 ? m_checkPoint->get(i) : nullptr;
 }
 
 /// @addr{0x80514148}

--- a/source/game/system/CourseMap.hh
+++ b/source/game/system/CourseMap.hh
@@ -8,6 +8,10 @@ namespace System {
 
 class MapdataCannonPoint;
 class MapdataCannonPointAccessor;
+class MapdataCheckPath;
+class MapdataCheckPathAccessor;
+class MapdataCheckPoint;
+class MapdataCheckPointAccessor;
 class MapdataFileAccessor;
 class MapdataGeoObj;
 class MapdataGeoObjAccessor;
@@ -22,13 +26,17 @@ class MapdataStartPointAccessor;
 class CourseMap : EGG::Disposer {
 public:
     void init();
-    [[nodiscard]] MapdataCannonPointAccessor *parseCannonPoint(u32 sectionName);
-    [[nodiscard]] MapdataGeoObjAccessor *parseGeoObj(u32 sectionName);
-    [[nodiscard]] MapdataStageInfoAccessor *parseStageInfo(u32 sectionName);
-    [[nodiscard]] MapdataStartPointAccessor *parseStartPoint(u32 sectionName);
+    [[nodiscard]] MapdataCannonPointAccessor *parseCannonPoint(u32 sectionName) const;
+    [[nodiscard]] MapdataCheckPathAccessor *parseCheckPath(u32 sectionName) const;
+    [[nodiscard]] MapdataCheckPointAccessor *parseCheckPoint(u32 sectionName) const;
+    [[nodiscard]] MapdataGeoObjAccessor *parseGeoObj(u32 sectionName) const;
+    [[nodiscard]] MapdataStageInfoAccessor *parseStageInfo(u32 sectionName) const;
+    [[nodiscard]] MapdataStartPointAccessor *parseStartPoint(u32 sectionName) const;
 
     /// @beginGetters
     [[nodiscard]] MapdataCannonPoint *getCannonPoint(u16 i) const;
+    [[nodiscard]] MapdataCheckPath *getCheckPath(u16 i) const;
+    [[nodiscard]] MapdataCheckPoint *getCheckPoint(u16 i) const;
     [[nodiscard]] MapdataGeoObj *getGeoObj(u16 i) const;
     [[nodiscard]] MapdataStageInfo *getStageInfo() const;
     [[nodiscard]] MapdataStartPoint *getStartPoint(u16 i) const;
@@ -51,6 +59,8 @@ private:
 
     MapdataFileAccessor *m_course;
     MapdataStartPointAccessor *m_startPoint;
+    MapdataCheckPathAccessor *m_checkPath;
+    MapdataCheckPointAccessor *m_checkPoint;
     MapdataGeoObjAccessor *m_geoObj;
     MapdataCannonPointAccessor *m_cannonPoint;
     MapdataStageInfoAccessor *m_stageInfo;

--- a/source/game/system/map/MapdataCheckPath.cc
+++ b/source/game/system/map/MapdataCheckPath.cc
@@ -1,0 +1,32 @@
+#include "game/system/map/MapdataCheckPath.hh"
+
+namespace System {
+
+MapdataCheckPath::MapdataCheckPath(const SData *data) : m_rawData(data), m_depth(-1) {
+    u8 *unsafeData = reinterpret_cast<u8 *>(const_cast<SData *>(data));
+    EGG::RamStream stream = EGG::RamStream(unsafeData, sizeof(SData));
+    read(stream);
+    m_oneOverCount = 1.0f / m_size;
+}
+
+void MapdataCheckPath::read(EGG::Stream &stream) {
+    m_start = stream.read_u8();
+    m_size = stream.read_u8();
+    for (auto &prev : m_prev) {
+        prev = stream.read_u8();
+    }
+
+    for (auto &next : m_next) {
+        next = stream.read_u8();
+    }
+}
+
+MapdataCheckPathAccessor::MapdataCheckPathAccessor(const MapSectionHeader *header)
+    : MapdataAccessorBase<MapdataCheckPath, MapdataCheckPath::SData>(header) {
+    init(reinterpret_cast<const MapdataCheckPath::SData *>(m_sectionHeader + 1),
+            parse<u16>(m_sectionHeader->count));
+}
+
+MapdataCheckPathAccessor::~MapdataCheckPathAccessor() = default;
+
+} // namespace System

--- a/source/game/system/map/MapdataCheckPath.hh
+++ b/source/game/system/map/MapdataCheckPath.hh
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "game/system/map/MapdataAccessorBase.hh"
+
+#include <egg/math/Vector.hh>
+
+namespace System {
+
+class MapdataCheckPath {
+public:
+    struct SData {
+        u8 start;
+        u8 size;
+
+        u8 prev[6];
+        u8 next[6];
+        u8 _0e[0x10 - 0x0e];
+    };
+    STATIC_ASSERT(sizeof(SData) == 0x10);
+
+    MapdataCheckPath(const SData *data);
+    void read(EGG::Stream &stream);
+
+private:
+    const SData *m_rawData;
+    u8 m_start;               ///< Index of the first checkpoint in this checkpath
+    u8 m_size;                ///< Number of checkpoints in this checkpath
+    std::array<u8, 6> m_prev; ///< Indices of previous connected checkpaths
+    std::array<u8, 6> m_next; ///< Indices of next connected checkpaths
+    s8 m_depth; ///< Number of checkpaths away from first checkpath (i.e. distance from start)
+    f32 m_oneOverCount;
+};
+
+class MapdataCheckPathAccessor
+    : public MapdataAccessorBase<MapdataCheckPath, MapdataCheckPath::SData> {
+public:
+    MapdataCheckPathAccessor(const MapSectionHeader *header);
+    ~MapdataCheckPathAccessor() override;
+};
+
+} // namespace System

--- a/source/game/system/map/MapdataCheckPoint.cc
+++ b/source/game/system/map/MapdataCheckPoint.cc
@@ -1,0 +1,36 @@
+#include "MapdataCheckPoint.hh"
+
+#include "game/system/CourseMap.hh"
+
+namespace System {
+
+/// @addr{0x805154E4}
+MapdataCheckPoint::MapdataCheckPoint(const SData *data)
+    : m_rawData(data), m_nextCount(0), m_prevCount(0) {
+    u8 *unsafeData = reinterpret_cast<u8 *>(const_cast<SData *>(data));
+    EGG::RamStream stream = EGG::RamStream(unsafeData, sizeof(SData));
+    read(stream);
+    m_midpoint = 0.5f * (m_left + m_right);
+    m_dir = EGG::Vector2f(m_left.y - m_right.y, m_right.x - m_left.x);
+    m_dir.normalise();
+}
+
+void MapdataCheckPoint::read(EGG::Stream &stream) {
+    m_left.read(stream);
+    m_right.read(stream);
+    m_jugemIndex = stream.read_u8();
+    m_checkArea = stream.read_s8();
+    m_prevPt = stream.read_u8();
+    m_nextPt = stream.read_u8();
+}
+
+MapdataCheckPointAccessor::MapdataCheckPointAccessor(const MapSectionHeader *header)
+    : MapdataAccessorBase<MapdataCheckPoint, MapdataCheckPoint::SData>(header) {
+    MapdataAccessorBase::init(
+            reinterpret_cast<const MapdataCheckPoint::SData *>(m_sectionHeader + 1),
+            parse<u16>(m_sectionHeader->count));
+}
+
+MapdataCheckPointAccessor::~MapdataCheckPointAccessor() = default;
+
+} // namespace System

--- a/source/game/system/map/MapdataCheckPoint.hh
+++ b/source/game/system/map/MapdataCheckPoint.hh
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "game/system/map/MapdataAccessorBase.hh"
+
+#include <egg/math/Vector.hh>
+
+namespace System {
+
+class MapdataCheckPoint {
+public:
+    struct SData {
+        EGG::Vector2f left;
+        EGG::Vector2f right;
+        u8 jugemIndex;
+        s8 checkArea;
+        u8 prevPt;
+        u8 nextPt;
+    };
+    STATIC_ASSERT(sizeof(SData) == 0x14);
+
+    MapdataCheckPoint(const SData *data);
+    void read(EGG::Stream &stream);
+
+private:
+    const SData *m_rawData;
+    EGG::Vector2f m_left;
+    EGG::Vector2f m_right;
+    u8 m_jugemIndex; ///< Index of respawn point associated with this checkpoint. Players who die
+                     ///< here will be respawned at this point.
+    s8 m_checkArea;
+    u8 m_prevPt;
+    u8 m_nextPt;
+    u16 m_nextCount;
+    u16 m_prevCount;
+    EGG::Vector2f m_midpoint;
+    EGG::Vector2f m_dir;
+};
+
+class MapdataCheckPointAccessor
+    : public MapdataAccessorBase<MapdataCheckPoint, MapdataCheckPoint::SData> {
+public:
+    MapdataCheckPointAccessor(const MapSectionHeader *header);
+    ~MapdataCheckPointAccessor() override;
+};
+
+} // namespace System


### PR DESCRIPTION
Adds `MapdataCheckPoint` and `MapdataCheckPath`, but not the rest of the checkpoint infrastructure like all the sector functions.

This is the first PR towards syncing respawn positions, verifying lap completion, and calculating lap times and finish times.

Makes progress towards #20.