### PR TITLE
Use paired singles for object collision transformation

### DIFF
--- a/source/game/field/ObjectCollisionConvexHull.cc
+++ b/source/game/field/ObjectCollisionConvexHull.cc
@@ -29,7 +29,7 @@ void ObjectCollisionConvexHull::transform(const EGG::Matrix34f &mat, const EGG::
 
     if (scale.x == 0.0f) {
         for (size_t i = 0; i < m_points.size(); ++i) {
-            m_worldPoints[i] = mat.multVector(m_points[i]);
+            m_worldPoints[i] = mat.ps_multVector(m_points[i]);
         }
     } else {
         EGG::Matrix34f temp;
@@ -37,7 +37,7 @@ void ObjectCollisionConvexHull::transform(const EGG::Matrix34f &mat, const EGG::
         temp = mat.multiplyTo(temp);
 
         for (size_t i = 0; i < m_points.size(); ++i) {
-            m_worldPoints[i] = temp.multVector(m_points[i]);
+            m_worldPoints[i] = temp.ps_multVector(m_points[i]);
         }
     }
 }

--- a/source/game/field/ObjectCollisionCylinder.cc
+++ b/source/game/field/ObjectCollisionCylinder.cc
@@ -22,7 +22,7 @@ ObjectCollisionCylinder::~ObjectCollisionCylinder() = default;
 void ObjectCollisionCylinder::transform(const EGG::Matrix34f &mat, const EGG::Vector3f &scale,
         const EGG::Vector3f &speed) {
     m_translation = speed;
-    m_worldPos = scale * m_pos;
+    m_worldPos = m_pos * scale.x;
     m_worldHeight = m_height * scale.y;
     m_worldRadius = m_radius * scale.x;
 


### PR DESCRIPTION
Also fix incorrect multiplication with ObjectCollisionCylinder that could shoot us in the foot later.