### PR TITLE
Make ObjectBase dirty flags a TBitFlag

### DIFF
--- a/source/game/field/obj/ObjectBase.cc
+++ b/source/game/field/obj/ObjectBase.cc
@@ -6,8 +6,10 @@ namespace Field {
 
 /// @addr{0x8081F828}
 ObjectBase::ObjectBase(const System::MapdataGeoObj &params)
-    : m_id(static_cast<ObjectId>(params.id())), m_flags(0x3), m_pos(params.pos()),
-      m_rot(params.rot() * DEG2RAD), m_scale(params.scale()), m_transform(EGG::Matrix34f::ident) {}
+    : m_id(static_cast<ObjectId>(params.id())), m_pos(params.pos()), m_rot(params.rot() * DEG2RAD),
+      m_scale(params.scale()), m_transform(EGG::Matrix34f::ident) {
+    m_dirtyFlags.setBit(eDirtyFlags::Position, eDirtyFlags::Rotation);
+}
 
 /// @addr{0x8067E3C4}
 ObjectBase::~ObjectBase() = default;
@@ -19,12 +21,12 @@ void ObjectBase::calcModel() {
 
 /// @addr{0x80821640}
 void ObjectBase::calcTransform() {
-    if (m_flags & 2) {
+    if (m_dirtyFlags.onBit(eDirtyFlags::Rotation)) {
         m_transform.makeRT(m_rot, m_pos);
-        m_flags &= ~0x3;
-    } else if (m_flags & 1) {
+        m_dirtyFlags.resetBit(eDirtyFlags::Rotation, eDirtyFlags::Position);
+    } else if (m_dirtyFlags.onBit(eDirtyFlags::Position)) {
         m_transform.setBase(3, m_pos);
-        m_flags |= 4;
+        m_dirtyFlags.setBit(eDirtyFlags::Matrix);
     }
 }
 

--- a/source/game/field/obj/ObjectBase.hh
+++ b/source/game/field/obj/ObjectBase.hh
@@ -5,12 +5,21 @@
 
 #include "game/system/map/MapdataGeoObj.hh"
 
+#include <egg/core/BitFlag.hh>
 #include <egg/math/Matrix.hh>
 
 namespace Field {
 
 class ObjectBase {
 public:
+    enum class eDirtyFlags {
+        Position = 0,
+        Rotation = 1,
+        Matrix = 2,
+        Scale = 3,
+    };
+    typedef EGG::TBitFlag<u16, eDirtyFlags> DirtyFlags;
+
     ObjectBase(const System::MapdataGeoObj &params);
     virtual ~ObjectBase();
 
@@ -46,7 +55,7 @@ protected:
 
     ObjectId m_id;
     BoxColUnit *m_boxColUnit;
-    u16 m_flags;
+    DirtyFlags m_dirtyFlags;
     EGG::Vector3f m_pos;
     EGG::Vector3f m_rot;
     EGG::Vector3f m_scale;

--- a/source/game/field/obj/ObjectDokan.cc
+++ b/source/game/field/obj/ObjectDokan.cc
@@ -27,7 +27,7 @@ void ObjectDokan::calc() {
 
     m_velocity.y -= ACCEL;
     m_pos += m_velocity;
-    m_flags |= 1;
+    m_dirtyFlags.setBit(eDirtyFlags::Position);
 
     calcFloor();
 }
@@ -78,10 +78,10 @@ void ObjectDokan::calcFloor() {
 
     if (typeMask & KCL_TYPE_FLOOR) {
         m_pos.y += colInfo.tangentOff.y;
-        m_flags |= 1;
+        m_dirtyFlags.setBit(eDirtyFlags::Position);
     } else {
         m_velocity.y *= -ACCELERATION;
-        m_flags |= 1;
+        m_dirtyFlags.setBit(eDirtyFlags::Position);
         m_pos.y += colInfo.tangentOff.y;
 
         if (m_velocity.length() < ACCELERATION * PIPE_SQRT_RADIUS) {


### PR DESCRIPTION
Not sure who labeled this in Ghidra but I saw these were recently labeled, so might as well turn them into a TBitFlag in Kinoko. Let me know if `m_dirtyFlags.onBit(eDirtyFlags...)` is redundant naming lol