### PR TITLE
Implement Rail, RailInterpolator, and RailManager

### DIFF
--- a/source/egg/math/Vector.cc
+++ b/source/egg/math/Vector.cc
@@ -52,6 +52,14 @@ f32 Vector3f::normalise() {
     return len;
 }
 
+/// @addr{0x80243B6C}
+void Vector3f::normalise2() {
+    f32 sqLen = squaredLength();
+    if (sqLen > std::numeric_limits<f32>::epsilon()) {
+        *this *= Mathf::frsqrt(sqLen);
+    }
+}
+
 /// @addr{0x80085580}
 /// @brief Returns a vector whose elements are the max of the elements of both vectors.
 Vector3f Vector3f::maximize(const Vector3f &rhs) const {

--- a/source/egg/math/Vector.hh
+++ b/source/egg/math/Vector.hh
@@ -216,10 +216,17 @@ struct Vector3f {
         return diff.squaredLength();
     }
 
+    /// @addr{0x806A62A4}
+    /// @brief Multiplies a vector by the inverse of val.
+    [[nodiscard]] EGG::Vector3f multInv(f32 val) const {
+        return *this * (1.0f / val);
+    }
+
     [[nodiscard]] f32 ps_dot() const;
     [[nodiscard]] f32 ps_dot(const EGG::Vector3f &rhs) const;
     [[nodiscard]] f32 ps_squareMag() const;
     f32 normalise();
+    void normalise2();
     [[nodiscard]] Vector3f maximize(const Vector3f &rhs) const;
     [[nodiscard]] Vector3f minimize(const Vector3f &rhs) const;
     [[nodiscard]] f32 ps_sqDistance(const Vector3f &rhs) const;

--- a/source/game/field/Rail.cc
+++ b/source/game/field/Rail.cc
@@ -1,0 +1,283 @@
+#include "Rail.hh"
+
+#include "game/field/CollisionDirector.hh"
+
+namespace Field {
+
+/// @addr{0x806EC9A4}
+Rail::Rail(u16 idx, System::MapdataPointInfo *info) {
+    m_idx = idx;
+    m_pointCapacity = info->pointCount();
+    m_pointCount = info->pointCount();
+    m_isOscillating = info->setting(1) == 1;
+    m_points = info->points();
+    m_hasCheckedCol = false;
+    m_someScale = 0.1f;
+}
+
+/// @addr{0x806ECC40}
+/// TODO: If we make m_points allocate on the heap, then we need to free here
+Rail::~Rail() {
+    delete m_floorNrms.data();
+}
+
+/// @addr{0x806ED110}
+void Rail::addPoint(f32 scale, const EGG::Vector3f &point) {
+    m_points.back().pos = point;
+    m_someScale = scale;
+    onPointAdded();
+}
+
+/// @addr{0x806ECCC0}
+void Rail::checkSphereFull() {
+    if (m_hasCheckedCol) {
+        return;
+    }
+
+    m_floorNrms = std::span<EGG::Vector3f>(new EGG::Vector3f[m_pointCount], m_pointCount);
+
+    for (size_t i = 0; i < m_pointCount; ++i) {
+        CollisionInfo info;
+        info.bbox.setZero();
+
+        bool hasCourseCol = CollisionDirector::Instance()->checkSphereFull(100.0f, m_points[i].pos,
+                EGG::Vector3f::inf, KCL_TYPE_FLOOR, &info, nullptr, 0);
+
+        if (hasCourseCol) {
+            if (info.floorDist > std::numeric_limits<f32>::min()) {
+                m_floorNrms[i] = info.floorNrm;
+            }
+        } else {
+            m_floorNrms[i] = EGG::Vector3f::ey;
+        }
+    }
+
+    m_hasCheckedCol = true;
+}
+
+/// @addr{0x806EF9B4}
+RailLine::RailLine(u16 idx, System::MapdataPointInfo *info) : Rail(idx, info) {
+    m_dirCount = m_isOscillating ? m_pointCount - 1 : m_pointCount;
+    m_transitions = std::span<RailLineTransition>(new RailLineTransition[m_dirCount], m_dirCount);
+    m_pathLength = 0.0f;
+
+    for (u16 i = 0; i < m_pointCount - 1; ++i) {
+        auto &transition = m_transitions[i];
+        transition.m_dir = m_points[i + 1].pos - m_points[i].pos;
+        transition.m_length = transition.m_dir.normalise();
+        transition.m_lengthInv = 1.0f / transition.m_length;
+        m_pathLength += transition.m_length;
+    }
+
+    if (!m_isOscillating) {
+        auto &transition = m_transitions.back();
+        transition.m_dir = m_points.front().pos - m_points.back().pos;
+        transition.m_length = transition.m_dir.normalise();
+        transition.m_lengthInv = 1.0f / transition.m_length;
+        m_pathLength += transition.m_length;
+    }
+}
+
+/// @addr{0x806EFD6C}
+RailLine::~RailLine() {
+    delete m_transitions.data();
+}
+
+/// @addr{0x806ED57C}
+RailSpline::RailSpline(u16 idx, System::MapdataPointInfo *info) : Rail(idx, info) {
+    m_transitionCount = m_isOscillating ? m_pointCount - 1 : m_pointCount;
+    m_transitions = std::span<RailSplineTransition>(new RailSplineTransition[m_transitionCount],
+            m_transitionCount);
+    m_estimatorSampleCount = 10;
+    m_estimatorStep = 1.0f / static_cast<f32>(m_estimatorSampleCount);
+
+    // This is normally not set until AFTER the call to invalidateTransitions,
+    // but the expected behavior requires that this is set to false.
+    // This misordering was probably never noticed since EGG::Heap zeroes memory.
+    m_doNotAllocatePathPercentages = false;
+
+    invalidateTransitions(false);
+
+    m_pathLength = 0.0f;
+
+    for (size_t i = 0; i < m_transitionCount; ++i) {
+        m_pathLength += m_transitions[i].m_length;
+    }
+}
+
+/// @addr{0x806ED828}
+RailSpline::~RailSpline() {
+    delete m_transitions.data();
+    delete m_pathPercentages.data();
+}
+
+/// @addr{0x806ED8BC}
+void RailSpline::onPointsChanged() {
+    m_doNotAllocatePathPercentages = true;
+    m_transitionCount = m_isOscillating ? m_pointCount - 1 : m_pointCount;
+
+    invalidateTransitions(false);
+
+    m_pathLength = 0.0f;
+
+    for (auto &transition : m_transitions) {
+        m_pathLength += transition.m_length;
+    }
+}
+
+/// @addr{0x806ED960}
+void RailSpline::onPointAdded() {
+    m_doNotAllocatePathPercentages = true;
+    m_transitionCount = m_isOscillating ? m_pointCount - 1 : m_pointCount;
+
+    invalidateTransitions(true);
+
+    m_pathLength = 0.0f;
+
+    for (auto &transition : m_transitions) {
+        m_pathLength += transition.m_length;
+    }
+}
+
+/// @addr{0x806EDA04}
+void RailSpline::invalidateTransitions(bool lastOnly) {
+    if (!m_doNotAllocatePathPercentages) {
+        size_t count = m_estimatorSampleCount * m_transitionCount + 1;
+        m_pathPercentages = std::span<f32>(new f32[count], count);
+    }
+
+    m_segmentCount = 0;
+
+    if (m_isOscillating) {
+        if (!lastOnly) {
+            auto &firstTransition = m_transitions[0];
+            firstTransition.m_p0 = m_points[0].pos;
+            firstTransition.m_p1 =
+                    (m_points[1].pos - m_points[0].pos).multInv(4.0f) + m_points[0].pos;
+            firstTransition.m_p2 =
+                    calcCubicBezierP2(m_points[0].pos, m_points[1].pos, m_points[2].pos);
+            firstTransition.m_p3 = m_points[1].pos;
+            firstTransition.m_length = estimateLength(firstTransition, m_estimatorSampleCount);
+            firstTransition.m_lengthInv = 1.0f / firstTransition.m_length;
+
+            for (u16 i = 1; i < m_transitionCount - 1; ++i) {
+                calcCubicBezierControlPoints(m_points[i - 1].pos, m_points[i].pos,
+                        m_points[i + 1].pos, m_points[i + 2].pos, m_estimatorSampleCount,
+                        m_transitions[i]);
+            }
+        }
+
+        auto &lastTransition = m_transitions.back();
+        lastTransition.m_p0 = m_points[m_transitionCount - 1].pos;
+        lastTransition.m_p1 = calcCubicBezierP1(m_points[m_transitionCount - 2].pos,
+                m_points[m_transitionCount - 1].pos, m_points[m_transitionCount].pos);
+        lastTransition.m_p2 =
+                (m_points[m_transitionCount - 1].pos - m_points[m_transitionCount].pos)
+                        .multInv(4.0f) +
+                m_points[m_transitionCount].pos;
+        lastTransition.m_p3 = m_points[m_transitionCount].pos;
+        lastTransition.m_length = estimateLength(lastTransition, m_estimatorSampleCount);
+        lastTransition.m_lengthInv = 1.0f / lastTransition.m_length;
+    } else {
+        if (!lastOnly) {
+            auto &firstTransition = m_transitions[0];
+            firstTransition.m_p0 = m_points[0].pos;
+            firstTransition.m_p1 = calcCubicBezierP1(m_points[m_transitionCount - 1].pos,
+                    m_points[0].pos, m_points[1].pos);
+            firstTransition.m_p2 =
+                    calcCubicBezierP2(m_points[0].pos, m_points[1].pos, m_points[2].pos);
+            firstTransition.m_p3 = m_points[1].pos;
+            firstTransition.m_length = estimateLength(firstTransition, m_estimatorSampleCount);
+            firstTransition.m_lengthInv = 1.0f / firstTransition.m_length;
+
+            for (u16 i = 1; i < m_transitionCount - 1; ++i) {
+                if (i + 2 != m_transitionCount) {
+                    calcCubicBezierControlPoints(m_points[i - 1].pos, m_points[i].pos,
+                            m_points[i + 1].pos, m_points[i + 2].pos, m_estimatorSampleCount,
+                            m_transitions[i]);
+                } else {
+                    calcCubicBezierControlPoints(m_points[i - 1].pos, m_points[i].pos,
+                            m_points[i + 1].pos, m_points[0].pos, m_estimatorSampleCount,
+                            m_transitions[i]);
+                }
+            }
+        }
+
+        auto &lastTransition = m_transitions.back();
+        lastTransition.m_p0 = m_points[m_transitionCount - 1].pos;
+        lastTransition.m_p1 = calcCubicBezierP1(m_points[m_transitionCount - 2].pos,
+                m_points[m_transitionCount - 1].pos, m_points[0].pos);
+        lastTransition.m_p2 = calcCubicBezierP2(m_points[m_transitionCount - 1].pos,
+                m_points[0].pos, m_points[1].pos);
+        lastTransition.m_p3 = m_points[0].pos;
+        lastTransition.m_length = estimateLength(lastTransition, m_estimatorSampleCount);
+        lastTransition.m_lengthInv = 1.0f / lastTransition.m_length;
+    }
+}
+
+/// @addr{0x806EE27C}
+void RailSpline::calcCubicBezierControlPoints(const EGG::Vector3f &p0, const EGG::Vector3f &p1,
+        const EGG::Vector3f &p2, const EGG::Vector3f &p3, s32 count,
+        RailSplineTransition &transition) {
+    transition.m_p0 = p1;
+    transition.m_p1 = calcCubicBezierP1(p0, p1, p2);
+    transition.m_p2 = calcCubicBezierP2(p1, p2, p3);
+    transition.m_p3 = p2;
+    transition.m_length = estimateLength(transition, count);
+    transition.m_lengthInv = 1.0f / transition.m_length;
+}
+
+/// @addr{0x806EE56C}
+f32 RailSpline::estimateLength(const RailSplineTransition &transition, s32 count) {
+    std::array<EGG::Vector3f, 11> waypoints;
+
+    for (s32 i = 0; i < count + 1; ++i) {
+        waypoints[i] = cubicBezier(m_estimatorStep * static_cast<f32>(i), transition);
+    }
+    f32 length = 0.0f;
+
+    // Numerator loop
+    for (s32 i = 0; i < count; ++i) {
+        m_pathPercentages[m_segmentCount++] = length;
+        length += (waypoints[i] - waypoints[i + 1]).length();
+    }
+
+    // Denominator loop
+    for (s32 i = m_segmentCount - 1; i > m_segmentCount - count - 1; --i) {
+        m_pathPercentages[i] /= length;
+    }
+
+    return length;
+}
+
+/// @addr{0x806EE408}
+EGG::Vector3f RailSpline::calcCubicBezierP1(const EGG::Vector3f &p0, const EGG::Vector3f &p1,
+        const EGG::Vector3f &p2) const {
+    EGG::Vector3f res = p2 - p0;
+    f32 len = res.length();
+    res.normalise2();
+    return p1 + res * (len * m_someScale);
+}
+
+/// @addr{0x806EE4B8}
+EGG::Vector3f RailSpline::calcCubicBezierP2(const EGG::Vector3f &p0, const EGG::Vector3f &p1,
+        const EGG::Vector3f &p2) const {
+    EGG::Vector3f res = p0 - p2;
+    f32 len = res.length();
+    res.normalise2();
+    return p1 + res * (len * m_someScale);
+}
+
+/// @addr{0x806EE72C}
+EGG::Vector3f RailSpline::cubicBezier(f32 t, const RailSplineTransition &transition) const {
+    f32 dt = 1.0f - t;
+
+    EGG::Vector3f res = transition.m_p0 * (dt * dt * dt);
+    res += transition.m_p1 * (3.0f * t * (dt * dt));
+    res += transition.m_p2 * (3.0f * (t * t) * dt);
+    res += transition.m_p3 * (t * t * t);
+
+    return res;
+}
+
+} // namespace Field

--- a/source/game/field/Rail.hh
+++ b/source/game/field/Rail.hh
@@ -1,0 +1,185 @@
+#pragma once
+
+#include "game/system/map/MapdataPointInfo.hh"
+
+namespace Field {
+
+struct RailLineTransition {
+    f32 m_length;
+    f32 m_lengthInv;
+    EGG::Vector3f m_dir;
+};
+
+struct RailSplineTransition {
+    EGG::Vector3f m_p0;
+    EGG::Vector3f m_p1;
+    EGG::Vector3f m_p2;
+    EGG::Vector3f m_p3;
+    f32 m_length;
+    f32 m_lengthInv;
+};
+
+class Rail {
+public:
+    Rail(u16 idx, System::MapdataPointInfo *info);
+    virtual ~Rail();
+
+    virtual f32 getPathLength() const = 0;
+    virtual const std::span<RailLineTransition> &getLinearTransitions() const = 0;
+    virtual const std::span<RailSplineTransition> &getSplineTransitions() const = 0;
+    virtual s32 getEstimatorSampleCount() const = 0;
+    virtual f32 getEstimatorStep() const = 0;
+    virtual const std::span<f32> &getPathPercentages() const = 0;
+
+    void addPoint(f32 scale, const EGG::Vector3f &point);
+    void checkSphereFull();
+
+    [[nodiscard]] u16 pointCount() const {
+        return m_pointCount;
+    }
+
+    [[nodiscard]] bool isOscillating() const {
+        return m_isOscillating;
+    }
+
+    [[nodiscard]] const std::span<System::MapdataPointInfo::Point> &points() const {
+        return m_points;
+    }
+
+    /// @addr{0x806ED150}
+    [[nodiscard]] const EGG::Vector3f &pointPos(u16 idx) const {
+        ASSERT(idx < m_pointCount);
+        return m_points[idx].pos;
+    }
+
+    [[nodiscard]] const EGG::Vector3f &floorNrm(u16 idx) const {
+        ASSERT(m_floorNrms.data() && idx < m_floorNrms.size());
+        return m_floorNrms[idx];
+    }
+
+protected:
+    virtual void onPointsChanged() = 0;
+    virtual void onPointAdded() = 0;
+
+    u16 m_pointCount;
+    bool m_isOscillating;
+    std::span<System::MapdataPointInfo::Point> m_points;
+    f32 m_someScale;
+
+private:
+    u16 m_idx;
+    u16 m_pointCapacity;
+    bool m_hasCheckedCol;
+    std::span<EGG::Vector3f> m_floorNrms;
+};
+
+class RailLine : public Rail {
+public:
+    RailLine(u16 idx, System::MapdataPointInfo *info);
+    ~RailLine() override;
+
+    /// @addr{0x806F09A8}
+    [[nodiscard]] s32 getEstimatorSampleCount() const override {
+        return 0;
+    }
+
+    /// @addr{0x806F099C}
+    [[nodiscard]] f32 getEstimatorStep() const override {
+        return 0.0f;
+    }
+
+    /// @addr{0x806F0994}
+    /// @brief In the base game we return a nullptr. To mimic this, return an empty vector.
+    [[nodiscard]] const std::span<f32> &getPathPercentages() const override {
+        static std::span<f32> EMPTY_PERCENTAGES;
+        return EMPTY_PERCENTAGES;
+    }
+
+private:
+    /// @addr{0x806F09C0}
+    [[nodiscard]] f32 getPathLength() const override {
+        return m_pathLength;
+    }
+
+    /// @addr{0x806F09B8}
+    [[nodiscard]] const std::span<RailLineTransition> &getLinearTransitions() const override {
+        return m_transitions;
+    }
+
+    /// @addr{0x806F09B0}
+    /// @brief In the base game we return a nullptr. To mimic this, return an empty vector.
+    [[nodiscard]] const std::span<RailSplineTransition> &getSplineTransitions() const override {
+        static std::span<RailSplineTransition> EMPTY_TRANSITIONS;
+        return EMPTY_TRANSITIONS;
+    }
+
+    void onPointsChanged() override {}
+    void onPointAdded() override {}
+
+    u16 m_dirCount;
+    std::span<RailLineTransition> m_transitions;
+    f32 m_pathLength;
+};
+
+class RailSpline : public Rail {
+public:
+    RailSpline(u16 idx, System::MapdataPointInfo *info);
+    ~RailSpline() override;
+
+    /// @addr{0x806EF994}
+    [[nodiscard]] s32 getEstimatorSampleCount() const override {
+        return m_estimatorSampleCount;
+    }
+
+    /// @addr{0x806EF98C}
+    [[nodiscard]] f32 getEstimatorStep() const override {
+        return m_estimatorStep;
+    }
+
+    /// @addr{0x806EF984}
+    [[nodiscard]] const std::span<f32> &getPathPercentages() const override {
+        return m_pathPercentages;
+    }
+
+private:
+    /// @addr{0x806EF9AC}
+    [[nodiscard]] f32 getPathLength() const override {
+        return m_pathLength;
+    }
+
+    /// @addr{0x806EF9A4}
+    [[nodiscard]] const std::span<RailLineTransition> &getLinearTransitions() const override {
+        static std::span<RailLineTransition> EMPTY_TRANSITIONS;
+        return EMPTY_TRANSITIONS;
+    }
+
+    /// @addr{0x806EF99C}
+    [[nodiscard]] const std::span<RailSplineTransition> &getSplineTransitions() const override {
+        return m_transitions;
+    }
+
+    void onPointsChanged() override;
+    void onPointAdded() override;
+
+    void invalidateTransitions(bool lastOnly);
+    void calcCubicBezierControlPoints(const EGG::Vector3f &p0, const EGG::Vector3f &p1,
+            const EGG::Vector3f &p2, const EGG::Vector3f &p3, s32 count,
+            RailSplineTransition &transition);
+    [[nodiscard]] f32 estimateLength(const RailSplineTransition &transition, s32 count);
+    [[nodiscard]] EGG::Vector3f calcCubicBezierP1(const EGG::Vector3f &p0, const EGG::Vector3f &p1,
+            const EGG::Vector3f &p2) const;
+    [[nodiscard]] EGG::Vector3f calcCubicBezierP2(const EGG::Vector3f &p0, const EGG::Vector3f &p1,
+            const EGG::Vector3f &p2) const;
+    [[nodiscard]] EGG::Vector3f cubicBezier(f32 t, const RailSplineTransition &transition) const;
+
+    u16 m_transitionCount;
+    std::span<RailSplineTransition> m_transitions;
+    u32 m_estimatorSampleCount;
+    f32 m_estimatorStep;
+    std::span<f32> m_pathPercentages;
+    s32 m_segmentCount;
+    f32 m_pathLength;
+    bool m_doNotAllocatePathPercentages;
+};
+
+} // namespace Field

--- a/source/game/field/RailInterpolator.cc
+++ b/source/game/field/RailInterpolator.cc
@@ -1,0 +1,489 @@
+#include "RailInterpolator.hh"
+
+#include "game/field/RailManager.hh"
+
+namespace Field {
+
+/// @addr{0x806ED160}
+RailInterpolator::RailInterpolator(f32 speed, u32 idx) {
+    m_railIdx = idx;
+    auto *rail = RailManager::Instance()->rail(idx);
+    m_pointCount = rail->pointCount();
+    m_points = rail->points();
+    m_isOscillating = rail->isOscillating();
+    m_speed = speed;
+}
+
+/// @addr{0x806ED53C}
+RailInterpolator::~RailInterpolator() = default;
+
+/// @addr{0806ED24C}
+const EGG::Vector3f &RailInterpolator::floorNrm(size_t idx) const {
+    return RailManager::Instance()->rail(idx)->floorNrm(idx);
+}
+
+/// @addr{0x806ED30C}
+f32 RailInterpolator::railLength() const {
+    return RailManager::Instance()->rail(m_railIdx)->getPathLength();
+}
+
+/// @addr{0x806ED3E4}
+void RailInterpolator::updateVel() {
+    f32 t = m_segmentT;
+    setCurrVel((1.0f - t) * m_prevPointVel + t * m_nextPointVel);
+}
+
+/// @addr{0x806ED34C}
+void RailInterpolator::calcVelocities() {
+    m_prevPointVel = static_cast<f32>(m_points[m_currPointIdx].setting[0]);
+    m_nextPointVel = static_cast<f32>(m_points[m_nextPointIdx].setting[0]);
+
+    if (m_prevPointVel == 0.0f) {
+        m_prevPointVel = m_speed;
+    }
+
+    if (m_nextPointVel == 0.0f) {
+        m_nextPointVel = m_speed;
+    }
+}
+
+/// @addr{0x806F0814}
+bool RailInterpolator::shouldChangeDirection() const {
+    if (!m_isOscillating) {
+        return m_pointCount == m_nextPointIdx;
+    }
+
+    return m_movementDirectionForward ? m_nextPointIdx == m_pointCount : m_nextPointIdx == -1;
+}
+
+/// @addr{0x806F0880}
+void RailInterpolator::calcDirectionChange() {
+    if (!m_isOscillating) {
+        return;
+    }
+
+    if (m_movementDirectionForward) {
+        m_nextPointIdx -= 2;
+    } else {
+        m_nextPointIdx += 2;
+    }
+
+    m_movementDirectionForward = !m_movementDirectionForward;
+}
+
+void RailInterpolator::calcNextIndices() {
+    if (m_movementDirectionForward) {
+        ++m_currPointIdx;
+        ++m_nextPointIdx;
+    } else {
+        --m_currPointIdx;
+        --m_nextPointIdx;
+    }
+
+    if (!m_isOscillating) {
+        if (m_nextPointIdx == m_pointCount) {
+            m_nextPointIdx = 0;
+        }
+
+        if (m_currPointIdx == m_pointCount) {
+            m_currPointIdx = 0;
+        }
+    }
+}
+
+/// @addr{0x806EFDC4}
+RailLinearInterpolator::RailLinearInterpolator(f32 speed, u32 idx) : RailInterpolator(speed, idx) {
+    m_transitions = RailManager::Instance()->rail(m_railIdx)->getLinearTransitions();
+    init(0.0f, 0);
+}
+
+/// @addr{0x806F094C}
+RailLinearInterpolator::~RailLinearInterpolator() = default;
+
+/// @addr{0x806EFEAC}
+void RailLinearInterpolator::init(f32 t, u32 idx) {
+    m_segmentT = t;
+    m_currPointIdx = idx;
+
+    bool isLastPoint = (static_cast<u16>(idx) == m_pointCount - 1);
+    m_nextPointIdx = isLastPoint ? idx - 1 : idx + 1;
+    m_movementDirectionForward = isLastPoint ? !m_isOscillating : true;
+
+    m_curPos = m_points[m_currPointIdx].pos;
+    m_currentDirection = m_points[m_nextPointIdx].pos - m_curPos;
+    m_curTangentDir = m_currentDirection;
+    m_curTangentDir.normalise2();
+    m_currVel = m_speed;
+    m_prevPointVel = m_speed;
+    m_nextPointVel = m_speed;
+    m_4a = false;
+    m_usePerPointVelocities = false;
+    m_currSegmentVel = m_speed / m_currentDirection.length();
+}
+
+/// @addr{0x806F0050}
+RailInterpolator::Status RailLinearInterpolator::calc() {
+    if (m_4a) {
+        m_curPos = m_points[m_pointCount - 1].pos;
+
+        return Status::ChangingDirection;
+    }
+
+    if (m_usePerPointVelocities) {
+        updateVel();
+    }
+
+    m_segmentT += m_currSegmentVel;
+    m_curPos = lerp(m_segmentT, m_currPointIdx, m_nextPointIdx);
+
+    if (m_segmentT <= 1.0f) {
+        return Status::InProgress;
+    }
+
+    Status status = Status::SegmentEnd;
+
+    calcNextSegment();
+
+    if (shouldChangeDirection()) {
+        status = Status::ChangingDirection;
+
+        calcDirectionChange();
+    }
+
+    m_currentDirection = m_points[m_nextPointIdx].pos - m_points[m_currPointIdx].pos;
+    m_curTangentDir = m_currentDirection;
+    m_currSegmentVel = m_currVel / m_currentDirection.length();
+    m_curTangentDir.normalise2();
+
+    return status;
+}
+
+/// @addr{0x806EFFF4}
+void RailLinearInterpolator::setCurrVel(f32 speed) {
+    m_currVel = speed;
+    m_currSegmentVel = m_currVel / m_currentDirection.length();
+}
+
+/// @addr{0x806F02EC}
+void RailLinearInterpolator::evalCubicBezierOnPath(f32 t, EGG::Vector3f &currDir,
+        EGG::Vector3f &curTangentDir) {
+    s16 currIdx = 0;
+    f32 len = 0.0f;
+
+    getPathLocation(t, currIdx, len);
+
+    s16 nextIdx = currIdx + 1;
+    if (nextIdx == m_pointCount) {
+        nextIdx = 0;
+    }
+
+    currDir = m_points[currIdx].pos * (1.0f - len) + m_points[nextIdx].pos * len;
+    curTangentDir = m_transitions[currIdx].m_dir;
+}
+
+/// @addr{0x806F041C}
+void RailLinearInterpolator::getPathLocation(f32 t, s16 &idx, f32 &len) {
+    if (!m_movementDirectionForward) {
+        return;
+    }
+
+    f32 dist = m_segmentT * m_transitions[m_currPointIdx].m_length;
+    if (t <= dist) {
+        idx = m_currPointIdx;
+        len = (dist - t) * m_transitions[m_currPointIdx].m_lengthInv;
+        return;
+    }
+
+    for (s32 i = 0; i < m_pointCount; ++i) {
+        s32 currIdx = m_currPointIdx - 1;
+        if (currIdx == -1) {
+            currIdx = m_pointCount - 1;
+        }
+
+        currIdx -= i;
+        if (currIdx < 0) {
+            currIdx += m_pointCount;
+        }
+
+        dist += m_transitions[currIdx].m_length;
+        if (t <= dist) {
+            idx = currIdx;
+            len = (dist - t) * m_transitions[currIdx].m_lengthInv;
+            return;
+        }
+    }
+}
+
+/// @addr{0x806F0610}
+void RailLinearInterpolator::calcNextSegment() {
+    calcNextIndices();
+
+    f32 prevDirLength = m_currentDirection.length();
+    m_currentDirection = m_points[m_nextPointIdx].pos - m_points[m_currPointIdx].pos;
+    m_segmentT = ((m_segmentT - 1.0f) * prevDirLength) / m_currentDirection.length();
+
+    if (shouldChangeDirection()) {
+        m_segmentT = 0.0f;
+    }
+
+    if (m_segmentT > 1.0f) {
+        m_segmentT = 0.99f;
+    }
+
+    if (m_usePerPointVelocities) {
+        calcVelocities();
+    }
+}
+
+/// @addr{0x806F0540}
+EGG::Vector3f RailLinearInterpolator::lerp(f32 t, u32 currIdx, u32 nextIdx) const {
+    return m_points[currIdx].pos * (1.0f - t) + m_points[nextIdx].pos * t;
+}
+
+/// @addr{0x806EE830}
+RailSmoothInterpolator::RailSmoothInterpolator(f32 speed, u32 idx) : RailInterpolator(speed, idx) {
+    auto *rail = RailManager::Instance()->rail(m_railIdx);
+    m_transitions = rail->getSplineTransitions();
+    m_estimatorSampleCount = static_cast<u32>(rail->getEstimatorSampleCount());
+    m_estimatorStep = rail->getEstimatorStep();
+    m_pathPercentages = rail->getPathPercentages();
+
+    init(0.0f, 0);
+}
+
+/// @addr{0x806EF944}
+RailSmoothInterpolator::~RailSmoothInterpolator() = default;
+
+/// @addr{0x806EE924}
+void RailSmoothInterpolator::init(f32 t, u32 idx) {
+    m_segmentT = t;
+
+    m_currPointIdx = idx;
+
+    if (idx == static_cast<u32>(m_pointCount - 1) && m_isOscillating) {
+        m_nextPointIdx = m_currPointIdx - 1;
+        m_movementDirectionForward = false;
+        m_curTangentDir = calcCubicBezierTangentDir(m_segmentT, m_transitions[m_currPointIdx]);
+        m_currSegmentVel = m_currVel * m_transitions[m_nextPointIdx].m_lengthInv;
+    } else {
+        m_nextPointIdx = idx + 1 == m_pointCount ? 0 : idx + 1;
+        m_movementDirectionForward = true;
+        m_curTangentDir = calcCubicBezierTangentDir(m_segmentT, m_transitions[m_currPointIdx]);
+        m_currSegmentVel = m_currVel * m_transitions[m_currPointIdx].m_lengthInv;
+    }
+
+    m_curPos = m_points[m_currPointIdx].pos;
+    m_prevPos = m_points[m_currPointIdx].pos;
+    m_currVel = m_speed;
+    m_prevPointVel = m_speed;
+    m_nextPointVel = m_speed;
+    m_velocity = 0.0f;
+    m_4a = false;
+    m_usePerPointVelocities = false;
+}
+
+/// @addr{0x806EEBEC}
+RailInterpolator::Status RailSmoothInterpolator::calc() {
+    if (m_4a) {
+        m_curPos = m_transitions[m_pointCount - 2].m_p3;
+
+        return Status::ChangingDirection;
+    }
+
+    if (m_usePerPointVelocities) {
+        updateVel();
+    }
+
+    m_prevPos = m_curPos;
+
+    f32 t = m_movementDirectionForward ? calcT(m_segmentT) : calcT(1.0f - m_segmentT);
+
+    calcCubicBezier(t, m_currPointIdx, m_nextPointIdx, m_curPos, m_curTangentDir);
+
+    EGG::Vector3f deltaPos = m_curPos - m_prevPos;
+    m_velocity = deltaPos.length();
+    m_segmentT += m_currSegmentVel;
+
+    if (m_segmentT <= 1.0f) {
+        return Status::InProgress;
+    }
+
+    Status status = Status::SegmentEnd;
+
+    calcNextSegment();
+
+    if (shouldChangeDirection()) {
+        status = Status::ChangingDirection;
+
+        calcDirectionChange();
+    }
+
+    if (m_movementDirectionForward) {
+        m_currSegmentVel = m_currVel * m_transitions[m_currPointIdx].m_lengthInv;
+    } else {
+        m_currSegmentVel = m_currVel * m_transitions[m_nextPointIdx].m_lengthInv;
+    }
+
+    return status;
+}
+
+/// @addr{0x806EEB94}
+void RailSmoothInterpolator::setCurrVel(f32 speed) {
+    m_currVel = speed;
+
+    if (m_movementDirectionForward) {
+        m_currSegmentVel = speed * m_transitions[m_currPointIdx].m_lengthInv;
+    } else {
+        m_currSegmentVel = speed * m_transitions[m_nextPointIdx].m_lengthInv;
+    }
+}
+
+/// @addr{0x806EEEBC}
+void RailSmoothInterpolator::evalCubicBezierOnPath(f32 t, EGG::Vector3f &currDir,
+        EGG::Vector3f &curTangentDir) {
+    s16 currIdx = 0;
+    f32 len = 0.0f;
+
+    getPathLocation(t, currIdx, len);
+
+    s16 nextIdx = currIdx + 1;
+    if (nextIdx == m_pointCount) {
+        nextIdx = 0;
+    }
+
+    len = m_movementDirectionForward ? calcT(len) : calcT(1.0f - len);
+
+    calcCubicBezier(len, currIdx, nextIdx, currDir, curTangentDir);
+}
+
+/// @addr{0x806EEFA0}
+void RailSmoothInterpolator::getPathLocation(f32 t, s16 &idx, f32 &len) {
+    if (!m_movementDirectionForward) {
+        return;
+    }
+
+    f32 dist = m_segmentT * m_transitions[m_currPointIdx].m_length;
+    if (t <= dist) {
+        idx = m_currPointIdx;
+        len = (dist - t) * m_transitions[m_currPointIdx].m_lengthInv;
+        return;
+    }
+
+    for (s32 i = 0; i < m_pointCount; ++i) {
+        s32 currIdx = m_currPointIdx - 1;
+        if (currIdx == -1) {
+            currIdx = m_pointCount - 1;
+        }
+
+        currIdx -= i;
+        if (currIdx < 0) {
+            currIdx += m_pointCount;
+        }
+
+        dist += m_transitions[currIdx].m_length;
+        if (t <= dist) {
+            idx = currIdx;
+            len = (dist - t) * m_transitions[currIdx].m_lengthInv;
+            return;
+        }
+    }
+}
+
+/// @addr{0x806EF224}
+void RailSmoothInterpolator::calcCubicBezier(f32 t, u32 currIdx, u32 nextIdx, EGG::Vector3f &pos,
+        EGG::Vector3f &dir) const {
+    auto &transition = m_movementDirectionForward ? m_transitions[currIdx] : m_transitions[nextIdx];
+
+    pos = calcCubicBezierPos(t, transition);
+    dir = calcCubicBezierTangentDir(t, transition);
+}
+
+/// @addr{0x806EF350}
+EGG::Vector3f RailSmoothInterpolator::calcCubicBezierPos(f32 t,
+        const RailSplineTransition &trans) const {
+    f32 dt = 1.0f - t;
+
+    EGG::Vector3f res = trans.m_p0 * (dt * dt * dt);
+    res += trans.m_p1 * (3.0f * t * (dt * dt));
+    res += trans.m_p2 * (3.0f * (t * t) * dt);
+    res += trans.m_p3 * (t * t * t);
+
+    return res;
+}
+
+/// @addr{0x806EF454}
+EGG::Vector3f RailSmoothInterpolator::calcCubicBezierTangentDir(f32 t,
+        const RailSplineTransition &trans) const {
+    EGG::Vector3f c1 = trans.m_p0 * -1.0f + trans.m_p1 * 3.0f - (trans.m_p2 * 3.0f) + trans.m_p3;
+    EGG::Vector3f c2 = trans.m_p0 * 3.0f - trans.m_p1 * 6.0f + trans.m_p2 * 3.0f;
+    EGG::Vector3f c3 = trans.m_p0 * -3.0f + trans.m_p1 * 3.0f;
+    EGG::Vector3f ret = c1 * 3.0f * (t * t) + c2 * 2.0f * t + c3;
+
+    ret.normalise2();
+
+    if (!m_movementDirectionForward) {
+        ret *= -1.0f;
+    }
+
+    return ret;
+}
+
+/// @addr{0x806EF0F8}
+f32 RailSmoothInterpolator::calcT(f32 t) const {
+    u16 sampleIdx = m_movementDirectionForward ? m_currPointIdx * m_estimatorSampleCount :
+                                                 m_nextPointIdx * m_estimatorSampleCount;
+
+    f32 delta = 0.0f;
+    u16 idx = 0;
+
+    for (u16 i = 0; i < m_estimatorSampleCount - 1; ++i) {
+        f32 currPercent = m_pathPercentages[sampleIdx + i];
+        f32 nextPercent = m_pathPercentages[sampleIdx + i + 1];
+
+        if (currPercent <= t && nextPercent > t) {
+            delta = (t - currPercent) / (nextPercent - currPercent);
+            idx = i;
+        }
+    }
+
+    f32 lastPercent = m_pathPercentages[sampleIdx + m_estimatorSampleCount - 1];
+
+    if (lastPercent <= t && 1.0f >= t) {
+        idx = m_estimatorSampleCount - 1;
+        delta = (t - lastPercent) / (1.0f - lastPercent);
+    }
+
+    return m_estimatorStep * static_cast<f32>(idx) + m_estimatorStep * delta;
+}
+
+/// @addr{0x806EF664}
+void RailSmoothInterpolator::calcNextSegment() {
+    f32 nextT = m_segmentT - 1.0f;
+
+    if (m_isOscillating) {
+        if (m_nextPointIdx == 0 || m_nextPointIdx == m_pointCount - 1) {
+            m_segmentT = 0.0f;
+        } else if (m_movementDirectionForward) {
+            m_segmentT = nextT * m_transitions[m_currPointIdx].m_length *
+                    m_transitions[m_nextPointIdx].m_lengthInv;
+        } else {
+            m_segmentT = nextT * m_transitions[m_currPointIdx - 1].m_length *
+                    m_transitions[m_nextPointIdx - 1].m_lengthInv;
+        }
+    } else {
+        m_segmentT = nextT * m_transitions[m_currPointIdx].m_length *
+                m_transitions[m_nextPointIdx].m_lengthInv;
+    }
+
+    if (m_segmentT > 1.0f) {
+        m_segmentT = 0.99f;
+    }
+
+    calcNextIndices();
+
+    if (m_usePerPointVelocities) {
+        calcVelocities();
+    }
+}
+
+} // namespace Field

--- a/source/game/field/RailInterpolator.hh
+++ b/source/game/field/RailInterpolator.hh
@@ -1,0 +1,145 @@
+#pragma once
+
+#include <Common.hh>
+
+#include "game/field/Rail.hh"
+
+#include "game/system/map/MapdataPointInfo.hh"
+
+#include <egg/math/Vector.hh>
+
+namespace Field {
+
+class RailInterpolator {
+public:
+    enum class Status {
+        InProgress = 0,
+        SegmentEnd = 1,
+        ChangingDirection = 2,
+    };
+
+    RailInterpolator(f32 speed, u32 idx);
+    virtual ~RailInterpolator();
+
+    virtual void init(f32 t, u32 idx) = 0;
+    virtual Status calc() = 0;
+    virtual void setCurrVel(f32 speed) = 0;
+
+    virtual f32 getCurrVel() = 0;
+    virtual void evalCubicBezierOnPath(f32 t, EGG::Vector3f &currDir,
+            EGG::Vector3f &curTangentDir) = 0;
+    virtual void getPathLocation(f32 t, s16 &idx, f32 &len) = 0;
+
+    /// @addr{0x806C63A8}
+    void setT(f32 t) {
+        m_segmentT = t;
+    }
+
+    [[nodiscard]] const EGG::Vector3f &floorNrm(size_t idx) const;
+    [[nodiscard]] f32 railLength() const;
+
+    [[nodiscard]] const System::MapdataPointInfo::Point &curPoint() const {
+        ASSERT(static_cast<size_t>(m_currPointIdx) < m_points.size());
+        return m_points[m_currPointIdx];
+    }
+
+    [[nodiscard]] const EGG::Vector3f &curPos() const {
+        return m_curPos;
+    }
+
+    [[nodiscard]] const EGG::Vector3f &curTangentDir() const {
+        return m_curTangentDir;
+    }
+
+    [[nodiscard]] bool isMovementDirectionForward() const {
+        return m_movementDirectionForward;
+    }
+
+protected:
+    void updateVel();
+    void calcVelocities();
+    [[nodiscard]] bool shouldChangeDirection() const;
+    void calcDirectionChange();
+    void calcNextIndices();
+
+    s16 m_railIdx;
+    u16 m_pointCount;
+    std::span<System::MapdataPointInfo::Point> m_points;
+    bool m_isOscillating;
+    f32 m_speed;
+    bool m_usePerPointVelocities;
+    EGG::Vector3f m_curPos;
+    EGG::Vector3f m_curTangentDir;
+    f32 m_currVel;
+    f32 m_prevPointVel;
+    f32 m_nextPointVel;
+    f32 m_currSegmentVel;
+    f32 m_segmentT;
+    bool m_movementDirectionForward;
+    s16 m_currPointIdx;
+    s16 m_nextPointIdx;
+    bool m_4a;
+};
+
+class RailLinearInterpolator : public RailInterpolator {
+public:
+    RailLinearInterpolator(f32 speed, u32 idx);
+    ~RailLinearInterpolator() override;
+
+    void init(f32 t, u32 idx) override;
+    Status calc() override;
+    void setCurrVel(f32 speed) override;
+
+    /// @addr{0x806F0944}
+    [[nodiscard]] f32 getCurrVel() override {
+        return m_currVel;
+    }
+
+    void evalCubicBezierOnPath(f32 t, EGG::Vector3f &currDir,
+            EGG::Vector3f &curTangentDir) override;
+    void getPathLocation(f32 t, s16 &idx, f32 &len) override;
+
+private:
+    void calcNextSegment();
+    EGG::Vector3f lerp(f32 t, u32 currIdx, u32 nextIdx) const;
+
+    EGG::Vector3f m_currentDirection;
+    std::span<RailLineTransition> m_transitions;
+};
+
+class RailSmoothInterpolator : public RailInterpolator {
+public:
+    RailSmoothInterpolator(f32 speed, u32 idx);
+    ~RailSmoothInterpolator() override;
+
+    void init(f32 t, u32 idx) override;
+    Status calc() override;
+    void setCurrVel(f32 speed) override;
+
+    /// @addr{0x806EF93C}
+    [[nodiscard]] f32 getCurrVel() override {
+        return m_velocity;
+    }
+
+    void evalCubicBezierOnPath(f32 t, EGG::Vector3f &currDir,
+            EGG::Vector3f &curTangentDir) override;
+    void getPathLocation(f32 t, s16 &idx, f32 &len) override;
+
+private:
+    void calcCubicBezier(f32 t, u32 currIdx, u32 nextIdx, EGG::Vector3f &pos,
+            EGG::Vector3f &dir) const;
+    [[nodiscard]] EGG::Vector3f calcCubicBezierPos(f32 t, const RailSplineTransition &trans) const;
+    [[nodiscard]] EGG::Vector3f calcCubicBezierTangentDir(f32 t,
+            const RailSplineTransition &trans) const;
+    [[nodiscard]] f32 calcT(f32 t) const;
+    void calcNextSegment();
+
+    std::span<RailSplineTransition> m_transitions;
+    u32 m_estimatorSampleCount;
+    f32 m_estimatorStep;
+    std::span<f32> m_pathPercentages;
+    EGG::Vector3f m_prevPos;
+    f32 m_velocity;
+};
+
+} // namespace Field

--- a/source/game/field/RailManager.cc
+++ b/source/game/field/RailManager.cc
@@ -1,0 +1,92 @@
+#include "RailManager.hh"
+
+#include "game/system/CourseMap.hh"
+#include "game/system/map/MapdataGeoObj.hh"
+
+namespace Field {
+
+/// @addr{0x806F09C8}
+RailManager *RailManager::CreateInstance() {
+    ASSERT(!s_instance);
+    s_instance = new RailManager;
+    s_instance->createPaths();
+    return s_instance;
+}
+
+/// @addr{0x806F0A4C}
+void RailManager::DestroyInstance() {
+    ASSERT(s_instance);
+    auto *instance = s_instance;
+    s_instance = nullptr;
+    delete instance;
+}
+
+/// @addr{0x806F0A3C}
+RailManager::RailManager() = default;
+
+/// @addr{0x806F0A98}
+RailManager::~RailManager() = default;
+
+/// @addr{0x806F0AD8}
+void RailManager::createPaths() {
+    auto *courseMap = System::CourseMap::Instance();
+    m_pointCount = courseMap->getPointInfoCount();
+    m_extraInterplatorCount = 8;
+    u16 geoCount = courseMap->getGeoObjCount();
+    m_rails.reserve(m_pointCount + m_extraInterplatorCount);
+    m_interpolatorTotal = m_pointCount;
+
+    // For now, assume screenCount of 1 instead of calling into RaceScenario
+    m_cameraPointCount = m_pointCount * 1;
+    m_interpolatorTotal = m_pointCount * 1 + m_extraInterplatorCount;
+    m_cameraCount = 1;
+
+    // The base game indexes based on i and j, so we need to resize regardless of isObjectRoute.
+    m_interpolators = std::span<RailInterpolator *>(new RailInterpolator *[m_interpolatorTotal],
+            m_interpolatorTotal);
+
+    for (u16 i = 0; i < m_pointCount; ++i) {
+        bool isObjectRoute = false;
+        auto *pointInfo = courseMap->getPointInfo(i);
+        bool isSpline = pointInfo->setting(0);
+
+        for (u16 j = 0; j < geoCount; ++j) {
+            auto *geoObj = courseMap->getGeoObj(j);
+
+            if (geoObj->pathId() != i) {
+                continue;
+            }
+
+            if (isSpline) {
+                m_rails.push_back(new RailSpline(i, pointInfo));
+            } else {
+                m_rails.push_back(new RailLine(i, pointInfo));
+            }
+
+            isObjectRoute = true;
+            break;
+        }
+
+        if (isObjectRoute) {
+            continue;
+        }
+
+        if (isSpline) {
+            m_rails.push_back(new RailSpline(i, pointInfo));
+
+            for (u16 j = 0; j < m_cameraCount; ++j) {
+                m_interpolators[j + i * m_cameraCount] = new RailSmoothInterpolator(0.0f, i);
+            }
+        } else {
+            m_rails.push_back(new RailLine(i, pointInfo));
+
+            for (u16 j = 0; j < m_cameraCount; ++j) {
+                m_interpolators[j + i * m_cameraCount] = new RailLinearInterpolator(0.0f, i);
+            }
+        }
+    }
+}
+
+RailManager *RailManager::s_instance = nullptr; ///> @addr{0x809C22B0}
+
+} // namespace Field

--- a/source/game/field/RailManager.hh
+++ b/source/game/field/RailManager.hh
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "game/field/RailInterpolator.hh"
+
+#include <vector>
+
+namespace Field {
+
+// TODO: Inherit EGG::Disposer
+class RailManager {
+public:
+    /// @beginGetters
+    const Rail *rail(size_t idx) const {
+        ASSERT(idx < m_rails.size());
+        return m_rails[idx];
+    }
+    /// @endGetters
+
+    static RailManager *CreateInstance();
+    static void DestroyInstance();
+
+    static RailManager *Instance() {
+        return s_instance;
+    }
+
+private:
+    RailManager();
+    ~RailManager();
+
+    void createPaths();
+
+    std::vector<Rail *> m_rails;
+    std::span<RailInterpolator *> m_interpolators;
+    u16 m_totalRails;
+    u16 m_interpolatorTotal;
+    u16 m_extraInterplatorCount;
+    u16 m_pointCount;
+    u16 m_cameraPointCount;
+    u16 m_cameraCount;
+
+    static RailManager *s_instance; ///< @addr{0x809C22B0}
+};
+
+} // namespace Field

--- a/source/game/field/obj/ObjectBase.hh
+++ b/source/game/field/obj/ObjectBase.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "game/field/BoxColManager.hh"
+#include "game/field/RailInterpolator.hh"
 #include "game/field/obj/ObjectId.hh"
 
 #include "game/system/map/MapdataGeoObj.hh"
@@ -19,6 +20,7 @@ public:
     virtual void calcModel();
     virtual void load() = 0;
     virtual void createCollision() = 0;
+    virtual void loadRail();
     virtual void calcCollisionTransform() = 0;
 
     /// @addr{0x806BF434}
@@ -46,12 +48,14 @@ protected:
     void calcTransform();
 
     ObjectId m_id;
+    RailInterpolator *m_railInterpolator;
     BoxColUnit *m_boxColUnit;
     u16 m_flags;
     EGG::Vector3f m_pos;
     EGG::Vector3f m_rot;
     EGG::Vector3f m_scale;
     EGG::Matrix34f m_transform;
+    const System::MapdataGeoObj *m_mapObj;
 };
 
 } // namespace Field

--- a/source/game/system/map/MapdataGeoObj.hh
+++ b/source/game/system/map/MapdataGeoObj.hh
@@ -22,23 +22,32 @@ public:
     void read(EGG::Stream &stream);
 
     /// @beginGetters
-    u16 id() const {
+    [[nodiscard]] u16 id() const {
         return m_id;
     }
 
-    const EGG::Vector3f &pos() const {
+    [[nodiscard]] const EGG::Vector3f &pos() const {
         return m_pos;
     }
 
-    const EGG::Vector3f &rot() const {
+    [[nodiscard]] const EGG::Vector3f &rot() const {
         return m_rot;
     }
 
-    const EGG::Vector3f &scale() const {
+    [[nodiscard]] const EGG::Vector3f &scale() const {
         return m_scale;
     }
 
-    u16 presenceFlag() const {
+    [[nodiscard]] s16 pathId() const {
+        return m_pathId;
+    }
+
+    [[nodiscard]] u16 setting(size_t idx) const {
+        ASSERT(idx < m_settings.size());
+        return m_settings[idx];
+    }
+
+    [[nodiscard]] u16 presenceFlag() const {
         return m_presenceFlag;
     }
     /// @endGetters

--- a/source/game/system/map/MapdataPointInfo.cc
+++ b/source/game/system/map/MapdataPointInfo.cc
@@ -35,10 +35,6 @@ void MapdataPointInfo::read(EGG::RamStream &stream) {
     }
 }
 
-size_t MapdataPointInfo::pointCount() const {
-    return m_points.size();
-}
-
 /// @addr{0x80515D3C}
 MapdataPointInfoAccessor::MapdataPointInfoAccessor(const MapSectionHeader *header)
     : MapdataAccessorBase<MapdataPointInfo, MapdataPointInfo::SData>(header) {

--- a/source/game/system/map/MapdataPointInfo.hh
+++ b/source/game/system/map/MapdataPointInfo.hh
@@ -28,7 +28,18 @@ public:
 
     void read(EGG::RamStream &stream);
 
-    [[nodiscard]] size_t pointCount() const;
+    [[nodiscard]] size_t pointCount() const {
+        return m_points.size();
+    }
+
+    [[nodiscard]] u8 setting(size_t idx) const {
+        ASSERT(idx < m_settings.size());
+        return m_settings[idx];
+    }
+
+    [[nodiscard]] const std::span<Point> &points() const {
+        return m_points;
+    }
 
 private:
     const SData *m_rawData;


### PR DESCRIPTION
This PR implements the following:
- Rail
  - RailLine
  - RailSpline
- RailInterpolator
  - RailLinearInterpolator
  - RailSmoothInterpolator
- RailManager

It's a bit tricky to trim this down more unfortunately, because Rails depend on Interpolators which depend on RailManager which depend on Rails.

Validated rails via `PenguinM` and `Kuribo`. These are the walking-only penguins and Goombas. They make use of linear and smooth interpolators. Goombas oscillate while penguins have continuous/looping rail points. This should cover enough bases. I was going to try to validate the speed change behavior that can occur for sliding penguins, for example, but sliding penguins' state has a dependency on drawMdl. For right now, I think this is sufficient testing.