### PR TITLE
Fix incorrect vector normalisation with dot products smaller than epsilon

### DIFF
--- a/source/egg/math/Quat.cc
+++ b/source/egg/math/Quat.cc
@@ -25,7 +25,7 @@ void Quatf::setRPY(const Vector3f &rpy) {
 /// @addr{0x8023A168}
 /// @brief Scales the quaternion to a unit length.
 void Quatf::normalise() {
-    f32 len = dot() > std::numeric_limits<f32>::epsilon() ? Mathf::sqrt(dot()) : 0.0f;
+    f32 len = squaredNorm() > std::numeric_limits<f32>::epsilon() ? norm() : 0.0f;
 
     if (len != 0.0f) {
         f32 inv = 1.0f / len;
@@ -112,8 +112,12 @@ Quatf Quatf::slerpTo(const Quatf &q1, f32 t) const {
 
 /// @addr{0x8023A138}
 /// @brief Computes \f$this \cdot this = w^2 + x^2 + y^2 + z^2\f$
-f32 Quatf::dot() const {
-    return w * w + v.dot();
+f32 Quatf::squaredNorm() const {
+    return w * w + v.squaredLength();
+}
+
+f32 Quatf::norm() const {
+    return Mathf::sqrt(squaredNorm());
 }
 
 /// @brief Computes \f$this \cdot rhs = w \times rhs.w + x \times rhs.x + y \times rhs.y + z \times

--- a/source/egg/math/Quat.hh
+++ b/source/egg/math/Quat.hh
@@ -83,7 +83,8 @@ struct Quatf {
     Vector3f rotateVector(const Vector3f &vec) const;
     Vector3f rotateVectorInv(const Vector3f &vec) const;
     Quatf slerpTo(const Quatf &q2, f32 t) const;
-    f32 dot() const;
+    f32 squaredNorm() const;
+    f32 norm() const;
     f32 dot(const Quatf &q) const;
     void setAxisRotation(f32 angle, const Vector3f &axis);
     Quatf multSwap(const Vector3f &v) const;

--- a/source/egg/math/Vector.cc
+++ b/source/egg/math/Vector.cc
@@ -39,7 +39,7 @@ void Vector2f::read(Stream &stream) {
 }
 
 /// @brief The dot product between the vector and itself.
-f32 Vector3f::dot() const {
+f32 Vector3f::squaredLength() const {
     return x * x + y * y + z * z;
 }
 
@@ -75,16 +75,18 @@ Vector3f Vector3f::cross(const Vector3f &rhs) const {
 
 /// @brief The square root of the vector's dot product.
 f32 Vector3f::length() const {
-    return Mathf::sqrt(dot());
+    return Mathf::sqrt(squaredLength());
 }
 
 /// @addr{0x80243ADC}
 /// @brief Normalizes the vector and returns the original length.
 /// @return (optional) The length of the vector before normalisation.
 f32 Vector3f::normalise() {
-    f32 len = length();
-    if (std::numeric_limits<f32>::epsilon() < dot()) {
-        *this = *this * (1.0f / len);
+    f32 len = 0.0f;
+
+    if (squaredLength() > std::numeric_limits<f32>::epsilon()) {
+        len = length();
+        *this *= (1.0f / len);
     }
 
     return len;
@@ -134,7 +136,7 @@ std::pair<Vector3f, Vector3f> Vector3f::projAndRej(const Vector3f &rhs) const {
 /// @brief The square of the distance between two vectors.
 f32 Vector3f::sqDistance(const Vector3f &rhs) const {
     const EGG::Vector3f diff = *this - rhs;
-    return diff.dot();
+    return diff.squaredLength();
 }
 
 /// @addr{0x8019ADE0}

--- a/source/egg/math/Vector.hh
+++ b/source/egg/math/Vector.hh
@@ -155,7 +155,7 @@ struct Vector3f {
     }
 
     [[nodiscard]] Vector3f cross(const EGG::Vector3f &rhs) const;
-    [[nodiscard]] f32 dot() const;
+    [[nodiscard]] f32 squaredLength() const;
     [[nodiscard]] f32 dot(const EGG::Vector3f &rhs) const;
     [[nodiscard]] f32 ps_dot() const;
     [[nodiscard]] f32 ps_dot(const EGG::Vector3f &rhs) const;

--- a/source/game/field/ObjectCollisionBase.cc
+++ b/source/game/field/ObjectCollisionBase.cc
@@ -76,12 +76,12 @@ bool ObjectCollisionBase::check(ObjectCollisionBase &rhs, EGG::Vector3f &distanc
             return true;
         }
 
-        max = EGG::Mathf::sqrt(D.dot());
+        max = D.length();
 
         if (max2 - max * max <= std::numeric_limits<f32>::epsilon() * max2) {
             FUN_808350e4(state, D);
             getNearestPoint(state, state.m_flags, v0, v1);
-            f32 len = EGG::Mathf::sqrt(D.dot());
+            f32 len = D.length();
             v0 -= D * (getBoundingRadius() / len);
             v1 += D * (rhs.getBoundingRadius() / len);
 
@@ -123,7 +123,7 @@ void ObjectCollisionBase::FUN_808350e4(GJKState &state, EGG::Vector3f &v) const 
         EGG::Vector3f tmp = EGG::Vector3f::zero;
         getNearestPoint(state, mask, tmp);
 
-        sqLen = tmp.dot();
+        sqLen = tmp.squaredLength();
         if (sqLen < min) {
             state.m_flags = mask;
             v = tmp;
@@ -240,7 +240,7 @@ void ObjectCollisionBase::calcSimplex(GJKState &state) const {
     }
 
     state.m_scales[state.m_mask][idx] = 1.0f;
-    s_dotProductCache[idx][idx] = state.m_s[idx].dot();
+    s_dotProductCache[idx][idx] = state.m_s[idx].squaredLength();
 
     for (u32 i = 0, iMask = 1; i < 4; ++i, iMask *= 2) {
         if ((state.m_flags & iMask) == 0) {

--- a/source/game/kart/KartCollide.cc
+++ b/source/game/kart/KartCollide.cc
@@ -476,7 +476,7 @@ void KartCollide::calcSideCollision(CollisionData &collisionData, Hitbox &hitbox
         if (Field::CollisionDirector::Instance()->checkSphereCachedPartial(effectivePos,
                     hitbox.lastPos(), KCL_TYPE_DRIVER_WALL, &tempColInfo, nullptr,
                     hitbox.radius())) {
-            tangents[i] = colInfo->tangentOff.dot();
+            tangents[i] = colInfo->tangentOff.squaredLength();
         }
     }
 
@@ -727,7 +727,7 @@ void KartCollide::applySomeFloorMoment(f32 down, f32 rate, CollisionGroup *hitbo
     crossVec = colData.floorNrm.cross(negSpeed);
     crossVec = crossVec.cross(colData.floorNrm);
 
-    if (std::numeric_limits<f32>::epsilon() >= crossVec.dot()) {
+    if (std::numeric_limits<f32>::epsilon() >= crossVec.squaredLength()) {
         return;
     }
 

--- a/source/game/kart/KartDynamics.cc
+++ b/source/game/kart/KartDynamics.cc
@@ -110,13 +110,13 @@ void KartDynamics::calc(f32 dt, f32 maxSpeed, bool /*air*/) {
     EGG::Vector3f playerBackHoriz = playerBack;
     playerBackHoriz.y = 0.0f;
 
-    if (std::numeric_limits<f32>::epsilon() < playerBackHoriz.dot()) {
+    if (std::numeric_limits<f32>::epsilon() < playerBackHoriz.squaredLength()) {
         playerBackHoriz.normalise();
         const auto [proj, rej] = m_extVel.projAndRej(playerBackHoriz);
         const EGG::Vector3f &speedBack = proj;
         m_extVel = rej;
 
-        f32 norm = speedBack.dot();
+        f32 norm = speedBack.squaredLength();
         if (std::numeric_limits<f32>::epsilon() < norm) {
             norm = EGG::Mathf::sqrt(norm);
         } else {
@@ -147,10 +147,10 @@ void KartDynamics::calc(f32 dt, f32 maxSpeed, bool /*air*/) {
 
     EGG::Vector3f angVelSum = m_angVel2 + m_angVel1 + m_angVel0Factor * m_angVel0;
 
-    if (std::numeric_limits<f32>::epsilon() < angVelSum.dot()) {
+    if (std::numeric_limits<f32>::epsilon() < angVelSum.squaredLength()) {
         m_mainRot += m_mainRot.multSwap(angVelSum) * (dt * 0.5f);
 
-        if (EGG::Mathf::abs(m_mainRot.dot()) < std::numeric_limits<f32>::epsilon()) {
+        if (EGG::Mathf::abs(m_mainRot.norm()) < std::numeric_limits<f32>::epsilon()) {
             m_mainRot = EGG::Quatf::ident;
         } else {
             m_mainRot.normalise();
@@ -161,7 +161,7 @@ void KartDynamics::calc(f32 dt, f32 maxSpeed, bool /*air*/) {
         stabilize();
     }
 
-    if (EGG::Mathf::abs(m_mainRot.dot()) < std::numeric_limits<f32>::epsilon()) {
+    if (EGG::Mathf::abs(m_mainRot.norm()) < std::numeric_limits<f32>::epsilon()) {
         m_mainRot = EGG::Quatf::ident;
     } else {
         m_mainRot.normalise();

--- a/source/game/kart/KartJump.cc
+++ b/source/game/kart/KartJump.cc
@@ -183,7 +183,7 @@ void KartJump::setAngle(const EGG::Vector3f &left) {
 
     f32 vel1YDot = m_move->vel1Dir().dot(EGG::Vector3f::ey);
     EGG::Vector3f vel1YCross = m_move->vel1Dir().cross(EGG::Vector3f::ey);
-    f32 vel1YCrossMag = EGG::Mathf::sqrt(vel1YCross.dot());
+    f32 vel1YCrossMag = vel1YCross.length();
     f32 pitch = EGG::Mathf::abs(EGG::Mathf::atan2(vel1YCrossMag, vel1YDot));
     f32 angle = 90.0f - (pitch * RAD2DEG);
     u32 weightClass = static_cast<u32>(param()->stats().weightClass);

--- a/source/game/kart/KartMove.cc
+++ b/source/game/kart/KartMove.cc
@@ -516,7 +516,7 @@ void KartMove::calcDirs() {
 
         EGG::Vector3f dirDiff = local_b8 - m_dir;
 
-        if (dirDiff.dot() <= std::numeric_limits<f32>::epsilon()) {
+        if (dirDiff.squaredLength() <= std::numeric_limits<f32>::epsilon()) {
             m_dir = local_b8;
             m_dirDiff.setZero();
         } else {
@@ -546,7 +546,7 @@ void KartMove::calcDirs() {
     if (m_hasLandingDir) {
         f32 dot = m_dir.dot(m_landingDir);
         EGG::Vector3f cross = m_dir.cross(m_landingDir);
-        f32 crossDot = EGG::Mathf::sqrt(cross.dot());
+        f32 crossDot = cross.length();
         f32 angle = EGG::Mathf::atan2(crossDot, dot);
         angle = EGG::Mathf::abs(angle);
 
@@ -1577,7 +1577,7 @@ void KartMove::calcDive() {
     EGG::Vector3f forwardRotated = dynamics()->mainRot().rotateVector(EGG::Vector3f::ez);
     f32 upDotTop = m_up.dot(topRotated);
     EGG::Vector3f upCrossTop = m_up.cross(topRotated);
-    f32 crossNorm = EGG::Mathf::sqrt(upCrossTop.dot());
+    f32 crossNorm = upCrossTop.length();
     f32 angle = EGG::Mathf::abs(EGG::Mathf::atan2(crossNorm, upDotTop));
 
     f32 fVar1 = angle * RAD2DEG - 20.0f;
@@ -1654,7 +1654,7 @@ void KartMove::calcVehicleRotation(f32 turn) {
         EGG::Vector3f frontSpeed = velocity().rej(front).perpInPlane(m_up, false);
         f32 magnitude = tiltMagnitude;
 
-        if (frontSpeed.dot() > std::numeric_limits<f32>::epsilon()) {
+        if (frontSpeed.squaredLength() > std::numeric_limits<f32>::epsilon()) {
             magnitude = frontSpeed.length();
 
             if (front.z * frontSpeed.x - front.x * frontSpeed.z > 0.0f) {
@@ -2418,7 +2418,7 @@ void KartMoveBike::calcVehicleRotation(f32 turn) {
         scalar = std::min(1.0f, scalar);
         top = scalar * m_up + (1.0f - scalar) * EGG::Vector3f::ey;
 
-        if (std::numeric_limits<f32>::epsilon() < top.dot()) {
+        if (std::numeric_limits<f32>::epsilon() < top.squaredLength()) {
             top.normalise();
         }
     }


### PR DESCRIPTION
When the dot product is less than epsilon, we expect to return 0.0f. Also renaming `dot()` to `squareLength` to better represent the significance of what this function is used for.