### PR TITLE
Fix inaccurate paired singles instructions

### DIFF
--- a/source/egg/math/Vector.cc
+++ b/source/egg/math/Vector.cc
@@ -54,9 +54,7 @@ f32 Vector3f::dot(const Vector3f &rhs) const {
 
 /// @brief Paired-singles dot product implementation.
 f32 Vector3f::ps_dot() const {
-    f32 y_ = y * y;
-    f32 xy = Mathf::fma(x, x, y_);
-    return xy + z * z;
+    return ps_dot(*this);
 }
 
 /// @addr{0x8019ACAC}
@@ -65,6 +63,13 @@ f32 Vector3f::ps_dot(const Vector3f &rhs) const {
     f32 y_ = y * rhs.y;
     f32 xy = Mathf::fma(x, rhs.x, y_);
     return xy + z * rhs.z;
+}
+
+/// @brief Differs from ps_dot due to variation in which operands are fused.
+f32 Vector3f::ps_squareMag() const {
+    f32 x_ = x * x;
+    f32 zx = Mathf::fma(z, z, x_);
+    return zx + y * y;
 }
 
 /// @addr{0x80214968}

--- a/source/egg/math/Vector.hh
+++ b/source/egg/math/Vector.hh
@@ -145,6 +145,7 @@ struct Vector3f {
     [[nodiscard]] f32 dot(const EGG::Vector3f &rhs) const;
     [[nodiscard]] f32 ps_dot() const;
     [[nodiscard]] f32 ps_dot(const EGG::Vector3f &rhs) const;
+    [[nodiscard]] f32 ps_squareMag() const;
     [[nodiscard]] f32 length() const;
     f32 normalise();
     [[nodiscard]] Vector3f maximize(const Vector3f &rhs) const;

--- a/source/game/field/KColData.cc
+++ b/source/game/field/KColData.cc
@@ -504,7 +504,7 @@ bool KColData::checkCollision(const KCollisionPrism &prism, f32 *distOut, EGG::V
         f32 s = edge_dist - t * cos;
         const EGG::Vector3f corner_pos = edge_nor * t + other_edge_nor * s;
 
-        f32 cornerDot = corner_pos.ps_dot();
+        f32 cornerDot = corner_pos.ps_squareMag();
         if (type == CollisionCheckType::Plane) {
             if (cornerDot > plane_dist * plane_dist) {
                 return false;


### PR DESCRIPTION
I'm not immediately sure how to double-check for other uses elsewhere, but I think this is the only one we have to worry about?