### PR TITLE
Implement start boost burnout

### DIFF
--- a/source/game/item/KartItem.cc
+++ b/source/game/item/KartItem.cc
@@ -1,6 +1,8 @@
 #include "KartItem.hh"
 
 #include "game/kart/KartMove.hh"
+#include "game/kart/KartState.hh"
+
 #include "game/system/RaceManager.hh"
 
 namespace Item {
@@ -32,6 +34,7 @@ void KartItem::calc() {
     const auto *raceMgr = System::RaceManager::Instance();
     bool canUse = m_flags.onBit(eFlags::ItemButtonActivation);
     canUse = canUse && raceMgr->isStageReached(System::RaceManager::Stage::Race);
+    canUse = canUse && !state()->isBurnout();
     canUse = canUse && (m_inventory.id() != ItemId::NONE);
 
     if (canUse) {

--- a/source/game/kart/KartBurnout.cc
+++ b/source/game/kart/KartBurnout.cc
@@ -1,0 +1,84 @@
+#include "KartBurnout.hh"
+
+#include "game/kart/KartPhysics.hh"
+#include "game/kart/KartState.hh"
+
+#include <egg/math/Math.hh>
+
+namespace Kart {
+
+/// @addr{inlined in 0x80577FC4}
+KartBurnout::KartBurnout() = default;
+
+/// @addr{0x805781DC}
+KartBurnout::~KartBurnout() = default;
+
+/// @addr{0x805890B0}
+void KartBurnout::start() {
+    activate();
+    m_timer = 0;
+    m_phase = 0;
+    m_amplitude = 1.0f;
+}
+
+/// @addr{0x80589118}
+void KartBurnout::calc() {
+    constexpr u32 BURNOUT_DURATION = 120;
+
+    if (!isActive()) {
+        return;
+    }
+
+    calcRotation();
+
+    if (calcEnd(BURNOUT_DURATION)) {
+        deactivate();
+    }
+}
+
+/// @addr{0x80589308}
+void KartBurnout::calcRotation() {
+    constexpr u16 PHASE_INCREMENT = 800;
+    constexpr f32 PHASE_TO_FIDX = 1.0f / 256.0f;
+    constexpr f32 AMPLITUDE_FACTOR = 40.0f;
+    constexpr f32 DAMPENING_THRESHOLD = 30.0f;
+    constexpr f32 DAMPENING_FACTOR = 0.97f;
+
+    m_phase += PHASE_INCREMENT;
+
+    f32 sin = EGG::Mathf::SinFIdx(static_cast<f32>(m_phase) * PHASE_TO_FIDX);
+
+    // Apply a dampening effect after burning out for 30 frames
+    if (static_cast<f32>(m_timer) > DAMPENING_THRESHOLD) {
+        m_amplitude *= DAMPENING_FACTOR;
+    }
+
+    f32 pitch = DEG2RAD * (AMPLITUDE_FACTOR * sin) * m_amplitude;
+
+    EGG::Quatf rpy;
+    rpy.setRPY(EGG::Vector3f(0.0f, pitch, 0.0f));
+
+    physics()->composeStuntRot(rpy);
+}
+
+/// @addr{0x8058920C}
+bool KartBurnout::calcEnd(u32 duration) {
+    return ++m_timer >= duration;
+}
+
+/// @addr{0x80589844}
+void KartBurnout::activate() {
+    state()->setBurnout(true);
+}
+
+/// @addr{0x80589818}
+void KartBurnout::deactivate() {
+    state()->setBurnout(false);
+}
+
+/// @addr{0x80589830}
+bool KartBurnout::isActive() const {
+    return state()->isBurnout();
+}
+
+} // namespace Kart

--- a/source/game/kart/KartBurnout.hh
+++ b/source/game/kart/KartBurnout.hh
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "game/kart/KartObjectProxy.hh"
+
+namespace Kart {
+
+/// @brief Calculates the duration of burnout and rotation induced
+/// when holding acceleration too long during the race countdown.
+/// @nosubgrouping
+class KartBurnout : KartObjectProxy {
+public:
+    KartBurnout();
+    ~KartBurnout();
+
+    void start();
+    void calc();
+
+private:
+    void calcRotation();
+    bool calcEnd(u32 duration);
+
+    void activate();
+    void deactivate();
+    [[nodiscard]] bool isActive() const;
+
+    u32 m_timer;
+    u16 m_phase;
+    f32 m_amplitude;
+};
+
+} // namespace Kart

--- a/source/game/kart/KartMove.cc
+++ b/source/game/kart/KartMove.cc
@@ -249,6 +249,7 @@ void KartMove::setKartSpeedLimit() {
 /// Afterwards, calculates the kart's speed and rotation.
 void KartMove::calc() {
     dynamics()->resetInternalVelocity();
+    m_burnout.calc();
     calcSsmtStart();
     m_halfPipe->calc();
     calcTop();
@@ -1125,17 +1126,21 @@ void KartMove::calcAcceleration() {
 
     m_lastSpeed = m_speed;
 
-    if (m_acceleration < 0.0f) {
-        if (m_speed < -20.0f) {
-            m_acceleration = 0.0f;
-        } else {
-            if (m_speed + m_acceleration <= -20.0f) {
-                m_acceleration = -20.0f - m_speed;
+    if (state()->isBurnout()) {
+        m_speed = 0.0f;
+    } else {
+        if (m_acceleration < 0.0f) {
+            if (m_speed < -20.0f) {
+                m_acceleration = 0.0f;
+            } else {
+                if (m_speed + m_acceleration <= -20.0f) {
+                    m_acceleration = -20.0f - m_speed;
+                }
             }
         }
-    }
 
-    m_speed += m_acceleration;
+        m_speed += m_acceleration;
+    }
 
     if (state()->isBeforeRespawn()) {
         m_speed *= OOB_SLOWDOWN_RATE;
@@ -2083,6 +2088,10 @@ KartJump *KartMove::jump() const {
 
 KartHalfPipe *KartMove::halfPipe() const {
     return m_halfPipe;
+}
+
+KartBurnout &KartMove::burnout() {
+    return m_burnout;
 }
 
 /// @addr{0x80587B30}

--- a/source/game/kart/KartMove.hh
+++ b/source/game/kart/KartMove.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "game/kart/KartBoost.hh"
+#include "game/kart/KartBurnout.hh"
 #include "game/kart/KartHalfPipe.hh"
 #include "game/kart/KartObjectProxy.hh"
 #include "game/kart/KartReject.hh"
@@ -141,6 +142,7 @@ public:
     [[nodiscard]] PadType &padType();
     [[nodiscard]] KartJump *jump() const;
     [[nodiscard]] KartHalfPipe *halfPipe() const;
+    [[nodiscard]] KartBurnout &burnout();
     /// @endGetters
 
 protected:
@@ -253,6 +255,7 @@ protected:
     Flags m_flags;
     KartJump *m_jump;
     KartHalfPipe *m_halfPipe;                   ///< Pertains to zipper physics.
+    KartBurnout m_burnout;                      ///< Manages the state of start boost burnout.
     const DriftingParameters *m_driftingParams; ///< Drift-type-specific parameters.
     f32 m_rawTurn; ///< Float in range [-1, 1]. Represents stick magnitude + direction.
 };

--- a/source/game/kart/KartState.cc
+++ b/source/game/kart/KartState.cc
@@ -85,12 +85,15 @@ void KartState::calcInput() {
                 }
             }
 
-            m_bAccelerate = currentState.accelerate();
-            m_bAccelerateStart = m_bAccelerate && !lastState.accelerate();
-            m_bBrake = currentState.brake();
-            if (!m_bAutoDrift) {
-                m_bDriftInput = currentState.drift();
-                m_bHopStart = m_bDriftInput && !lastState.drift();
+            if (!state()->isBurnout()) {
+                m_bAccelerate = currentState.accelerate();
+                m_bAccelerateStart = m_bAccelerate && !lastState.accelerate();
+                m_bBrake = currentState.brake();
+
+                if (!m_bAutoDrift) {
+                    m_bDriftInput = currentState.drift();
+                    m_bHopStart = m_bDriftInput && !lastState.drift();
+                }
             }
         }
 
@@ -389,9 +392,10 @@ void KartState::calcHandleStartBoost() {
 /// @param idx The index into the start boost entries array.
 void KartState::handleStartBoost(size_t idx) {
     if (m_startBoostIdx == std::numeric_limits<size_t>::max()) {
-        PANIC("More burnout RE required. See KartMoveSub264 function 0x805890b0.");
+        move()->burnout().start();
+    } else {
+        move()->applyStartBoost(START_BOOST_ENTRIES[idx].frames);
     }
-    move()->applyStartBoost(START_BOOST_ENTRIES[idx].frames);
 }
 
 /// @brief Resets certain bitfields pertaining to ejections (reject road, half pipe zippers, etc.)
@@ -565,6 +569,10 @@ bool KartState::isZipperTrick() const {
     return m_bZipperTrick;
 }
 
+bool KartState::isBurnout() const {
+    return m_bBurnout;
+}
+
 bool KartState::isZipperStick() const {
     return m_bZipperStick;
 }
@@ -706,6 +714,7 @@ void KartState::clearBitfield1() {
     m_bZipperBoost = false;
     m_bZipperStick = false;
     m_bZipperTrick = false;
+    m_bBurnout = false;
     m_bTrickRot = false;
     m_bChargingSsmt = false;
     m_bRejectRoad = false;
@@ -848,6 +857,10 @@ void KartState::setZipperStick(bool isSet) {
 
 void KartState::setZipperTrick(bool isSet) {
     m_bZipperTrick = isSet;
+}
+
+void KartState::setBurnout(bool isSet) {
+    m_bBurnout = isSet;
 }
 
 void KartState::setTrickRot(bool isSet) {

--- a/source/game/kart/KartState.hh
+++ b/source/game/kart/KartState.hh
@@ -61,6 +61,7 @@ public:
     void setZipperBoost(bool isSet);
     void setZipperStick(bool isSet);
     void setZipperTrick(bool isSet);
+    void setBurnout(bool isSet);
     void setTrickRot(bool isSet);
     void setChargingSsmt(bool isSet);
     void setRejectRoad(bool isSet);
@@ -122,6 +123,7 @@ public:
     [[nodiscard]] bool isDisableBackwardsAccel() const;
     [[nodiscard]] bool isZipperBoost() const;
     [[nodiscard]] bool isZipperTrick() const;
+    [[nodiscard]] bool isBurnout() const;
     [[nodiscard]] bool isZipperStick() const;
     [[nodiscard]] bool isTrickRot() const;
     [[nodiscard]] bool isChargingSsmt() const;
@@ -202,6 +204,7 @@ private:
     bool m_bZipperBoost;               ///< Set when boosting after landing from a zipper.
     bool m_bZipperStick;               ///< Set while mid-air and still influenced by the zipper.
     bool m_bZipperTrick;               ///< Set while tricking mid-air from a zipper.
+    bool m_bBurnout;                   ///< Set during a burnout on race start.
     bool m_bTrickRot;
     bool m_bChargingSsmt;      ///< Tracks whether we are charging a stand-still mini-turbo.
     bool m_bRejectRoad;        ///< Collision which causes a change in the player's pos and rot.


### PR DESCRIPTION
This synchronizes burnout physics when holding acceleration for too long during race countdown. Verified sync if attempting to activate an item during burnout. Verified analog stick inputs are still respected during burnout.