### PR TITLE
Clear item inventory when respawning

### DIFF
--- a/source/game/item/ItemDirector.cc
+++ b/source/game/item/ItemDirector.cc
@@ -18,6 +18,11 @@ void ItemDirector::calc() {
     }
 }
 
+KartItem &ItemDirector::kartItem(size_t idx) {
+    ASSERT(idx < m_karts.size());
+    return m_karts[idx];
+}
+
 /// @addr{0x80799138}
 ItemDirector *ItemDirector::CreateInstance() {
     ASSERT(!s_instance);

--- a/source/game/item/ItemDirector.hh
+++ b/source/game/item/ItemDirector.hh
@@ -13,6 +13,8 @@ public:
     void init();
     void calc();
 
+    KartItem &kartItem(size_t idx);
+
     static ItemDirector *CreateInstance();
     static void DestroyInstance();
     [[nodiscard]] static ItemDirector *Instance();

--- a/source/game/item/ItemInventory.cc
+++ b/source/game/item/ItemInventory.cc
@@ -21,6 +21,11 @@ void ItemInventory::useItem(int count) {
         return;
     }
 
+    clear();
+}
+
+/// @addr{0x807BC9C0}
+void ItemInventory::clear() {
     m_currentId = ItemId::NONE;
     m_currentCount = 0;
 }

--- a/source/game/item/ItemInventory.hh
+++ b/source/game/item/ItemInventory.hh
@@ -13,6 +13,7 @@ public:
     /// @beginSetters
     void setItem(ItemId id);
     void useItem(int count);
+    void clear();
     /// @endSetters
 
     /// @beginGetters

--- a/source/game/item/KartItem.cc
+++ b/source/game/item/KartItem.cc
@@ -43,6 +43,13 @@ void KartItem::calc() {
     }
 }
 
+/// @addr{0x80798848}
+void KartItem::clear() {
+    if (m_inventory.id() != ItemId::NONE) {
+        m_inventory.clear();
+    }
+}
+
 /// @addr{0x8079864C}
 void KartItem::activateMushroom() {
     move()->activateMushroom();

--- a/source/game/item/KartItem.hh
+++ b/source/game/item/KartItem.hh
@@ -17,6 +17,7 @@ public:
 
     void init(size_t playerIdx);
     void calc();
+    void clear();
 
     void activateMushroom();
     void useMushroom();

--- a/source/game/kart/KartMove.cc
+++ b/source/game/kart/KartMove.cc
@@ -12,6 +12,9 @@
 #include "game/field/CollisionDirector.hh"
 #include "game/field/KCollisionTypes.hh"
 
+#include "game/item/ItemDirector.hh"
+#include "game/item/KartItem.hh"
+
 #include "game/system/CourseMap.hh"
 #include "game/system/RaceManager.hh"
 #include "game/system/map/MapdataCannonPoint.hh"
@@ -308,6 +311,9 @@ void KartMove::calcRespawnStart() {
     EGG::Vector3f respawnRot = EGG::Vector3f(0.0f, jugemRot.y, 0.0f);
 
     setInitialPhysicsValues(respawnPos, respawnRot);
+
+    Item::ItemDirector::Instance()->kartItem(0).clear();
+
     state()->setTriggerRespawn(false);
     state()->setInRespawn(true);
 }


### PR DESCRIPTION
This was an outstanding desync possible on Luigi Circuit, if you press the "item" button after respawning. Kinoko did not yet remove your items from your inventory. In-game nothing would happen if you press the "item" button, but in Kinoko it would still activate a shroom boost.

This fixes #148 