### PR TITLE
Sync ObjectDokan collision (pipes)

### DIFF
--- a/source/egg/math/Matrix.cc
+++ b/source/egg/math/Matrix.cc
@@ -142,6 +142,14 @@ void Matrix34f::makeR(const Vector3f &r) {
     mtx[2][3] = 0.0f;
 }
 
+/// @addr{0x80230280}
+void Matrix34f::makeS(const Vector3f &s) {
+    makeZero();
+    mtx[0][0] = s.x;
+    mtx[1][1] = s.y;
+    mtx[2][2] = s.z;
+}
+
 /// @brief Zeroes every element of the matrix.
 void Matrix34f::makeZero() {
     *this = Matrix34f::zero;

--- a/source/egg/math/Matrix.hh
+++ b/source/egg/math/Matrix.hh
@@ -30,6 +30,7 @@ public:
     void makeQ(const Quatf &q);
     void makeRT(const Vector3f &r, const Vector3f &t);
     void makeR(const Vector3f &r);
+    void makeS(const Vector3f &s);
     void makeZero();
     void makeOrthonormalBasis(const Vector3f &v0, const Vector3f &v1);
     void setAxisRotation(f32 angle, const Vector3f &axis);

--- a/source/egg/util/Stream.cc
+++ b/source/egg/util/Stream.cc
@@ -107,6 +107,10 @@ u8 *RamStream::data() {
     return m_buffer;
 }
 
+u8 *RamStream::dataAtIndex() {
+    return m_buffer + m_index;
+}
+
 /// @brief Splits the current stream into two.
 /// @details Segments the current stream at the current index. The returned stream is the data from
 /// the current index to size bytes after. The current stream is then moved to `size` bytes after

--- a/source/egg/util/Stream.hh
+++ b/source/egg/util/Stream.hh
@@ -69,6 +69,7 @@ public:
     [[nodiscard]] RamStream split(u32 size);
     void setBufferAndSize(void *buffer, u32 size);
     [[nodiscard]] u8 *data();
+    [[nodiscard]] u8 *dataAtIndex();
 
 private:
     u8 *m_buffer;

--- a/source/game/field/BoxColManager.cc
+++ b/source/game/field/BoxColManager.cc
@@ -1,5 +1,7 @@
 #include "BoxColManager.hh"
 
+#include "game/field/obj/ObjectCollidable.hh"
+
 #include <numeric>
 
 namespace Field {
@@ -17,6 +19,7 @@ void BoxColUnit::init(f32 radius, f32 maxSpeed, const EGG::Vector3f *pos, const 
     m_radius = radius;
     m_range = radius + maxSpeed;
     m_flag = flag;
+    m_flag.setBit(eBoxColFlag::Active);
     m_userData = userData;
     m_xMax = pos->x + m_range;
     m_xMin = pos->x - m_range;
@@ -176,8 +179,8 @@ void BoxColManager::calc() {
 }
 
 /// @addr{0x80785E5C}
-void *BoxColManager::getNextObject() {
-    return getNextImpl(m_nextObjectID, eBoxColFlag::Object);
+ObjectCollidable *BoxColManager::getNextObject() {
+    return reinterpret_cast<ObjectCollidable *>(getNextImpl(m_nextObjectID, eBoxColFlag::Object));
 }
 
 /// @addr{0x80785EC4}
@@ -273,7 +276,7 @@ BoxColManager *BoxColManager::Instance() {
 }
 
 /// @brief Helper function since the getters share all code except the flag.
-void *BoxColManager::getNextImpl(s32 id, const BoxColFlag &flag) {
+void *BoxColManager::getNextImpl(s32 &id, const BoxColFlag &flag) {
     if (id == MAX_UNIT_COUNT) {
         return nullptr;
     }
@@ -287,7 +290,7 @@ void *BoxColManager::getNextImpl(s32 id, const BoxColFlag &flag) {
 /// @addr{Inlined}
 void BoxColManager::iterate(s32 &iter, const BoxColFlag &flag) {
     while (++iter < m_maxID) {
-        if (m_units[iter]->m_flag == flag) {
+        if (m_units[iter]->m_flag.on(flag)) {
             return;
         }
     }

--- a/source/game/field/BoxColManager.hh
+++ b/source/game/field/BoxColManager.hh
@@ -11,17 +11,19 @@ class KartObject;
 
 namespace Field {
 
+class ObjectCollidable;
+
 /// @brief A bitfield that represents the state and type of a given BoxColUnit.
 /// @details The lower 8 bits represent the type, while the remaining bits represent the state.
 /// There are originally two flags for objects, but one is for CPUs, which we can ignore for now.
 enum class eBoxColFlag {
     Driver = 0,
     Object = 3,
-    Drivable = 5,
-    PermRecalcAABB = 9, ///< Recalculate this unit's spatial indexing every frame.
-    Intangible = 10,    ///< Ignore collision with the unit.
-    Active = 11,
-    TempRecalcAABB = 12, ///< Only recalculate once.
+    Drivable = 4,
+    PermRecalcAABB = 8, ///< Recalculate this unit's spatial indexing every frame.
+    Intangible = 9,     ///< Ignore collision with the unit.
+    Active = 10,
+    TempRecalcAABB = 11, ///< Only recalculate once.
 };
 typedef EGG::TBitFlag<u32, eBoxColFlag> BoxColFlag;
 
@@ -69,7 +71,7 @@ public:
     void clear();
     void calc();
 
-    [[nodiscard]] void *getNextObject();
+    [[nodiscard]] ObjectCollidable *getNextObject();
     [[nodiscard]] void *getNextDrivable();
 
     void resetIterators();
@@ -90,7 +92,7 @@ public:
     [[nodiscard]] static BoxColManager *Instance();
 
 private:
-    [[nodiscard]] void *getNextImpl(s32 id, const BoxColFlag &flag);
+    [[nodiscard]] void *getNextImpl(s32 &id, const BoxColFlag &flag);
     void iterate(s32 &iter, const BoxColFlag &flag);
     [[nodiscard]] BoxColUnit *insert(f32 radius, f32 maxSpeed, const EGG::Vector3f *pos,
             const BoxColFlag &flag, void *userData);

--- a/source/game/field/ObjectCollisionBase.cc
+++ b/source/game/field/ObjectCollisionBase.cc
@@ -48,8 +48,8 @@ bool ObjectCollisionBase::check(ObjectCollisionBase &rhs, EGG::Vector3f &distanc
         if (inSimplex(state, A) || (max2 - dot) < max2 * 0.000001) {
             getNearestPoint(state, state.m_flags, v0, v1);
 
-            v0 -= D * getBoundingRadius() / max;
-            v1 += D * rhs.getBoundingRadius() / max;
+            v0 -= D * (getBoundingRadius() / max);
+            v1 += D * (rhs.getBoundingRadius() / max);
 
             distance = v1 - v0;
 
@@ -65,8 +65,8 @@ bool ObjectCollisionBase::check(ObjectCollisionBase &rhs, EGG::Vector3f &distanc
         if (!getNearestSimplex(state, D)) {
             getNearestPoint(state, state.m_flags, v0, v1);
 
-            v0 -= D * getBoundingRadius() / max;
-            v1 += D * rhs.getBoundingRadius() / max;
+            v0 -= D * (getBoundingRadius() / max);
+            v1 += D * (rhs.getBoundingRadius() / max);
 
             distance = v1 - v0;
 
@@ -82,8 +82,8 @@ bool ObjectCollisionBase::check(ObjectCollisionBase &rhs, EGG::Vector3f &distanc
             FUN_808350e4(state, D);
             getNearestPoint(state, state.m_flags, v0, v1);
             f32 len = EGG::Mathf::sqrt(D.dot());
-            v0 -= D * getBoundingRadius() / len;
-            v1 += D * rhs.getBoundingRadius() / len;
+            v0 -= D * (getBoundingRadius() / len);
+            v1 += D * (rhs.getBoundingRadius() / len);
 
             distance = v1 - v0;
 
@@ -173,8 +173,8 @@ void ObjectCollisionBase::getNearestPoint(GJKState &state, u32 idx, EGG::Vector3
         v1 += state.m_support2[i] * state.m_scales[idx][i];
     }
 
-    v0 /= sum;
-    v1 /= sum;
+    v0 *= 1.0f / sum;
+    v1 *= 1.0f / sum;
 }
 
 /// @addr{0x808357E4} @addr{0x808359A4}
@@ -222,7 +222,7 @@ void ObjectCollisionBase::getNearestPoint(const GJKState &state, u32 idx, EGG::V
         v += state.m_s[i] * state.m_scales[idx][i];
     }
 
-    v /= sum;
+    v *= 1.0f / sum;
 }
 
 /// @addr{0x80835A8C}

--- a/source/game/field/ObjectCollisionBase.hh
+++ b/source/game/field/ObjectCollisionBase.hh
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <egg/math/Vector.hh>
+#include <egg/math/Matrix.hh>
 
 namespace Field {
 
@@ -26,10 +26,15 @@ public:
     ObjectCollisionBase();
     virtual ~ObjectCollisionBase();
 
-    virtual f32 getBoundingRadius() const = 0;
+    virtual void transform(const EGG::Matrix34f &mat, const EGG::Vector3f &scale,
+            const EGG::Vector3f &speed) = 0;
     virtual const EGG::Vector3f &getSupport(const EGG::Vector3f &v) const = 0;
+    virtual f32 getBoundingRadius() const = 0;
 
     bool check(ObjectCollisionBase &rhs, EGG::Vector3f &distance);
+
+protected:
+    EGG::Vector3f m_translation;
 
 private:
     bool enclosesOrigin(const GJKState &state, u32 idx) const;

--- a/source/game/field/ObjectCollisionBox.cc
+++ b/source/game/field/ObjectCollisionBox.cc
@@ -12,4 +12,10 @@ ObjectCollisionBox::ObjectCollisionBox(f32 x, f32 y, f32 z, const EGG::Vector3f 
 /// @addr{0x808342F0}
 ObjectCollisionBox::~ObjectCollisionBox() = default;
 
+/// @addr{0x80833EEC}
+void ObjectCollisionBox::transform(const EGG::Matrix34f & /*mat*/, const EGG::Vector3f & /*scale*/,
+        const EGG::Vector3f & /*speed*/) {
+    ; // TODO
+}
+
 } // namespace Field

--- a/source/game/field/ObjectCollisionBox.hh
+++ b/source/game/field/ObjectCollisionBox.hh
@@ -10,6 +10,9 @@ public:
     ObjectCollisionBox(f32 x, f32 y, f32 z, const EGG::Vector3f &center);
     ~ObjectCollisionBox() override;
 
+    void transform(const EGG::Matrix34f &mat, const EGG::Vector3f &scale,
+            const EGG::Vector3f &speed) override;
+
 private:
     EGG::Vector3f m_dimensions;
     EGG::Vector3f m_center;

--- a/source/game/field/ObjectCollisionConvexHull.cc
+++ b/source/game/field/ObjectCollisionConvexHull.cc
@@ -22,9 +22,24 @@ ObjectCollisionConvexHull::~ObjectCollisionConvexHull() {
     delete[] m_worldPoints.data();
 }
 
-/// @addr{0x807F957C}
-f32 ObjectCollisionConvexHull::getBoundingRadius() const {
-    return m_worldRadius;
+/// @addr{0x808367C4}
+void ObjectCollisionConvexHull::transform(const EGG::Matrix34f &mat, const EGG::Vector3f &scale,
+        const EGG::Vector3f &speed) {
+    m_translation = speed;
+
+    if (scale.x == 0.0f) {
+        for (size_t i = 0; i < m_points.size(); ++i) {
+            m_worldPoints[i] = mat.multVector(m_points[i]);
+        }
+    } else {
+        EGG::Matrix34f temp;
+        temp.makeS(scale);
+        temp = mat.multiplyTo(temp);
+
+        for (size_t i = 0; i < m_points.size(); ++i) {
+            m_worldPoints[i] = temp.multVector(m_points[i]);
+        }
+    }
 }
 
 /// @addr{0x80836628}
@@ -43,6 +58,16 @@ const EGG::Vector3f &ObjectCollisionConvexHull::getSupport(const EGG::Vector3f &
     }
 
     return *result;
+}
+
+/// @addr{0x807F957C}
+f32 ObjectCollisionConvexHull::getBoundingRadius() const {
+    return m_worldRadius;
+}
+
+/// @addr{0x8080C414}
+void ObjectCollisionConvexHull::setBoundingRadius(f32 val) {
+    m_worldRadius = val;
 }
 
 /// @addr{0x808364E0}

--- a/source/game/field/ObjectCollisionConvexHull.hh
+++ b/source/game/field/ObjectCollisionConvexHull.hh
@@ -10,8 +10,12 @@ public:
     ObjectCollisionConvexHull(const std::span<const EGG::Vector3f> &points);
     ~ObjectCollisionConvexHull() override;
 
-    f32 getBoundingRadius() const override;
+    void transform(const EGG::Matrix34f &mat, const EGG::Vector3f &scale,
+            const EGG::Vector3f &speed) override;
     const EGG::Vector3f &getSupport(const EGG::Vector3f &v) const override;
+    f32 getBoundingRadius() const override;
+
+    virtual void setBoundingRadius(f32 val);
 
 protected:
     ObjectCollisionConvexHull(size_t count);

--- a/source/game/field/ObjectCollisionCylinder.cc
+++ b/source/game/field/ObjectCollisionCylinder.cc
@@ -18,14 +18,27 @@ ObjectCollisionCylinder::ObjectCollisionCylinder(f32 radius, f32 height,
 /// @addr{0x808364A0}
 ObjectCollisionCylinder::~ObjectCollisionCylinder() = default;
 
-/// @addr{0x80836498}
-f32 ObjectCollisionCylinder::getBoundingRadius() const {
-    return m_worldRadius;
+/// @addr{0x80836334}
+void ObjectCollisionCylinder::transform(const EGG::Matrix34f &mat, const EGG::Vector3f &scale,
+        const EGG::Vector3f &speed) {
+    m_translation = speed;
+    m_worldPos = scale * m_pos;
+    m_worldHeight = m_height * scale.y;
+    m_worldRadius = m_radius * scale.x;
+
+    m_center = mat.multVector(m_worldPos);
+    m_top = mat.multVector(m_worldPos + EGG::Vector3f::ey * m_worldHeight);
+    m_bottom = mat.multVector(m_worldPos - EGG::Vector3f::ey * m_worldHeight);
 }
 
 /// @addr{0x8083618C}
 const EGG::Vector3f &ObjectCollisionCylinder::getSupport(const EGG::Vector3f &v) const {
     return m_top.dot(v) > m_bottom.dot(v) ? m_top : m_bottom;
+}
+
+/// @addr{0x80836498}
+f32 ObjectCollisionCylinder::getBoundingRadius() const {
+    return m_worldRadius;
 }
 
 } // namespace Field

--- a/source/game/field/ObjectCollisionCylinder.hh
+++ b/source/game/field/ObjectCollisionCylinder.hh
@@ -9,8 +9,10 @@ public:
     ObjectCollisionCylinder(f32 radius, f32 height, const EGG::Vector3f &center);
     ~ObjectCollisionCylinder() override;
 
-    f32 getBoundingRadius() const override;
+    void transform(const EGG::Matrix34f &mat, const EGG::Vector3f &scale,
+            const EGG::Vector3f &speed) override;
     const EGG::Vector3f &getSupport(const EGG::Vector3f &v) const override;
+    f32 getBoundingRadius() const override;
 
 private:
     f32 m_radius;

--- a/source/game/field/ObjectCollisionKart.hh
+++ b/source/game/field/ObjectCollisionKart.hh
@@ -18,10 +18,13 @@ public:
 
     void init(u32 idx);
 
+    size_t checkCollision(const EGG::Matrix34f &mat, const EGG::Vector3f &v);
+
+    static EGG::Vector3f GetHitDirection(u16 objKartHit);
     static constexpr std::span<const EGG::Vector3f> GetVehicleVertices(Vehicle vehicle);
 
 private:
-    ObjectCollisionConvexHull *m_convexHull;
+    ObjectCollisionConvexHull *m_hull;
     Kart::KartObject *m_kartObject;
     u32 m_playerIdx;
 };

--- a/source/game/field/ObjectCollisionSphere.cc
+++ b/source/game/field/ObjectCollisionSphere.cc
@@ -14,9 +14,10 @@ ObjectCollisionSphere::ObjectCollisionSphere(f32 radius, const EGG::Vector3f &ce
 /// @addr{0x80836B5C}
 ObjectCollisionSphere::~ObjectCollisionSphere() = default;
 
-/// @addr{0x80836B54}
-f32 ObjectCollisionSphere::getBoundingRadius() const {
-    return m_worldRadius;
+/// @addr{0x80836A50}
+void ObjectCollisionSphere::transform(const EGG::Matrix34f & /*mat*/,
+        const EGG::Vector3f & /*scale*/, const EGG::Vector3f & /*speed*/) {
+    ; // TODO
 }
 
 /// @addr{0x80836920}
@@ -25,6 +26,11 @@ const EGG::Vector3f &ObjectCollisionSphere::getSupport(const EGG::Vector3f &v) c
     //      return m_worldPos;
 
     return m_worldPos.dot(v) > m_center.dot(v) ? m_worldPos : m_center;
+}
+
+/// @addr{0x80836B54}
+f32 ObjectCollisionSphere::getBoundingRadius() const {
+    return m_worldRadius;
 }
 
 } // namespace Field

--- a/source/game/field/ObjectCollisionSphere.hh
+++ b/source/game/field/ObjectCollisionSphere.hh
@@ -9,8 +9,10 @@ public:
     ObjectCollisionSphere(f32 radius, const EGG::Vector3f &center);
     ~ObjectCollisionSphere() override;
 
-    f32 getBoundingRadius() const override;
+    void transform(const EGG::Matrix34f &mat, const EGG::Vector3f &scale,
+            const EGG::Vector3f &speed) override;
     const EGG::Vector3f &getSupport(const EGG::Vector3f &v) const override;
+    f32 getBoundingRadius() const override;
 
 private:
     f32 m_radius;

--- a/source/game/field/ObjectDirector.hh
+++ b/source/game/field/ObjectDirector.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "game/field/ObjectCollisionConvexHull.hh"
 #include "game/field/ObjectFlowTable.hh"
 #include "game/field/ObjectHitTable.hh"
 #include "game/field/obj/ObjectCollidable.hh"
@@ -14,7 +15,12 @@ public:
     void calc();
     void addObject(ObjectCollidable *obj);
 
+    size_t checkKartObjectCollision(Kart::KartObject *kartObj,
+            ObjectCollisionConvexHull *convexHull);
+
     const ObjectFlowTable &flowTable() const;
+    Kart::Reaction reaction(size_t idx) const;
+    const EGG::Vector3f &hitDepth(size_t idx) const;
 
     static ObjectDirector *CreateInstance();
     static void DestroyInstance();
@@ -34,6 +40,11 @@ private:
     std::vector<ObjectBase *> m_objects;          ///< All objects live here
     std::vector<ObjectBase *> m_calcObjects;      ///< Objects needing calc() live here too.
     std::vector<ObjectBase *> m_collisionObjects; ///< Objects having collision live here too
+
+    static constexpr size_t MAX_UNIT_COUNT = 0x100;
+
+    std::array<EGG::Vector3f, MAX_UNIT_COUNT> m_hitDepths;
+    std::array<Kart::Reaction, MAX_UNIT_COUNT> m_reactions;
 
     static ObjectDirector *s_instance;
 };

--- a/source/game/field/ObjectHitTable.cc
+++ b/source/game/field/ObjectHitTable.cc
@@ -24,16 +24,16 @@ ObjectHitTable::ObjectHitTable(const char *filename) {
         stream.skip(m_fieldCount * 2 - 2);
     }
 
-    m_slots = reinterpret_cast<const s16 *>(stream.data());
+    m_slots = reinterpret_cast<const s16 *>(stream.dataAtIndex());
 }
 
 /// @addr{0x807F9348}
 ObjectHitTable::~ObjectHitTable() = default;
 
-s16 ObjectHitTable::reaction(s16 i) const {
+Kart::Reaction ObjectHitTable::reaction(s16 i) const {
     ASSERT(i != -1);
     ASSERT(i < m_count);
-    return m_reactions[i];
+    return static_cast<Kart::Reaction>(m_reactions[i]);
 }
 
 s16 ObjectHitTable::slot(ObjectId id) const {

--- a/source/game/field/ObjectHitTable.hh
+++ b/source/game/field/ObjectHitTable.hh
@@ -2,6 +2,8 @@
 
 #include "game/field/obj/ObjectId.hh"
 
+#include "game/kart/KartCollide.hh"
+
 #include <span>
 
 namespace Field {
@@ -11,7 +13,7 @@ public:
     ObjectHitTable(const char *filename);
     ~ObjectHitTable();
 
-    s16 reaction(s16 i) const;
+    Kart::Reaction reaction(s16 i) const;
     s16 slot(ObjectId id) const;
 
 private:

--- a/source/game/field/obj/ObjectBase.cc
+++ b/source/game/field/obj/ObjectBase.cc
@@ -14,15 +14,7 @@ ObjectBase::~ObjectBase() = default;
 
 /// @addr{0x808217B8}
 void ObjectBase::calcModel() {
-    if (!(m_flags & 2)) {
-        if (!(m_flags & 1)) {
-            m_transform.setBase(3, m_pos);
-            m_flags |= 4;
-        }
-    } else {
-        m_transform.makeRT(m_rot, m_pos);
-        m_flags &= ~0x3;
-    }
+    calcTransform();
 }
 
 /// @addr{0x806BF434}
@@ -46,6 +38,17 @@ f32 ObjectBase::getCollisionRadius() const {
 /// @addr{0x80572574}
 ObjectId ObjectBase::id() const {
     return m_id;
+}
+
+/// @addr{0x80821640}
+void ObjectBase::calcTransform() {
+    if (m_flags & 2) {
+        m_transform.makeRT(m_rot, m_pos);
+        m_flags &= ~0x3;
+    } else if (m_flags & 1) {
+        m_transform.setBase(3, m_pos);
+        m_flags |= 4;
+    }
 }
 
 } // namespace Field

--- a/source/game/field/obj/ObjectBase.hh
+++ b/source/game/field/obj/ObjectBase.hh
@@ -18,6 +18,7 @@ public:
     virtual void calc() {}
     virtual void calcModel();
     virtual void load() = 0;
+    virtual void calcCollisionTransform() = 0;
     [[nodiscard]] virtual u32 loadFlags() const;
     [[nodiscard]] virtual const EGG::Vector3f &getPosition() const;
     [[nodiscard]] virtual f32 getCollisionRadius() const;
@@ -25,6 +26,8 @@ public:
     [[nodiscard]] ObjectId id() const;
 
 protected:
+    void calcTransform();
+
     ObjectId m_id;
     BoxColUnit *m_boxColUnit;
     u16 m_flags;

--- a/source/game/field/obj/ObjectCollidable.hh
+++ b/source/game/field/obj/ObjectCollidable.hh
@@ -4,6 +4,13 @@
 
 #include "game/field/ObjectCollisionBase.hh"
 
+namespace Kart {
+
+class KartObject;
+enum class Reaction;
+
+} // namespace Kart
+
 namespace Field {
 
 class ObjectCollidable : public ObjectBase {
@@ -12,11 +19,20 @@ public:
     ~ObjectCollidable() override;
 
     void load() override;
+    void calcCollisionTransform() override;
     [[nodiscard]] f32 getCollisionRadius() const override;
 
     virtual void loadAABB(f32 maxSpeed);
     virtual void loadAABB(f32 radius, f32 maxSpeed);
-    [[nodiscard]] virtual const ObjectCollisionBase *collision() const;
+    virtual void processKartReactions(Kart::KartObject *kartObj, Kart::Reaction &reactionOnKart,
+            Kart::Reaction &reactionOnObj);
+    virtual Kart::Reaction onCollision(Kart::KartObject *kartObj, Kart::Reaction reactionOnKart,
+            Kart::Reaction reactionOnObj, const EGG::Vector3f &hitDepth);
+    virtual void onWallCollision(Kart::KartObject *, const EGG::Vector3f &) {}
+    virtual void onObjectCollision(Kart::KartObject *) {}
+    virtual bool checkCollision(ObjectCollisionBase *lhs, EGG::Vector3f &dist);
+    virtual const EGG::Vector3f &getCollisionTranslation() const;
+    [[nodiscard]] virtual ObjectCollisionBase *collision() const;
 
 protected:
     virtual void createCollision();

--- a/source/game/field/obj/ObjectDokan.cc
+++ b/source/game/field/obj/ObjectDokan.cc
@@ -2,6 +2,8 @@
 
 #include "game/field/CollisionDirector.hh"
 
+#include "game/kart/KartCollide.hh"
+
 namespace Field {
 
 /// @addr{0x807787F0}
@@ -33,6 +35,22 @@ void ObjectDokan::calc() {
 /// @addr{0x80778FE4}
 u32 ObjectDokan::loadFlags() const {
     return 1;
+}
+
+/// @addr{0x80778C0C}
+Kart::Reaction ObjectDokan::onCollision(Kart::KartObject * /*kartObj*/,
+        Kart::Reaction reactionOnKart, Kart::Reaction reactionOnObj,
+        const EGG::Vector3f & /*hitDepth*/) {
+    constexpr f32 INITIAL_VELOCITY = 100.0f;
+
+    if (reactionOnObj == Kart::Reaction::UNK_3 || reactionOnObj == Kart::Reaction::UNK_5) {
+        if (!m_b0) {
+            m_b0 = true;
+            m_velocity = INITIAL_VELOCITY * EGG::Vector3f::ey;
+        }
+    }
+
+    return reactionOnKart;
 }
 
 /// @addr{0x807789BC}

--- a/source/game/field/obj/ObjectDokan.hh
+++ b/source/game/field/obj/ObjectDokan.hh
@@ -13,6 +13,9 @@ public:
     void calc() override;
     [[nodiscard]] u32 loadFlags() const override;
 
+    Kart::Reaction onCollision(Kart::KartObject *kartObj, Kart::Reaction reactionOnKart,
+            Kart::Reaction reactionOnObj, const EGG::Vector3f &hitDepth) override;
+
 private:
     void calcFloor();
 

--- a/source/game/field/obj/ObjectNoImpl.hh
+++ b/source/game/field/obj/ObjectNoImpl.hh
@@ -10,6 +10,7 @@ public:
     ~ObjectNoImpl() override;
 
     void load() override;
+    void calcCollisionTransform() override {}
 };
 
 } // namespace Field

--- a/source/game/kart/KartAction.hh
+++ b/source/game/kart/KartAction.hh
@@ -1,0 +1,22 @@
+#pragma once
+
+namespace Kart {
+
+enum class Action {
+    None = -1,
+    UNK_0 = 0,
+    UNK_1 = 1,
+    UNK_2 = 2,
+    UNK_3 = 3,
+    UNK_4 = 4,
+    UNK_5 = 5,
+    UNK_6 = 6,
+    UNK_7 = 7,
+    UNK_8 = 8,
+    UNK_9 = 9,
+    UNK_12 = 12,
+    UNK_14 = 14,
+    UNK_16 = 16,
+};
+
+} // namespace Kart

--- a/source/game/kart/KartMove.cc
+++ b/source/game/kart/KartMove.cc
@@ -918,7 +918,8 @@ void KartMove::calcRotation() {
 
         if (!drifting) {
             bool noTurn = false;
-            if (!state()->isWallCollision() && EGG::Mathf::abs(m_speed) < 1.0f) {
+            if (!state()->isWallCollision() && !state()->isWall3Collision() &&
+                    EGG::Mathf::abs(m_speed) < 1.0f) {
                 if (!(state()->isHop() && m_hopPosY > 0.0f)) {
                     turn = 0.0f;
                     noTurn = true;
@@ -1870,6 +1871,10 @@ void KartMove::exitCannon() {
     state()->setInCannon(false);
     state()->setSkipWheelCalc(false);
     dynamics()->setIntVel(m_cannonEntryOfs * m_speed);
+}
+
+void KartMove::setSpeed(f32 val) {
+    m_speed = val;
 }
 
 void KartMove::setSmoothedUp(const EGG::Vector3f &v) {

--- a/source/game/kart/KartMove.hh
+++ b/source/game/kart/KartMove.hh
@@ -99,6 +99,7 @@ public:
     void exitCannon();
 
     /// @beginSetters
+    void setSpeed(f32 val);
     void setSmoothedUp(const EGG::Vector3f &v);
     void setUp(const EGG::Vector3f &v);
     void setDir(const EGG::Vector3f &v);

--- a/source/game/kart/KartObjectManager.cc
+++ b/source/game/kart/KartObjectManager.cc
@@ -18,6 +18,7 @@ void KartObjectManager::init() {
 void KartObjectManager::calc() {
     for (size_t i = 0; i < m_count; ++i) {
         KartObject *object = m_objects[i];
+        object->collide()->setTangentOff(EGG::Vector3f::zero);
         object->collide()->setMovement(EGG::Vector3f::zero);
     }
 

--- a/source/game/kart/KartObjectProxy.cc
+++ b/source/game/kart/KartObjectProxy.cc
@@ -363,6 +363,11 @@ f32 KartObjectProxy::speedRatio() const {
     return move()->speedRatio();
 }
 
+/// @addr{80590DC0}
+f32 KartObjectProxy::speedRatioCapped() const {
+    return move()->speedRatioCapped();
+}
+
 std::list<KartObjectProxy *> &KartObjectProxy::proxyList() {
     return s_proxyList;
 }

--- a/source/game/kart/KartObjectProxy.hh
+++ b/source/game/kart/KartObjectProxy.hh
@@ -138,6 +138,7 @@ public:
     [[nodiscard]] bool hasFloorCollision(const WheelPhysics *wheelPhysics) const;
     [[nodiscard]] std::pair<EGG::Vector3f, EGG::Vector3f> getCannonPosRot();
     [[nodiscard]] f32 speedRatio() const;
+    [[nodiscard]] f32 speedRatioCapped() const;
 
     [[nodiscard]] static std::list<KartObjectProxy *> &proxyList();
     /// @endGetters

--- a/source/game/kart/KartSub.cc
+++ b/source/game/kart/KartSub.cc
@@ -167,6 +167,9 @@ void KartSub::calcPass1() {
     flags.setBit(Field::eBoxColFlag::Drivable, Field::eBoxColFlag::Object);
     boxColUnit()->search(flags);
 
+    collide()->calcObjectCollision();
+    dynamics()->setPos(pos() + collide()->tangentOff());
+
     if (state()->isSomethingWallCollision()) {
         const EGG::Vector3f &softWallSpeed = state()->softWallSpeed();
         f32 speedFactor = 5.0f;

--- a/testCases.json
+++ b/testCases.json
@@ -47,7 +47,7 @@
     "Kierio rMC3 Test": {
         "rkgPath": "samples/rmc3-kierio-test-3-24-416.rkg",
         "krkgPath": "samples/rmc3-kierio-test-3-24-416.krkg",
-        "targetFrame": 3470
+        "targetFrame": 11073
     },
     "Luke rBC NG RTA WR": {
         "rkgPath": "samples/rbc-ng-rta-2-30-459.rkg",


### PR DESCRIPTION
This PR is a huge milestone - this is the first object whose collision syncs with the base game. There were several bugs that came to fruition during this PR's scope, namely:

1. In `ObjectHitTable`'s constructor, `m_slots` was being assigned a pointer to the start of `stream`'s data, when we really wanted to factor in the stream index.
2.  `BoxColManager::getNextImpl` was supposed to pass-by-reference
3. `eBoxColFlag` entries were off-by-one'd
4. Missing parentheses and improper division instead of multiplication throughout `ObjectCollisionBase`
5. `ObjectCollisionKart::GetVehicleVertices` vectors need to be `static` since they are accessed via a span.