### PR TITLE
Implement ObjectPuchiPakkun (rMR piranhas)

### DIFF
--- a/source/egg/math/Matrix.cc
+++ b/source/egg/math/Matrix.cc
@@ -301,6 +301,10 @@ Matrix34f Matrix34f::transpose() const {
     return ret;
 }
 
+Vector3f Matrix34f::translation() const {
+    return Vector3f(mtx[0][3], mtx[1][3], mtx[2][3]);
+}
+
 /// @addr{0x80384370}
 const Matrix34f Matrix34f::ident(1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f,
         0.0f);

--- a/source/egg/math/Matrix.hh
+++ b/source/egg/math/Matrix.hh
@@ -43,6 +43,7 @@ public:
     [[nodiscard]] Vector3f multVector33(const Vector3f &vec) const;
     void inverseTo33(Matrix34f &out) const;
     [[nodiscard]] Matrix34f transpose() const;
+    [[nodiscard]] Vector3f translation() const;
 
     static const Matrix34f ident;
     static const Matrix34f zero;

--- a/source/game/field/ObjectCollisionSphere.cc
+++ b/source/game/field/ObjectCollisionSphere.cc
@@ -4,25 +4,29 @@ namespace Field {
 
 /// @addr{0x808368D0}
 ObjectCollisionSphere::ObjectCollisionSphere(f32 radius, const EGG::Vector3f &center)
-    : m_radius(radius), m_pos(center) {
-    m_worldRadius = radius;
-    m_worldPos = center;
-
-    m_center = center;
-}
+    : m_radius(radius), m_pos(center), m_scaledRadius(radius), m_scaledPos(center),
+      m_worldPos(center) {}
 
 /// @addr{0x80836B5C}
 ObjectCollisionSphere::~ObjectCollisionSphere() = default;
 
 /// @addr{0x80836A50}
-void ObjectCollisionSphere::transform(const EGG::Matrix34f & /*mat*/,
-        const EGG::Vector3f & /*scale*/, const EGG::Vector3f & /*speed*/) {
-    ; // TODO
+void ObjectCollisionSphere::transform(const EGG::Matrix34f &mat, const EGG::Vector3f &scale,
+        const EGG::Vector3f &speed) {
+    m_translation = speed;
+
+    if (scale.x != 1.0f) {
+        m_scaledPos = m_pos * scale.x;
+        m_scaledRadius = m_radius * scale.x;
+    }
+
+    m_worldPos = mat.multVector(m_scaledPos);
+    m_center = m_worldPos - speed;
 }
 
 /// @addr{0x80836920}
 const EGG::Vector3f &ObjectCollisionSphere::getSupport(const EGG::Vector3f &v) const {
-    // if (m_hasColDir)
+    // if (!m_hasColDir)
     //      return m_worldPos;
 
     return m_worldPos.dot(v) > m_center.dot(v) ? m_worldPos : m_center;
@@ -30,7 +34,7 @@ const EGG::Vector3f &ObjectCollisionSphere::getSupport(const EGG::Vector3f &v) c
 
 /// @addr{0x80836B54}
 f32 ObjectCollisionSphere::getBoundingRadius() const {
-    return m_worldRadius;
+    return m_scaledRadius;
 }
 
 } // namespace Field

--- a/source/game/field/ObjectCollisionSphere.hh
+++ b/source/game/field/ObjectCollisionSphere.hh
@@ -17,10 +17,9 @@ public:
 private:
     f32 m_radius;
     EGG::Vector3f m_pos;
-
-    f32 m_worldRadius;
+    f32 m_scaledRadius;
+    EGG::Vector3f m_scaledPos;
     EGG::Vector3f m_worldPos;
-
     EGG::Vector3f m_center;
 };
 

--- a/source/game/field/ObjectDirector.cc
+++ b/source/game/field/ObjectDirector.cc
@@ -193,6 +193,8 @@ ObjectBase *ObjectDirector::createObject(const System::MapdataGeoObj &params) {
         return new ObjectOilSFC(params);
     case ObjectId::ParasolR:
         return new ObjectParasolR(params);
+    case ObjectId::PuchiPakkun:
+        return new ObjectPuchiPakkun(params);
     // Non-specified objects are stock collidable objects by default
     // However, we need to specify an impl, so we don't use default
     case ObjectId::DummyPole:

--- a/source/game/field/obj/ObjectDokan.cc
+++ b/source/game/field/obj/ObjectDokan.cc
@@ -37,6 +37,19 @@ u32 ObjectDokan::loadFlags() const {
     return 1;
 }
 
+/// @addr{0x80778D50}
+void ObjectDokan::calcCollisionTransform() {
+    if (m_id == ObjectId::DokanSFC) {
+        ObjectCollidable::calcCollisionTransform();
+    } else {
+        // rMR piranhas
+        calcTransform();
+        EGG::Matrix34f mat = m_transform;
+        mat.setBase(3, mat.translation() + EGG::Vector3f::ey * 300.0f);
+        m_collision->transform(mat, m_scale, getCollisionTranslation());
+    }
+}
+
 /// @addr{0x80778C0C}
 Kart::Reaction ObjectDokan::onCollision(Kart::KartObject * /*kartObj*/,
         Kart::Reaction reactionOnKart, Kart::Reaction reactionOnObj, EGG::Vector3f & /*hitDepth*/) {

--- a/source/game/field/obj/ObjectDokan.hh
+++ b/source/game/field/obj/ObjectDokan.hh
@@ -12,6 +12,7 @@ public:
     void init() override;
     void calc() override;
     [[nodiscard]] u32 loadFlags() const override;
+    void calcCollisionTransform() override;
 
     Kart::Reaction onCollision(Kart::KartObject *kartObj, Kart::Reaction reactionOnKart,
             Kart::Reaction reactionOnObj, EGG::Vector3f &hitDepth) override;

--- a/source/game/field/obj/ObjectId.hh
+++ b/source/game/field/obj/ObjectId.hh
@@ -12,6 +12,7 @@ enum class ObjectId {
     DKtreeA64c = 0x158,
     OilSFC = 0x15d,
     ParasolR = 0x16e,
+    PuchiPakkun = 0x1aa,
 };
 
 enum class BlacklistedObjectId {

--- a/source/game/field/obj/ObjectPuchiPakkun.hh
+++ b/source/game/field/obj/ObjectPuchiPakkun.hh
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "game/field/obj/ObjectDokan.hh"
+
+namespace Field {
+
+/// @brief This is just to help with readability. The rMR piranhas are really just pipes.
+typedef ObjectDokan ObjectPuchiPakkun;
+
+} // namespace Field

--- a/source/game/field/obj/ObjectRegistry.hh
+++ b/source/game/field/obj/ObjectRegistry.hh
@@ -4,3 +4,4 @@
 #include "game/field/obj/ObjectNoImpl.hh"
 #include "game/field/obj/ObjectOilSFC.hh"
 #include "game/field/obj/ObjectParasolR.hh"
+#include "game/field/obj/ObjectPuchiPakkun.hh"

--- a/source/game/kart/KartMove.cc
+++ b/source/game/kart/KartMove.cc
@@ -1409,8 +1409,9 @@ void KartMove::calcAcceleration() {
     m_vel1Dir = local_90.multVector33(m_vel1Dir);
 
     const auto *raceMgr = System::RaceManager::Instance();
-    if (!state()->isDisableBackwardsAccel() && state()->isTouchingGround() &&
-            !state()->isAccelerate() && raceMgr->isStageReached(System::RaceManager::Stage::Race)) {
+    if (!state()->isInAction() && !state()->isDisableBackwardsAccel() &&
+            state()->isTouchingGround() && !state()->isAccelerate() &&
+            raceMgr->isStageReached(System::RaceManager::Stage::Race)) {
         calcDeceleration();
     }
 


### PR DESCRIPTION
- Piranhas are really pipes (ObjectDokan) because they fly upwards if you hit them, but they have specialized behavior in calcCollisionTransform.
- Added as a typedef to help with readability
- Also had to add to ObjectCollisionSphere