### PR TITLE
Remove initialization in default constructors

### DIFF
--- a/source/egg/math/BoundBox.cc
+++ b/source/egg/math/BoundBox.cc
@@ -5,9 +5,7 @@
 namespace EGG {
 
 /// @addr{0x802145C0}
-BoundBox2f::BoundBox2f() {
-    resetBound();
-}
+BoundBox2f::BoundBox2f() = default;
 
 BoundBox2f::~BoundBox2f() = default;
 
@@ -30,9 +28,7 @@ void BoundBox2f::setMax(const Vector2f &v) {
     max = v;
 }
 
-BoundBox3f::BoundBox3f() {
-    resetBound();
-}
+BoundBox3f::BoundBox3f() = default;
 
 BoundBox3f::~BoundBox3f() = default;
 

--- a/source/egg/math/Matrix.cc
+++ b/source/egg/math/Matrix.cc
@@ -6,9 +6,13 @@ namespace EGG {
 
 using namespace Mathf;
 
+#ifdef BUILD_DEBUG
 Matrix34f::Matrix34f() {
-    makeZero();
+    a.fill(std::numeric_limits<f32>::signaling_NaN());
 }
+#else
+Matrix34f::Matrix34f() = default;
+#endif
 
 Matrix34f::Matrix34f(f32 _e00, f32 _e01, f32 _e02, f32 _e03, f32 _e10, f32 _e11, f32 _e12, f32 _e13,
         f32 _e20, f32 _e21, f32 _e22, f32 _e23) {
@@ -257,7 +261,7 @@ Vector3f Matrix34f::multVector33(const Vector3f &vec) const {
 /// @brief Inverts the 3x3 portion of the 3x4 matrix.
 /// @details Unlike a typical matrix inversion, if the determinant is 0, then this function returns
 /// the identity matrix.
-Matrix34f Matrix34f::inverseTo33() const {
+void Matrix34f::inverseTo33(Matrix34f &out) const {
     f32 determinant = ((((mtx[2][1] * (mtx[0][2] * mtx[1][0])) +
                                 ((mtx[2][2] * (mtx[0][0] * mtx[1][1])) +
                                         (mtx[2][0] * (mtx[0][1] * mtx[1][2])))) -
@@ -266,24 +270,21 @@ Matrix34f Matrix34f::inverseTo33() const {
             (mtx[1][2] * (mtx[0][0] * mtx[2][1]));
 
     if (determinant == 0.0f) {
-        return Matrix34f::ident;
+        out = Matrix34f::ident;
+        return;
     }
 
     f32 invDet = 1.0f / determinant;
 
-    Matrix34f ret;
-
-    ret[0, 2] = (mtx[0][1] * mtx[1][2] - mtx[1][1] * mtx[0][2]) * invDet;
-    ret[1, 2] = -(mtx[0][0] * mtx[1][2] - mtx[0][2] * mtx[1][0]) * invDet;
-    ret[2, 1] = -(mtx[0][0] * mtx[2][1] - mtx[2][0] * mtx[0][1]) * invDet;
-    ret[2, 2] = (mtx[0][0] * mtx[1][1] - mtx[1][0] * mtx[0][1]) * invDet;
-    ret[2, 0] = (mtx[1][0] * mtx[2][1] - mtx[2][0] * mtx[1][1]) * invDet;
-    ret[0, 0] = (mtx[1][1] * mtx[2][2] - mtx[2][1] * mtx[1][2]) * invDet;
-    ret[0, 1] = -(mtx[0][1] * mtx[2][2] - mtx[2][1] * mtx[0][2]) * invDet;
-    ret[1, 0] = -(mtx[1][0] * mtx[2][2] - mtx[2][0] * mtx[1][2]) * invDet;
-    ret[1, 1] = (mtx[0][0] * mtx[2][2] - mtx[2][0] * mtx[0][2]) * invDet;
-
-    return ret;
+    out[0, 2] = (mtx[0][1] * mtx[1][2] - mtx[1][1] * mtx[0][2]) * invDet;
+    out[1, 2] = -(mtx[0][0] * mtx[1][2] - mtx[0][2] * mtx[1][0]) * invDet;
+    out[2, 1] = -(mtx[0][0] * mtx[2][1] - mtx[2][0] * mtx[0][1]) * invDet;
+    out[2, 2] = (mtx[0][0] * mtx[1][1] - mtx[1][0] * mtx[0][1]) * invDet;
+    out[2, 0] = (mtx[1][0] * mtx[2][1] - mtx[2][0] * mtx[1][1]) * invDet;
+    out[0, 0] = (mtx[1][1] * mtx[2][2] - mtx[2][1] * mtx[1][2]) * invDet;
+    out[0, 1] = -(mtx[0][1] * mtx[2][2] - mtx[2][1] * mtx[0][2]) * invDet;
+    out[1, 0] = -(mtx[1][0] * mtx[2][2] - mtx[2][0] * mtx[1][2]) * invDet;
+    out[1, 1] = (mtx[0][0] * mtx[2][2] - mtx[2][0] * mtx[0][2]) * invDet;
 }
 
 /// @brief Transposes the 3x3 portion of the matrix.

--- a/source/egg/math/Matrix.hh
+++ b/source/egg/math/Matrix.hh
@@ -41,7 +41,7 @@ public:
     [[nodiscard]] Vector3f multVector(const Vector3f &vec) const;
     [[nodiscard]] Vector3f ps_multVector(const Vector3f &vec) const;
     [[nodiscard]] Vector3f multVector33(const Vector3f &vec) const;
-    [[nodiscard]] Matrix34f inverseTo33() const;
+    void inverseTo33(Matrix34f &out) const;
     [[nodiscard]] Matrix34f transpose() const;
 
     static const Matrix34f ident;

--- a/source/egg/math/Quat.cc
+++ b/source/egg/math/Quat.cc
@@ -4,12 +4,6 @@
 
 namespace EGG {
 
-Quatf::Quatf() : w(1.0f) {}
-
-Quatf::Quatf(f32 w_, const Vector3f &v_) : v(v_), w(w_) {}
-
-Quatf::Quatf(f32 w_, f32 x_, f32 y_, f32 z_) : v(x_, y_, z_), w(w_) {}
-
 Quatf::~Quatf() = default;
 
 /// @addr{0x80239E10}

--- a/source/egg/math/Quat.hh
+++ b/source/egg/math/Quat.hh
@@ -9,9 +9,13 @@ namespace EGG {
 /// The vector is used to represent the axis of rotation, while
 /// the scalar is used to represent the amount of rotation.
 struct Quatf {
-    Quatf();
-    Quatf(f32 w_, const Vector3f &v_);
-    Quatf(f32 w_, f32 x_, f32 y_, f32 z_);
+#ifdef BUILD_DEBUG
+    constexpr Quatf() : w(std::numeric_limits<f32>::signaling_NaN()) {}
+#else
+    constexpr Quatf() = default;
+#endif
+    constexpr Quatf(f32 w_, const Vector3f &v_) : v(v_), w(w_) {}
+    constexpr Quatf(f32 w_, f32 x_, f32 y_, f32 z_) : v(x_, y_, z_), w(w_) {}
     ~Quatf();
 
     Quatf &operator=(const Quatf &q) {

--- a/source/egg/math/Vector.cc
+++ b/source/egg/math/Vector.cc
@@ -4,10 +4,6 @@
 
 namespace EGG {
 
-Vector2f::Vector2f(f32 x_, f32 y_) : x(x_), y(y_) {}
-
-Vector2f::Vector2f() = default;
-
 Vector2f::~Vector2f() = default;
 
 f32 Vector2f::cross(const Vector2f &rhs) const {

--- a/source/egg/math/Vector.hh
+++ b/source/egg/math/Vector.hh
@@ -8,8 +8,14 @@ namespace EGG {
 
 /// @brief A 2D float vector.
 struct Vector2f {
-    Vector2f(f32 x_, f32 y_);
-    Vector2f();
+#ifdef BUILD_DEBUG
+    constexpr Vector2f()
+        : x(std::numeric_limits<f32>::signaling_NaN()),
+          y(std::numeric_limits<f32>::signaling_NaN()) {}
+#else
+    constexpr Vector2f() = default;
+#endif
+    constexpr Vector2f(f32 x_, f32 y_) : x(x_), y(y_) {}
     ~Vector2f();
 
     inline void set(f32 val) {
@@ -61,8 +67,16 @@ struct Vector2f {
 
 /// @brief A 3D float vector.
 struct Vector3f {
+#ifdef BUILD_DEBUG
+    constexpr Vector3f()
+        : x(std::numeric_limits<f32>::signaling_NaN()),
+          y(std::numeric_limits<f32>::signaling_NaN()),
+          z(std::numeric_limits<f32>::signaling_NaN()) {}
+#else
+    constexpr Vector3f() = default;
+#endif
     constexpr Vector3f(f32 x_, f32 y_, f32 z_) : x(x_), y(y_), z(z_) {}
-    constexpr Vector3f() : x(0.0f), y(0.0f), z(0.0f) {}
+
     // NOTE: Defining the destructor in the header ensures the struct is trivially destructible
     ~Vector3f() = default;
 

--- a/source/game/field/ObjectCollisionBase.cc
+++ b/source/game/field/ObjectCollisionBase.cc
@@ -22,7 +22,7 @@ bool ObjectCollisionBase::check(ObjectCollisionBase &rhs, EGG::Vector3f &distanc
     f32 max = INITIAL_MAX_VALUE;
     f32 lastRadius = 0.0f;
 
-    EGG::Vector3f D;
+    EGG::Vector3f D = EGG::Vector3f::zero;
     EGG::Vector3f v0;
     EGG::Vector3f v1;
     GJKState state;
@@ -120,7 +120,7 @@ void ObjectCollisionBase::FUN_808350e4(GJKState &state, EGG::Vector3f &v) const 
         }
 
         f32 sqLen = 0.0f;
-        EGG::Vector3f tmp;
+        EGG::Vector3f tmp = EGG::Vector3f::zero;
         getNearestPoint(state, mask, tmp);
 
         sqLen = tmp.dot();

--- a/source/game/kart/CollisionGroup.cc
+++ b/source/game/kart/CollisionGroup.cc
@@ -154,7 +154,7 @@ f32 CollisionGroup::initHitboxes(const std::array<BSP::Hitbox, 16> &hitboxes) {
 /// @addr{0x805B883C}
 /// @return The furthest point of all the hitboxes' spheres
 f32 CollisionGroup::computeCollisionLimits() {
-    EGG::Vector3f max;
+    EGG::Vector3f max = EGG::Vector3f::zero;
 
     for (const auto &hitbox : m_hitboxes) {
         const BSP::Hitbox *bspHitbox = hitbox.bspHitbox();

--- a/source/game/kart/KartCollide.cc
+++ b/source/game/kart/KartCollide.cc
@@ -208,7 +208,7 @@ void KartCollide::calcBodyCollision(f32 totalScale, f32 sinkDepth, const EGG::Qu
     CollisionData &collisionData = hitboxGroup->collisionData();
     collisionData.reset();
 
-    EGG::Vector3f posRel;
+    EGG::Vector3f posRel = EGG::Vector3f::zero;
     s32 count = 0;
     Field::CourseColMgr::CollisionInfo colInfo;
     colInfo.bbox.setDirect(EGG::Vector3f::zero, EGG::Vector3f::zero);

--- a/source/game/kart/KartDynamics.cc
+++ b/source/game/kart/KartDynamics.cc
@@ -34,7 +34,9 @@ void KartDynamics::init() {
     m_extVel = EGG::Vector3f::zero;
     m_acceleration = EGG::Vector3f::zero;
     m_angVel0 = EGG::Vector3f::zero;
+    m_movingObjVel = EGG::Vector3f::zero;
     m_angVel1 = EGG::Vector3f::zero;
+    m_movingRoadVel = EGG::Vector3f::zero;
     m_velocity = EGG::Vector3f::zero;
     m_speedNorm = 0.0f;
     m_angVel2 = EGG::Vector3f::zero;
@@ -68,7 +70,7 @@ void KartDynamics::setInertia(const EGG::Vector3f &m, const EGG::Vector3f &n) {
     m_inertiaTensor[0, 0] = (m.y * m.y + m.z * m.z) * TWELFTH + n.y * n.y + n.z * n.z;
     m_inertiaTensor[1, 1] = (m.z * m.z + m.x * m.x) * TWELFTH + n.z * n.z + n.x * n.x;
     m_inertiaTensor[2, 2] = (m.x * m.x + m.y * m.y) * TWELFTH + n.x * n.x + n.y * n.y;
-    m_invInertiaTensor = m_inertiaTensor.inverseTo33();
+    m_inertiaTensor.inverseTo33(m_invInertiaTensor);
 }
 
 /// @brief On init, takes elements from the kart's BSP and computes the moment of inertia tensor.

--- a/source/game/kart/KartReject.cc
+++ b/source/game/kart/KartReject.cc
@@ -113,7 +113,7 @@ bool KartReject::calcRejection() {
         bool hasFloorCollision = false;
         bool hasRejectCollision = false;
         bool hasInvisibleWallCollision = false;
-        EGG::Vector3f tangentOff;
+        EGG::Vector3f tangentOff = EGG::Vector3f::zero;
 
         if (mask & KCL_TYPE_INVISIBLE_WALL) {
             hasInvisibleWallCollision =

--- a/source/game/kart/KartState.cc
+++ b/source/game/kart/KartState.cc
@@ -189,7 +189,7 @@ void KartState::calcCollisions() {
 
     u16 wheelCollisions = 0;
     u16 softWallCount = 0;
-    EGG::Vector3f wallNrm;
+    EGG::Vector3f wallNrm = EGG::Vector3f::zero;
     bool trickable = false;
 
     for (u16 tireIdx = 0; tireIdx < tireCount(); ++tireIdx) {

--- a/source/game/kart/KartSub.cc
+++ b/source/game/kart/KartSub.cc
@@ -268,9 +268,9 @@ void KartSub::calcPass1() {
         dynamics()->setPos(dynamics()->pos() + vehicleCompensation);
 
         if (!collisionData().bFloor) {
-            EGG::Vector3f relPos;
-            EGG::Vector3f vel;
-            EGG::Vector3f floorNrm;
+            EGG::Vector3f relPos = EGG::Vector3f::zero;
+            EGG::Vector3f vel = EGG::Vector3f::zero;
+            EGG::Vector3f floorNrm = EGG::Vector3f::zero;
             u32 count = 0;
 
             for (u16 wheelIdx = 0; wheelIdx < tireCount(); ++wheelIdx) {


### PR DESCRIPTION
This should help with performance. Thank you to ficool2 for the `std::numeric_limits<f32>::signaling_NaN()` suggestion. I also moved the Quatf non-default constructors to the header, since it's assuredly a performance improvement as well.

NOTE: BoundBox2f does not need `ifdef` because each `Vector3f` member will have the proper default constructor implementation as a result of their `ifdef`'s.