### PR TITLE
Delete spans on destruction in KColData

### DIFF
--- a/source/game/field/KColData.cc
+++ b/source/game/field/KColData.cc
@@ -54,6 +54,12 @@ KColData::KColData(const void *file) {
     computeBBox();
 }
 
+KColData::~KColData() {
+    delete[] m_prisms.data();
+    delete[] m_nrms.data();
+    delete[] m_vertices.data();
+}
+
 /// @addr{0x807C24C0}
 void KColData::narrowScopeLocal(const EGG::Vector3f &pos, f32 radius, KCLTypeMask mask) {
     m_prismCacheTop = m_prismCache.data();

--- a/source/game/field/KColData.hh
+++ b/source/game/field/KColData.hh
@@ -35,6 +35,7 @@ public:
     STATIC_ASSERT(sizeof(KCollisionPrism) == 0x10);
 
     KColData(const void *file);
+    ~KColData();
 
     void narrowScopeLocal(const EGG::Vector3f &pos, f32 radius, KCLTypeMask mask);
     void narrowPolygon_EachBlock(const u16 *prismArray);


### PR DESCRIPTION
Since spans are non-owning, we need to ensure their data is deleted