### PR TITLE
Add memory profiling and fix memory leaks

### DIFF
--- a/include/Common.hh
+++ b/include/Common.hh
@@ -175,6 +175,22 @@ enum class WeightClass {
     Heavy = 2,
 };
 
+enum class GroupID : u16 {
+    None = 0,
+    Race = 1,
+    Gfx = 2,
+    Kart = 3,
+    Object = 4,
+    Course = 5,
+    UI = 6,
+    Effect = 7,
+    Sound = 8,
+    Resource = 10,
+    HomeMenu = 11,
+    Item = 12,
+    Net = 13,
+};
+
 static constexpr WeightClass CharacterToWeight(Character character) {
     switch (character) {
     case Character::Baby_Peach:

--- a/include/ScopeLock.hh
+++ b/include/ScopeLock.hh
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <Common.hh>
+
+#include <egg/core/ExpHeap.hh>
+
+template <typename T>
+class ScopeLock;
+
+template <>
+class ScopeLock<GroupID> {
+public:
+    /// @brief Temporarily changes the group ID of a given heap to better track memory allocation.
+    /// @details Typical pattern is "ScopeLock<GroupID> lock(groupID);" to initialize a lock.
+    ScopeLock(GroupID newID) {
+        EGG::ExpHeap *heap = EGG::Heap::dynamicCastToExp(EGG::Heap::getCurrentHeap());
+        ASSERT(heap);
+        GroupID prevID = static_cast<GroupID>(heap->getGroupID());
+
+        if (prevID != GroupID::None) {
+            WARN("Overwriting non-default group ID! Replacing %d with %d", prevID, newID);
+        }
+
+        heap->setGroupID(static_cast<u16>(newID));
+    }
+
+    ~ScopeLock() {
+        EGG::ExpHeap *heap = EGG::Heap::dynamicCastToExp(EGG::Heap::getCurrentHeap());
+        ASSERT(heap);
+        heap->setGroupID(static_cast<u16>(GroupID::None));
+    }
+};

--- a/source/abstract/memory/ExpHeap.cc
+++ b/source/abstract/memory/ExpHeap.cc
@@ -91,6 +91,9 @@ void *MEMiExpBlockHead::getMemoryEnd() const {
 MEMiExpHeapHead::MEMiExpHeapHead(void *end, u16 opt)
     : MEMiHeapHead(EXP_HEAP_SIGNATURE, AddOffset(this, sizeof(MEMiExpHeapHead)), end, opt) {
     m_groupId = 0;
+#ifdef BUILD_DEBUG
+    m_tag = 0;
+#endif // BUILD_DEBUG
     m_attribute.makeAllZero();
 
     Region region = Region(getHeapStart(), getHeapEnd());
@@ -314,6 +317,9 @@ void *MEMiExpHeapHead::allocUsedBlockFromFreeBlock(MEMiExpBlockHead *block, void
     head->m_attribute.fields.direction = direction;
     head->m_attribute.fields.alignment = GetAddrNum(head) - GetAddrNum(leftRegion.end);
     head->m_attribute.fields.groupId = m_groupId;
+#ifdef BUILD_DEBUG
+    head->m_tag = ++m_tag;
+#endif // BUILD_DEBUG
 
     m_usedBlocks.append(head);
 

--- a/source/abstract/memory/ExpHeap.hh
+++ b/source/abstract/memory/ExpHeap.hh
@@ -57,6 +57,9 @@ public:
         } fields;
     } m_attribute;
     u32 m_size;
+#ifdef BUILD_DEBUG
+    u32 m_tag;
+#endif // BUILD_DEBUG
     MEMiExpBlockLink m_link;
 };
 
@@ -100,6 +103,9 @@ private:
     MEMiExpBlockList m_freeBlocks;
     MEMiExpBlockList m_usedBlocks;
     u16 m_groupId;
+#ifdef BUILD_DEBUG
+    u32 m_tag;
+#endif // BUILD_DEBUG
     Attribute m_attribute;
 
     static constexpr u32 EXP_HEAP_SIGNATURE = 0x45585048; // EXPH

--- a/source/egg/core/ExpHeap.cc
+++ b/source/egg/core/ExpHeap.cc
@@ -112,6 +112,10 @@ void ExpHeap::setGroupID(u16 groupID) {
     return dynamicCastHandleToExp()->setGroupID(groupID);
 }
 
+u16 ExpHeap::getGroupID() const {
+    return dynamicCastHandleToExp()->getGroupID();
+}
+
 MEMiExpHeapHead *ExpHeap::dynamicCastHandleToExp() {
     return reinterpret_cast<MEMiExpHeapHead *>(m_handle);
 }

--- a/source/egg/core/ExpHeap.hh
+++ b/source/egg/core/ExpHeap.hh
@@ -25,6 +25,10 @@ public:
         [[nodiscard]] size_t getGroupSize(u16 groupID) const;
         void addSize(u16 groupID, size_t size);
 
+        [[nodiscard]] constexpr size_t size() const {
+            return m_entries.size();
+        }
+
     private:
         std::array<size_t, 256> m_entries;
     };
@@ -45,6 +49,7 @@ public:
     void calcGroupSize(GroupSizeRecord *record);
 
     void setGroupID(u16 groupID);
+    [[nodiscard]] u16 getGroupID() const;
 
     [[nodiscard]] Abstract::Memory::MEMiExpHeapHead *dynamicCastHandleToExp();
     [[nodiscard]] const Abstract::Memory::MEMiExpHeapHead *dynamicCastHandleToExp() const;

--- a/source/game/field/ObjectCollisionKart.cc
+++ b/source/game/field/ObjectCollisionKart.cc
@@ -12,7 +12,9 @@ namespace Field {
 ObjectCollisionKart::ObjectCollisionKart() : m_kartObject(nullptr) {}
 
 /// @addr{0x8081E0E4}
-ObjectCollisionKart::~ObjectCollisionKart() = default;
+ObjectCollisionKart::~ObjectCollisionKart() {
+    delete m_hull;
+}
 
 /// @addr{0x8081D090}
 void ObjectCollisionKart::init(u32 idx) {

--- a/source/game/field/ObjectDirector.cc
+++ b/source/game/field/ObjectDirector.cc
@@ -45,6 +45,10 @@ void ObjectDirector::addObject(ObjectCollidable *obj) {
     m_objects.push_back(obj);
 }
 
+void ObjectDirector::addObjectNoImpl(ObjectNoImpl *obj) {
+    m_objects.push_back(obj);
+}
+
 /// @addr{0x8082AB04}
 size_t ObjectDirector::checkKartObjectCollision(Kart::KartObject *kartObj,
         ObjectCollisionConvexHull *convexHull) {

--- a/source/game/field/ObjectDirector.hh
+++ b/source/game/field/ObjectDirector.hh
@@ -4,6 +4,7 @@
 #include "game/field/ObjectFlowTable.hh"
 #include "game/field/ObjectHitTable.hh"
 #include "game/field/obj/ObjectCollidable.hh"
+#include "game/field/obj/ObjectNoImpl.hh"
 
 #include <vector>
 
@@ -14,6 +15,7 @@ public:
     void init();
     void calc();
     void addObject(ObjectCollidable *obj);
+    void addObjectNoImpl(ObjectNoImpl *obj);
 
     size_t checkKartObjectCollision(Kart::KartObject *kartObj,
             ObjectCollisionConvexHull *convexHull);

--- a/source/game/field/ObjectHitTable.cc
+++ b/source/game/field/ObjectHitTable.cc
@@ -28,7 +28,9 @@ ObjectHitTable::ObjectHitTable(const char *filename) {
 }
 
 /// @addr{0x807F9348}
-ObjectHitTable::~ObjectHitTable() = default;
+ObjectHitTable::~ObjectHitTable() {
+    delete m_reactions.data();
+}
 
 Kart::Reaction ObjectHitTable::reaction(s16 i) const {
     ASSERT(i != -1);

--- a/source/game/field/obj/ObjectCollidable.cc
+++ b/source/game/field/obj/ObjectCollidable.cc
@@ -13,7 +13,9 @@ namespace Field {
 ObjectCollidable::ObjectCollidable(const System::MapdataGeoObj &params) : ObjectBase(params) {}
 
 /// @addr{0x8067E384}
-ObjectCollidable::~ObjectCollidable() = default;
+ObjectCollidable::~ObjectCollidable() {
+    delete m_collision;
+}
 
 /// @addr{0x8081F0A0}
 void ObjectCollidable::load() {

--- a/source/game/field/obj/ObjectNoImpl.cc
+++ b/source/game/field/obj/ObjectNoImpl.cc
@@ -1,9 +1,15 @@
 #include "ObjectNoImpl.hh"
 
+#include "game/field/ObjectDirector.hh"
+
 namespace Field {
 
 ObjectNoImpl::ObjectNoImpl(const System::MapdataGeoObj &params) : ObjectBase(params) {}
 
 ObjectNoImpl::~ObjectNoImpl() = default;
+
+void ObjectNoImpl::load() {
+    ObjectDirector::Instance()->addObjectNoImpl(this);
+}
 
 } // namespace Field

--- a/source/game/field/obj/ObjectNoImpl.hh
+++ b/source/game/field/obj/ObjectNoImpl.hh
@@ -9,7 +9,7 @@ public:
     ObjectNoImpl(const System::MapdataGeoObj &params);
     ~ObjectNoImpl() override;
 
-    void load() override {}
+    void load() override;
     void calcCollisionTransform() override {}
 };
 

--- a/source/game/kart/KartMove.cc
+++ b/source/game/kart/KartMove.cc
@@ -47,7 +47,10 @@ KartMove::KartMove() : m_smoothedUp(EGG::Vector3f::ey), m_scale(1.0f, 1.0f, 1.0f
 }
 
 /// @addr{0x80587B78}
-KartMove::~KartMove() = default;
+KartMove::~KartMove() {
+    delete m_jump;
+    delete m_halfPipe;
+}
 
 /// @addr{0x8057821C}
 void KartMove::createSubsystems() {
@@ -1275,18 +1278,14 @@ f32 KartMove::calcVehicleAcceleration() const {
         return 1.0f;
     }
 
-    std::vector<f32> as;
-    std::vector<f32> ts;
+    std::span<const f32> as;
+    std::span<const f32> ts;
     if (state()->isDrifting()) {
-        const auto &as_arr = param()->stats().accelerationDriftA;
-        const auto &ts_arr = param()->stats().accelerationDriftT;
-        as = {as_arr.begin(), as_arr.end()};
-        ts = {ts_arr.begin(), ts_arr.end()};
+        as = param()->stats().accelerationDriftA;
+        ts = param()->stats().accelerationDriftT;
     } else {
-        const auto &as_arr = param()->stats().accelerationStandardA;
-        const auto &ts_arr = param()->stats().accelerationStandardT;
-        as = {as_arr.begin(), as_arr.end()};
-        ts = {ts_arr.begin(), ts_arr.end()};
+        as = param()->stats().accelerationStandardA;
+        ts = param()->stats().accelerationStandardT;
     }
 
     size_t i = 0;

--- a/source/game/kart/KartObject.cc
+++ b/source/game/kart/KartObject.cc
@@ -25,6 +25,7 @@ KartObject::~KartObject() {
     delete m_pointers.body;
     delete m_pointers.sub;
     delete m_pointers.model;
+    delete m_pointers.objectCollisionKart;
 
     for (auto *susp : m_pointers.suspensions) {
         delete susp;

--- a/source/game/scene/GameScene.cc
+++ b/source/game/scene/GameScene.cc
@@ -11,10 +11,39 @@ namespace Scene {
 GameScene::GameScene() {
     m_heap->setName("DefaultGameSceneHeap");
     m_nextSceneId = -1;
+
+#ifdef BUILD_DEBUG
+    m_totalMemoryUsed = 0;
+    EGG::ExpHeap *heap = EGG::Heap::dynamicCastToExp(m_heap);
+    ASSERT(heap);
+
+    heap->calcGroupSize(&m_groupSizeRecord);
+    for (u16 groupID = 0; groupID < m_groupSizeRecord.size(); ++groupID) {
+        m_totalMemoryUsed += m_groupSizeRecord.getGroupSize(groupID);
+    }
+#endif // BUILD_DEBUG
 }
 
 /// @addr{0x8051A3C0}
-GameScene::~GameScene() = default;
+GameScene::~GameScene() {
+    m_resources.clear();
+
+#ifdef BUILD_DEBUG
+    EGG::ExpHeap *heap = EGG::Heap::dynamicCastToExp(m_heap);
+    ASSERT(heap);
+
+    heap->calcGroupSize(&m_groupSizeRecord);
+    size_t sum = 0;
+    for (u16 groupID = 0; groupID < m_groupSizeRecord.size(); ++groupID) {
+        sum += m_groupSizeRecord.getGroupSize(groupID);
+    }
+
+    if (sum > m_totalMemoryUsed) {
+        WARN("MEMORY LEAK DETECTED: %zu bytes", sum - m_totalMemoryUsed);
+        getMemoryLeakTags();
+    }
+#endif // BUILD_DEBUG
+}
 
 /// @addr{0x8051B3C8}
 void GameScene::calc() {
@@ -59,6 +88,9 @@ void GameScene::initScene() {
     createEngines();
     System::KPadDirector::Instance()->reset();
     initEngines();
+#ifdef BUILD_DEBUG
+    checkMemory();
+#endif // BUILD_DEBUG
 }
 
 /// @addr{0x8051B0F4}
@@ -81,4 +113,89 @@ void GameScene::unmountResources() {
         delete resource;
     }
 }
+
+#ifdef BUILD_DEBUG
+void GameScene::checkMemory() {
+    EGG::ExpHeap *heap = EGG::Heap::dynamicCastToExp(m_heap);
+    ASSERT(heap);
+
+    heap->calcGroupSize(&m_groupSizeRecord);
+    size_t defaultSize = m_groupSizeRecord.getGroupSize(static_cast<u16>(GroupID::None));
+
+    // Because we're working with a class that can be inherited (but not doubly-inherited),
+    // it's possible that derived classes can have a different size compared to GameScene
+    // We don't need to know the exact derived class, though, as we have the memory block head
+    // The scene is the first, always group ID 0 allocation to happen in the scene's heap
+    Abstract::Memory::MEMiExpBlockHead *blockHead =
+            static_cast<Abstract::Memory::MEMiExpBlockHead *>(
+                    SubOffset(this, sizeof(Abstract::Memory::MEMiExpBlockHead)));
+    size_t initialAllocSize = blockHead->m_size;
+    ASSERT(defaultSize >= initialAllocSize);
+
+    defaultSize -= initialAllocSize;
+    if (defaultSize > 0) {
+        WARN("Default memory usage found! %zu bytes", defaultSize);
+    }
+
+    for (u16 groupID = 1; groupID < m_groupSizeRecord.size(); ++groupID) {
+        size_t size = m_groupSizeRecord.getGroupSize(groupID);
+        if (size == 0) {
+            continue;
+        }
+
+        DEBUG("Group ID %d: Allocated %zu bytes", groupID, size);
+    }
+}
+
+void GameScene::getMemoryLeakTags() {
+    size_t count = getMemoryLeakTagCount();
+    if (count == 0) {
+        return;
+    }
+
+    std::span<u32> tags = std::span<u32>(new u32[count], count);
+    for (auto &tag : tags) {
+        tag = 0; // empty tag
+    }
+
+    EGG::Heap::dynamicCastToExp(m_heap)->dynamicCastHandleToExp()->visitAllocated(ViewTags,
+            GetAddrNum(&tags));
+
+    DEBUG("TAGGED MEMORY BLOCKS:");
+    printf("[%d", tags[0]);
+    for (u32 i = 1; i < tags.size(); ++i) {
+        printf(", %d", tags[i]);
+    }
+    printf("]\n");
+
+    delete[] tags.data();
+}
+
+size_t GameScene::getMemoryLeakTagCount() {
+    size_t count = 0;
+    EGG::Heap::dynamicCastToExp(m_heap)->dynamicCastHandleToExp()->visitAllocated(IncreaseTagCount,
+            GetAddrNum(&count));
+    return count;
+}
+
+void GameScene::ViewTags(void *block, Abstract::Memory::MEMiHeapHead * /*heap*/, uintptr_t param) {
+    Abstract::Memory::MEMiExpBlockHead *blockHead =
+            static_cast<Abstract::Memory::MEMiExpBlockHead *>(
+                    SubOffset(block, sizeof(Abstract::Memory::MEMiExpBlockHead)));
+    std::span<u32> *span = reinterpret_cast<std::span<u32> *>(param);
+    for (auto &tag : *span) {
+        if (tag == 0) {
+            tag = blockHead->m_tag;
+            break;
+        }
+    }
+}
+
+void GameScene::IncreaseTagCount(void * /*block*/, Abstract::Memory::MEMiHeapHead * /*heap*/,
+        uintptr_t param) {
+    size_t &count = *reinterpret_cast<size_t *>(param);
+    ++count;
+}
+#endif // BUILD_DEBUG
+
 } // namespace Scene

--- a/source/game/scene/GameScene.hh
+++ b/source/game/scene/GameScene.hh
@@ -2,6 +2,7 @@
 
 #include "game/system/MultiDvdArchive.hh"
 
+#include <egg/core/ExpHeap.hh>
 #include <egg/core/Scene.hh>
 
 #include <list>
@@ -42,8 +43,21 @@ private:
     void deinitScene();
     void unmountResources();
 
+#ifdef BUILD_DEBUG
+    void checkMemory();
+    void getMemoryLeakTags();
+    size_t getMemoryLeakTagCount();
+
+    static void ViewTags(void *block, Abstract::Memory::MEMiHeapHead *heap, uintptr_t param);
+    static void IncreaseTagCount(void *block, Abstract::Memory::MEMiHeapHead *heap,
+            uintptr_t param);
+#endif // BUILD_DEBUG
+
+    EGG::ExpHeap::GroupSizeRecord m_groupSizeRecord;
     std::list<Resource *> m_resources; ///< List of all active resources in the scene.
     int m_nextSceneId;
+
+    size_t m_totalMemoryUsed;
 };
 
 } // namespace Scene

--- a/source/game/scene/RaceScene.cc
+++ b/source/game/scene/RaceScene.cc
@@ -11,6 +11,8 @@
 #include "game/system/RaceManager.hh"
 #include "game/system/ResourceManager.hh"
 
+#include <ScopeLock.hh>
+
 namespace Scene {
 
 /// @addr{0x80553B88}
@@ -23,21 +25,65 @@ RaceScene::~RaceScene() = default;
 
 /// @addr{0x80554208}
 void RaceScene::createEngines() {
-    System::CourseMap::CreateInstance()->init();
-    System::RaceManager::CreateInstance();
-    Field::BoxColManager::CreateInstance();
-    Kart::KartObjectManager::CreateInstance();
-    Field::CollisionDirector::CreateInstance();
-    Item::ItemDirector::CreateInstance();
-    Field::ObjectDirector::CreateInstance();
+    {
+        ScopeLock<GroupID> lock(GroupID::Course);
+        System::CourseMap::CreateInstance()->init();
+    }
+
+    {
+        ScopeLock<GroupID> lock(GroupID::Race);
+        System::RaceManager::CreateInstance();
+    }
+
+    {
+        ScopeLock<GroupID> lock(GroupID::Object);
+        Field::BoxColManager::CreateInstance();
+    }
+
+    {
+        ScopeLock<GroupID> lock(GroupID::Kart);
+        Kart::KartObjectManager::CreateInstance();
+    }
+
+    {
+        ScopeLock<GroupID> lock(GroupID::Course);
+        Field::CollisionDirector::CreateInstance();
+    }
+
+    {
+        ScopeLock<GroupID> lock(GroupID::Item);
+        Item::ItemDirector::CreateInstance();
+    }
+
+    {
+        ScopeLock<GroupID> lock(GroupID::Object);
+        Field::ObjectDirector::CreateInstance();
+    }
 }
 
 /// @addr{0x8055472C}
 void RaceScene::initEngines() {
-    Kart::KartObjectManager::Instance()->init();
-    System::RaceManager::Instance()->init();
-    Item::ItemDirector::Instance()->init();
-    Field::ObjectDirector::Instance()->init();
+    {
+        ScopeLock<GroupID> lock(GroupID::Kart);
+        Kart::KartObjectManager::Instance()->init();
+    }
+
+    {
+        ScopeLock<GroupID> lock(GroupID::Race);
+        System::RaceManager::Instance()->init();
+    }
+
+    {
+        ScopeLock<GroupID> lock(GroupID::Item);
+        Item::ItemDirector::Instance()->init();
+    }
+
+    {
+        ScopeLock<GroupID> lock(GroupID::Object);
+        Field::ObjectDirector::Instance()->init();
+    }
+
+    m_heap->disableAllocation();
 }
 
 /// @addr{0x80554E6C}
@@ -73,11 +119,16 @@ void RaceScene::configure() {
 
     raceCfg->initRace();
 
-    auto *commonArc = resMgr->load(0, nullptr);
-    appendResource(commonArc, 0);
+    // Normally, the resources are loaded into a specific archive heap
+    // For now, tag them with the resource group ID
+    {
+        ScopeLock<GroupID> lock(GroupID::Resource);
+        auto *commonArc = resMgr->load(0, nullptr);
+        appendResource(commonArc, 0);
 
-    auto *courseArc = resMgr->load(raceCfg->raceScenario().course);
-    appendResource(courseArc, 1);
+        auto *courseArc = resMgr->load(raceCfg->raceScenario().course);
+        appendResource(courseArc, 1);
+    }
 }
 
 /// @brief This is called on race shutdown in order to prep for the next race.

--- a/source/game/scene/RootScene.hh
+++ b/source/game/scene/RootScene.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <egg/core/ExpHeap.hh>
 #include <egg/core/Scene.hh>
 
 namespace Scene {
@@ -15,6 +16,12 @@ public:
 private:
     void allocate();
     void init();
+
+#ifdef BUILD_DEBUG
+    void checkMemory();
+#endif // BUILD_DEBUG
+
+    EGG::ExpHeap::GroupSizeRecord m_groupSizeRecord;
 };
 
 } // namespace Scene

--- a/source/game/system/CourseMap.cc
+++ b/source/game/system/CourseMap.cc
@@ -209,6 +209,12 @@ CourseMap::~CourseMap() {
 
     delete m_course;
     delete m_startPoint;
+    delete m_checkPath;
+    delete m_checkPoint;
+    delete m_pointInfo;
+    delete m_geoObj;
+    delete m_jugemPoint;
+    delete m_cannonPoint;
     delete m_stageInfo;
 }
 

--- a/source/game/system/map/MapdataPointInfo.cc
+++ b/source/game/system/map/MapdataPointInfo.cc
@@ -10,6 +10,10 @@ MapdataPointInfo::MapdataPointInfo(const SData *data) : m_rawData(data) {
     read(stream);
 }
 
+MapdataPointInfo::~MapdataPointInfo() {
+    delete m_points.data();
+}
+
 void MapdataPointInfo::read(EGG::RamStream &stream) {
     u16 count = stream.read_u16();
 

--- a/source/game/system/map/MapdataPointInfo.hh
+++ b/source/game/system/map/MapdataPointInfo.hh
@@ -24,6 +24,7 @@ public:
     STATIC_ASSERT(sizeof(SData) == 0x4);
 
     MapdataPointInfo(const SData *data);
+    ~MapdataPointInfo();
 
     void read(EGG::RamStream &stream);
 

--- a/source/host/KTestSystem.cc
+++ b/source/host/KTestSystem.cc
@@ -350,6 +350,9 @@ bool KTestSystem::runTest() {
         calc();
     }
 
+    // TODO: Use a system heap! std::string relies on heap allocation
+    // The heap is destroyed after this and there is no further allocation, so it's not re-disabled
+    m_sceneMgr->currentScene()->heap()->enableAllocation();
     writeTestOutput();
     return m_sync;
 }

--- a/source/host/KTestSystem.hh
+++ b/source/host/KTestSystem.hh
@@ -81,6 +81,8 @@ private:
             return;
         }
 
+        m_sceneMgr->currentScene()->heap()->enableAllocation();
+
         if (m_sync) {
             REPORT("Test Case Failed: %s [%d / %d]", getCurrentTestCase().name.c_str(),
                     m_currentFrame, m_frameCount);
@@ -92,6 +94,8 @@ private:
         REPORT("Expected: %s", s0.c_str());
         REPORT("Observed: %s", s1.c_str());
 
+        m_sceneMgr->currentScene()->heap()->disableAllocation();
+
         m_sync = false;
     }
 
@@ -99,6 +103,8 @@ private:
         if (t0 == t1) {
             return;
         }
+
+        m_sceneMgr->currentScene()->heap()->enableAllocation();
 
         if (m_sync) {
             REPORT("Test Case Failed: %s [%d / %d]", getCurrentTestCase().name.c_str(),
@@ -110,6 +116,8 @@ private:
         std::string s1 = std::to_string(t1);
         REPORT("Expected: 0x%08X | %s", f2u(t0), s0.c_str());
         REPORT("Observed: 0x%08X | %s", f2u(t1), s1.c_str());
+
+        m_sceneMgr->currentScene()->heap()->disableAllocation();
 
         m_sync = false;
     }


### PR DESCRIPTION
The GameScene still leaks due to being handled by the Disposer - fixing this problem will require a library change at a later point.