### PR TITLE
Error on implicit float-to-double promotion

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -40,6 +40,7 @@ common_ccflags = [
     '-isystem', 'build',
     '-std=c++23',
     '-Wall',
+    '-Wdouble-promotion',
     '-Werror',
     '-Wextra',
     '-Wno-delete-non-virtual-dtor',

--- a/source/egg/core/Heap.cc
+++ b/source/egg/core/Heap.cc
@@ -128,8 +128,9 @@ void *Heap::alloc(size_t size, int align, Heap *pHeap) {
             WARN("HEAP ALLOC FAIL (%p, %s):\nTotal bytes: %d (%.1fMBytes)\nFree bytes: %d "
                  "(%.1fMBytes)\nAlloc bytes: %d "
                  "(%.1fMBytes)\nAlign: %d",
-                    currentHeap, currentHeap->getName(), heapSize, heapSizeMB, heapFreeSize,
-                    heapFreeSizeMB, size, sizeMB, align);
+                    currentHeap, currentHeap->getName(), static_cast<f64>(heapSize),
+                    static_cast<f64>(heapSizeMB), heapFreeSize, static_cast<f64>(heapFreeSizeMB),
+                    size, static_cast<f64>(sizeMB), align);
         }
 
         return block;

--- a/source/egg/math/Math.cc
+++ b/source/egg/math/Math.cc
@@ -314,7 +314,7 @@ static constexpr AtanEntry sArcTanTbl[32 + 1] = {
 
 /// @addr{0x8022F80C}
 f32 sqrt(f32 x) {
-    return x > 0.0 ? frsqrt(x) * x : 0.0;
+    return x > 0.0f ? frsqrt(x) * x : 0.0f;
 }
 
 /// CREDIT: Hanachan
@@ -325,8 +325,9 @@ f32 frsqrt(f32 x) {
 
     // Newton-Raphson refinement
     f32 tmp0 = static_cast<f32>(est * force25Bit(est));
-    f32 tmp1 = static_cast<f32>(est * 0.5f);
-    f32 tmp2 = static_cast<f32>(3.0f - static_cast<f64>(tmp0) * static_cast<f64>(x));
+    f32 tmp1 = static_cast<f32>(est * static_cast<f64>(0.5f));
+    f32 tmp2 =
+            static_cast<f32>(static_cast<f64>(3.0f) - static_cast<f64>(tmp0) * static_cast<f64>(x));
     return tmp1 * tmp2;
 }
 

--- a/source/game/field/ObjectCollisionBase.cc
+++ b/source/game/field/ObjectCollisionBase.cc
@@ -45,7 +45,7 @@ bool ObjectCollisionBase::check(ObjectCollisionBase &rhs, EGG::Vector3f &distanc
 
         lastRadius = std::max(lastRadius, dot / max);
 
-        if (inSimplex(state, A) || (max2 - dot) < max2 * 0.000001) {
+        if (inSimplex(state, A) || (max2 - dot) < max2 * 0.000001f) {
             getNearestPoint(state, state.m_flags, v0, v1);
 
             v0 -= D * (getBoundingRadius() / max);

--- a/source/game/kart/KartHalfPipe.cc
+++ b/source/game/kart/KartHalfPipe.cc
@@ -130,7 +130,8 @@ void KartHalfPipe::calcRot() {
         break;
     case StuntType::Backside: {
         EGG::Quatf rpy;
-        rpy.setRPY(EGG::Vector3f(0.0f, DEG2RAD * (0.25 * -m_rotSign * m_stuntManager.angle), 0.0f));
+        rpy.setRPY(
+                EGG::Vector3f(0.0f, DEG2RAD * (0.25f * -m_rotSign * m_stuntManager.angle), 0.0f));
         EGG::Vector3f rot = rpy.rotateVector(EGG::Vector3f::ez);
         m_stuntRot.setAxisRotation(angle, rot);
     } break;


### PR DESCRIPTION
We never use doubles (except for paired singles), and implicit float promotion has only ever caused sync issues that become very difficult to track down. Just like with adding `nodiscard` to our functions, we should merge these changes in order to limit the types of mistakes that can be introduced during future development.

**NOTE:** C++ standard says variadic functions must always promote floats to doubles, so unfortunately this means any use of `printf` with `%f` will require a `static_cast<f64>` in order to compile. I completely predict that new developers will run into this, so I'm not sure what can be done to make this less of a pain.