### PR TITLE
Implement ObjectDrivable

### DIFF
--- a/source/game/field/BoxColManager.cc
+++ b/source/game/field/BoxColManager.cc
@@ -1,6 +1,7 @@
 #include "BoxColManager.hh"
 
 #include "game/field/obj/ObjectCollidable.hh"
+#include "game/field/obj/ObjectDrivable.hh"
 
 #include <numeric>
 
@@ -184,8 +185,8 @@ ObjectCollidable *BoxColManager::getNextObject() {
 }
 
 /// @addr{0x80785EC4}
-void *BoxColManager::getNextDrivable() {
-    return getNextImpl(m_nextDrivableID, eBoxColFlag::Drivable);
+ObjectDrivable *BoxColManager::getNextDrivable() {
+    return reinterpret_cast<ObjectDrivable *>(getNextImpl(m_nextDrivableID, eBoxColFlag::Drivable));
 }
 
 /// @addr{0x80785F2C}

--- a/source/game/field/BoxColManager.hh
+++ b/source/game/field/BoxColManager.hh
@@ -12,6 +12,7 @@ class KartObject;
 namespace Field {
 
 class ObjectCollidable;
+class ObjectDrivable;
 
 /// @brief A bitfield that represents the state and type of a given BoxColUnit.
 /// @details The lower 8 bits represent the type, while the remaining bits represent the state.
@@ -72,7 +73,7 @@ public:
     void calc();
 
     [[nodiscard]] ObjectCollidable *getNextObject();
-    [[nodiscard]] void *getNextDrivable();
+    [[nodiscard]] ObjectDrivable *getNextDrivable();
 
     void resetIterators();
 

--- a/source/game/field/CollisionDirector.cc
+++ b/source/game/field/CollisionDirector.cc
@@ -10,7 +10,7 @@ void CollisionDirector::checkCourseColNarrScLocal(f32 radius, const EGG::Vector3
 
 /// @addr{0x8078F500}
 bool CollisionDirector::checkSphereFull(f32 radius, const EGG::Vector3f &v0,
-        const EGG::Vector3f &v1, KCLTypeMask flags, CourseColMgr::CollisionInfo *pInfo,
+        const EGG::Vector3f &v1, KCLTypeMask flags, CollisionInfo *pInfo,
         KCLTypeMask *pFlagsOut, u32 /*timeOffset*/) {
     if (pInfo) {
         pInfo->bbox.min = EGG::Vector3f::zero;
@@ -56,7 +56,7 @@ bool CollisionDirector::checkSphereFull(f32 radius, const EGG::Vector3f &v0,
 
 /// @addr{0x8078F784}
 bool CollisionDirector::checkSphereFullPush(f32 radius, const EGG::Vector3f &v0,
-        const EGG::Vector3f &v1, KCLTypeMask flags, CourseColMgr::CollisionInfo *pInfo,
+        const EGG::Vector3f &v1, KCLTypeMask flags, CollisionInfo *pInfo,
         KCLTypeMask *pFlagsOut, u32 /*timeOffset*/) {
     if (pInfo) {
         pInfo->bbox.setZero();
@@ -103,7 +103,7 @@ bool CollisionDirector::checkSphereFullPush(f32 radius, const EGG::Vector3f &v0,
 /// @addr{0x807901F0}
 bool CollisionDirector::checkSphereCachedPartial(f32 radius, const EGG::Vector3f &pos,
         const EGG::Vector3f &prevPos, KCLTypeMask typeMask,
-        CourseColMgr::CollisionInfoPartial *info, KCLTypeMask *typeMaskOut, u32 /*timeOffset*/) {
+        CollisionInfoPartial *info, KCLTypeMask *typeMaskOut, u32 /*timeOffset*/) {
     if (info) {
         info->bbox.setZero();
     }
@@ -140,7 +140,7 @@ bool CollisionDirector::checkSphereCachedPartial(f32 radius, const EGG::Vector3f
 /// @addr{0x807903BC}
 bool CollisionDirector::checkSphereCachedPartialPush(f32 radius, const EGG::Vector3f &pos,
         const EGG::Vector3f &prevPos, KCLTypeMask typeMask,
-        CourseColMgr::CollisionInfoPartial *info, KCLTypeMask *typeMaskOut, u32 /*timeOffset*/) {
+        CollisionInfoPartial *info, KCLTypeMask *typeMaskOut, u32 /*timeOffset*/) {
     if (info) {
         info->bbox.setZero();
     }
@@ -166,7 +166,7 @@ bool CollisionDirector::checkSphereCachedPartialPush(f32 radius, const EGG::Vect
 
 /// @addr{0x807907F8}
 bool CollisionDirector::checkSphereCachedFullPush(f32 radius, const EGG::Vector3f &pos,
-        const EGG::Vector3f &prevPos, KCLTypeMask typeMask, CourseColMgr::CollisionInfo *colInfo,
+        const EGG::Vector3f &prevPos, KCLTypeMask typeMask, CollisionInfo *colInfo,
         KCLTypeMask *typeMaskOut, u32 /*timeOffset*/) {
     if (colInfo) {
         colInfo->bbox.min.setZero();

--- a/source/game/field/CollisionDirector.hh
+++ b/source/game/field/CollisionDirector.hh
@@ -24,20 +24,20 @@ public:
             u32 timeOffset);
 
     [[nodiscard]] bool checkSphereFull(f32 radius, const EGG::Vector3f &v0, const EGG::Vector3f &v1,
-            KCLTypeMask flags, CourseColMgr::CollisionInfo *pInfo, KCLTypeMask *pFlagsOut,
+            KCLTypeMask flags, CollisionInfo *pInfo, KCLTypeMask *pFlagsOut,
             u32 timeOffset);
     [[nodiscard]] bool checkSphereFullPush(f32 radius, const EGG::Vector3f &v0,
-            const EGG::Vector3f &v1, KCLTypeMask flags, CourseColMgr::CollisionInfo *pInfo,
+            const EGG::Vector3f &v1, KCLTypeMask flags, CollisionInfo *pInfo,
             KCLTypeMask *pFlagsOut, u32 timeOffset);
 
     [[nodiscard]] bool checkSphereCachedPartial(f32 radius, const EGG::Vector3f &pos,
             const EGG::Vector3f &prevPos, KCLTypeMask typeMask,
-            CourseColMgr::CollisionInfoPartial *info, KCLTypeMask *typeMaskOut, u32 timeOffset);
+            CollisionInfoPartial *info, KCLTypeMask *typeMaskOut, u32 timeOffset);
     [[nodiscard]] bool checkSphereCachedPartialPush(f32 radius, const EGG::Vector3f &pos,
             const EGG::Vector3f &prevPos, KCLTypeMask typeMask,
-            CourseColMgr::CollisionInfoPartial *info, KCLTypeMask *typeMaskOut, u32 timeOffset);
+            CollisionInfoPartial *info, KCLTypeMask *typeMaskOut, u32 timeOffset);
     [[nodiscard]] bool checkSphereCachedFullPush(f32 radius, const EGG::Vector3f &pos,
-            const EGG::Vector3f &prevPos, KCLTypeMask typeMask, CourseColMgr::CollisionInfo *info,
+            const EGG::Vector3f &prevPos, KCLTypeMask typeMask, CollisionInfo *info,
             KCLTypeMask *typeMaskOut, u32 timeOffset);
 
     void resetCollisionEntries(KCLTypeMask *ptr);

--- a/source/game/field/CourseColMgr.cc
+++ b/source/game/field/CourseColMgr.cc
@@ -574,25 +574,6 @@ bool CourseColMgr::doCheckMaskOnlyPush(KColData *data, CollisionCheckFunc collis
     return hasCol;
 }
 
-void CourseColMgr::CollisionInfo::update(f32 now_dist, const EGG::Vector3f &offset,
-        const EGG::Vector3f &fnrm, u32 kclAttributeTypeBit) {
-    bbox.min = bbox.min.minimize(offset);
-    bbox.max = bbox.max.maximize(offset);
-
-    if (kclAttributeTypeBit & KCL_TYPE_FLOOR) {
-        updateFloor(now_dist, fnrm);
-    } else if (kclAttributeTypeBit & KCL_TYPE_WALL) {
-        if (wallDist > -std::numeric_limits<f32>::min()) {
-            f32 dot = 1.0f - wallNrm.ps_dot(fnrm);
-            if (dot > perpendicularity) {
-                perpendicularity = std::min(dot, 1.0f);
-            }
-        }
-
-        updateWall(now_dist, fnrm);
-    }
-}
-
 CourseColMgr *CourseColMgr::s_instance = nullptr; ///< @addr{0x809C3C10}
 
 } // namespace Field

--- a/source/game/field/CourseColMgr.hh
+++ b/source/game/field/CourseColMgr.hh
@@ -17,40 +17,6 @@ typedef bool (
 /// @nosubgrouping
 class CourseColMgr : EGG::Disposer {
 public:
-    struct CollisionInfoPartial {
-        EGG::BoundBox3f bbox;
-        EGG::Vector3f tangentOff;
-    };
-
-    struct CollisionInfo {
-        EGG::BoundBox3f bbox;
-        EGG::Vector3f tangentOff;
-        EGG::Vector3f floorNrm;
-        EGG::Vector3f wallNrm;
-        EGG::Vector3f _3c;
-        f32 floorDist;
-        f32 wallDist;
-        f32 _50;
-        f32 perpendicularity;
-
-        void updateFloor(f32 dist, const EGG::Vector3f &fnrm) {
-            if (dist > floorDist) {
-                floorDist = dist;
-                floorNrm = fnrm;
-            }
-        }
-
-        void updateWall(f32 dist, const EGG::Vector3f &fnrm) {
-            if (dist > wallDist) {
-                wallDist = dist;
-                wallNrm = fnrm;
-            }
-        }
-
-        void update(f32 now_dist, const EGG::Vector3f &offset, const EGG::Vector3f &fnrm,
-                u32 kclAttributeTypeBit);
-    };
-
     struct NoBounceWallColInfo {
         EGG::BoundBox3f bbox;
         EGG::Vector3f tangentOff;

--- a/source/game/field/KColData.cc
+++ b/source/game/field/KColData.cc
@@ -682,4 +682,23 @@ KColData::KCollisionPrism::KCollisionPrism(f32 height, u16 posIndex, u16 faceNor
     : height(height), pos_i(posIndex), fnrm_i(faceNormIndex), enrm1_i(edge1NormIndex),
       enrm2_i(edge2NormIndex), enrm3_i(edge3NormIndex), attribute(attribute) {}
 
+void CollisionInfo::update(f32 now_dist, const EGG::Vector3f &offset, const EGG::Vector3f &fnrm,
+        u32 kclAttributeTypeBit) {
+    bbox.min = bbox.min.minimize(offset);
+    bbox.max = bbox.max.maximize(offset);
+
+    if (kclAttributeTypeBit & KCL_TYPE_FLOOR) {
+        updateFloor(now_dist, fnrm);
+    } else if (kclAttributeTypeBit & KCL_TYPE_WALL) {
+        if (wallDist > -std::numeric_limits<f32>::min()) {
+            f32 dot = 1.0f - wallNrm.ps_dot(fnrm);
+            if (dot > perpendicularity) {
+                perpendicularity = std::min(dot, 1.0f);
+            }
+        }
+
+        updateWall(now_dist, fnrm);
+    }
+}
+
 } // namespace Field

--- a/source/game/field/KColData.hh
+++ b/source/game/field/KColData.hh
@@ -9,6 +9,40 @@
 
 namespace Field {
 
+struct CollisionInfoPartial {
+    EGG::BoundBox3f bbox;
+    EGG::Vector3f tangentOff;
+};
+
+struct CollisionInfo {
+    EGG::BoundBox3f bbox;
+    EGG::Vector3f tangentOff;
+    EGG::Vector3f floorNrm;
+    EGG::Vector3f wallNrm;
+    EGG::Vector3f _3c;
+    f32 floorDist;
+    f32 wallDist;
+    f32 _50;
+    f32 perpendicularity;
+
+    void updateFloor(f32 dist, const EGG::Vector3f &fnrm) {
+        if (dist > floorDist) {
+            floorDist = dist;
+            floorNrm = fnrm;
+        }
+    }
+
+    void updateWall(f32 dist, const EGG::Vector3f &fnrm) {
+        if (dist > wallDist) {
+            wallDist = dist;
+            wallNrm = fnrm;
+        }
+    }
+
+    void update(f32 now_dist, const EGG::Vector3f &offset, const EGG::Vector3f &fnrm,
+            u32 kclAttributeTypeBit);
+};
+
 /// @brief Performs lookups for KCL triangles
 /// @nosubgrouping
 class KColData {

--- a/source/game/field/obj/ObjectBase.hh
+++ b/source/game/field/obj/ObjectBase.hh
@@ -18,6 +18,7 @@ public:
     virtual void calc() {}
     virtual void calcModel();
     virtual void load() = 0;
+    virtual void createCollision() = 0;
     virtual void calcCollisionTransform() = 0;
 
     /// @addr{0x806BF434}

--- a/source/game/field/obj/ObjectCollidable.hh
+++ b/source/game/field/obj/ObjectCollidable.hh
@@ -51,7 +51,7 @@ public:
     }
 
 protected:
-    virtual void createCollision();
+    void createCollision() override;
 
     /// @addr{0x806816B8}
     virtual const EGG::Vector3f &collisionCenter() const {

--- a/source/game/field/obj/ObjectDokan.cc
+++ b/source/game/field/obj/ObjectDokan.cc
@@ -66,7 +66,7 @@ void ObjectDokan::calcFloor() {
     constexpr f32 PIPE_SQRT_RADIUS = 10.0f;
     constexpr f32 ACCELERATION = 0.2f;
 
-    CourseColMgr::CollisionInfo colInfo;
+    CollisionInfo colInfo;
     EGG::Vector3f pos = m_pos;
     pos.y += PIPE_RADIUS;
     KCLTypeMask typeMask;

--- a/source/game/field/obj/ObjectDrivable.cc
+++ b/source/game/field/obj/ObjectDrivable.cc
@@ -1,0 +1,32 @@
+#include "game/field/obj/ObjectDrivable.hh"
+
+namespace Field {
+
+/// @addr{0x8081A6D0}
+ObjectDrivable::ObjectDrivable(const System::MapdataGeoObj &params) : ObjectBase(params) {}
+
+/// @addr{0x8067EB3C}
+ObjectDrivable::~ObjectDrivable() = default;
+
+/// @addr{0x8081A79C}
+void ObjectDrivable::load() {
+    createCollision();
+    initCollision();
+    loadAABB(getCollisionRadius());
+
+    // ObjectDrivableDirector::Instance()->addObject(this);
+}
+
+/// @addr{0x80682918}
+f32 ObjectDrivable::getCollisionRadius() const {
+    return 5000.0f;
+}
+
+/// @addr{0x8081A85C}
+void ObjectDrivable::loadAABB(f32 radius) {
+    auto *boxColMgr = BoxColManager::Instance();
+    const EGG::Vector3f &pos = getPosition();
+    m_boxColUnit = boxColMgr->insertDrivable(radius, 0.0f, &pos, false, this);
+}
+
+} // namespace Field

--- a/source/game/field/obj/ObjectDrivable.hh
+++ b/source/game/field/obj/ObjectDrivable.hh
@@ -1,0 +1,77 @@
+#pragma once
+
+#include "game/field/CourseColMgr.hh"
+#include "game/field/KCollisionTypes.hh"
+#include "game/field/ObjectCollisionBase.hh"
+#include "game/field/obj/ObjectBase.hh"
+
+namespace Field {
+
+class ObjectDrivable : public ObjectBase {
+public:
+    ObjectDrivable(const System::MapdataGeoObj &params);
+    ~ObjectDrivable() override;
+
+    void load() override;
+    [[nodiscard]] f32 getCollisionRadius() const override;
+
+    virtual void initCollision() {}
+    virtual void loadAABB(f32 radius);
+
+    [[nodiscard]] virtual bool checkPointPartial(const EGG::Vector3f &pos,
+            const EGG::Vector3f &prevPos, KCLTypeMask mask,
+            CollisionInfoPartial *info, KCLTypeMask *maskOut) = 0;
+    [[nodiscard]] virtual bool checkPointPartialPush(const EGG::Vector3f &pos,
+            const EGG::Vector3f &prevPos, KCLTypeMask flags,
+            CollisionInfoPartial *info, KCLTypeMask *maskOut) = 0;
+    [[nodiscard]] virtual bool checkPointFull(const EGG::Vector3f &pos,
+            const EGG::Vector3f &prevPos, KCLTypeMask mask, CollisionInfo *info,
+            KCLTypeMask *maskOut) = 0;
+    [[nodiscard]] virtual bool checkPointFullPush(const EGG::Vector3f &pos,
+            const EGG::Vector3f &prevPos, KCLTypeMask mask, CollisionInfo *info,
+            KCLTypeMask *maskOut) = 0;
+
+    [[nodiscard]] virtual bool checkSpherePartial(f32 radius, const EGG::Vector3f &pos,
+            const EGG::Vector3f &prevPos, KCLTypeMask mask,
+            CollisionInfoPartial *info, KCLTypeMask *maskOut, u32 timeOffset) = 0;
+    [[nodiscard]] virtual bool checkSpherePartialPush(f32 radius, const EGG::Vector3f &pos,
+            const EGG::Vector3f &prevPos, KCLTypeMask mask,
+            CollisionInfoPartial *info, KCLTypeMask *maskOut, u32 timeOffset) = 0;
+    [[nodiscard]] virtual bool checkSphereFull(f32 radius, const EGG::Vector3f &pos,
+            const EGG::Vector3f &prevPos, KCLTypeMask mask, CollisionInfo *info,
+            KCLTypeMask *maskOut, u32 timeOffset) = 0;
+    [[nodiscard]] virtual bool checkSphereFullPush(f32 radius, const EGG::Vector3f &pos,
+            const EGG::Vector3f &prevPos, KCLTypeMask mask, CollisionInfo *info,
+            KCLTypeMask *maskOut, u32 timeOffset) = 0;
+
+    virtual void narrScLocal(f32 radius, const EGG::Vector3f &pos, KCLTypeMask mask,
+            u32 timeOffset) {}
+
+    [[nodiscard]] virtual bool checkPointCachedPartial(const EGG::Vector3f &pos,
+            const EGG::Vector3f &prevPos, KCLTypeMask mask,
+            CollisionInfoPartial *info, KCLTypeMask *maskOut) = 0;
+    [[nodiscard]] virtual bool checkPointCachedPartialPush(const EGG::Vector3f &pos,
+            const EGG::Vector3f &prevPos, KCLTypeMask mask,
+            CollisionInfoPartial *info, KCLTypeMask *maskOut) = 0;
+    [[nodiscard]] virtual bool checkPointCachedFull(const EGG::Vector3f &pos,
+            const EGG::Vector3f &prevPos, KCLTypeMask mask, CollisionInfo *info,
+            KCLTypeMask *maskOut) = 0;
+    [[nodiscard]] virtual bool checkPointCachedFullPush(const EGG::Vector3f &pos,
+            const EGG::Vector3f &prevPos, KCLTypeMask mask, CollisionInfo *info,
+            KCLTypeMask *maskOut) = 0;
+
+    [[nodiscard]] virtual bool checkSphereCachedPartial(f32 radius, const EGG::Vector3f &pos,
+            const EGG::Vector3f &prevPos, KCLTypeMask mask,
+            CollisionInfoPartial *info, KCLTypeMask *maskOut, u32 timeOffset) = 0;
+    [[nodiscard]] virtual bool checkSphereCachedPartialPush(f32 radius, const EGG::Vector3f &pos,
+            const EGG::Vector3f &prevPos, KCLTypeMask mask,
+            CollisionInfoPartial *info, KCLTypeMask *maskOut, u32 timeOffset) = 0;
+    [[nodiscard]] virtual bool checkSphereCachedFull(f32 radius, const EGG::Vector3f &pos,
+            const EGG::Vector3f &prevPos, KCLTypeMask mask, CollisionInfo *info,
+            KCLTypeMask *maskOut, u32 timeOffset) = 0;
+    [[nodiscard]] virtual bool checkSphereCachedFullPush(f32 radius, const EGG::Vector3f &pos,
+            const EGG::Vector3f &prevPos, KCLTypeMask mask, CollisionInfo *info,
+            KCLTypeMask *maskOut, u32 timeOffset) = 0;
+};
+
+} // namespace Field

--- a/source/game/field/obj/ObjectNoImpl.hh
+++ b/source/game/field/obj/ObjectNoImpl.hh
@@ -10,6 +10,7 @@ public:
     ~ObjectNoImpl() override;
 
     void load() override;
+    void createCollision() override {}
     void calcCollisionTransform() override {}
 };
 

--- a/source/game/kart/KartCollide.cc
+++ b/source/game/kart/KartCollide.cc
@@ -213,7 +213,7 @@ void KartCollide::calcBodyCollision(f32 totalScale, f32 sinkDepth, const EGG::Qu
 
     EGG::Vector3f posRel = EGG::Vector3f::zero;
     s32 count = 0;
-    Field::CourseColMgr::CollisionInfo colInfo;
+    Field::CollisionInfo colInfo;
     colInfo.bbox.setDirect(EGG::Vector3f::zero, EGG::Vector3f::zero);
     Field::KCLTypeMask maskOut;
     Field::CourseColMgr::NoBounceWallColInfo noBounceWallInfo;
@@ -395,7 +395,7 @@ void KartCollide::calcWheelCollision(u16 /*wheelIdx*/, CollisionGroup *hitboxGro
     hitboxGroup->resetCollision();
     firstHitbox.setWorldPos(center);
 
-    Field::CourseColMgr::CollisionInfo colInfo;
+    Field::CollisionInfo colInfo;
     colInfo.bbox.setZero();
     Field::KCLTypeMask kclOut;
     Field::CourseColMgr::NoBounceWallColInfo noBounceWallInfo;
@@ -442,7 +442,7 @@ void KartCollide::calcWheelCollision(u16 /*wheelIdx*/, CollisionGroup *hitboxGro
 /// @stage 2
 /// @addr{0x8056F26C}
 void KartCollide::calcSideCollision(CollisionData &collisionData, Hitbox &hitbox,
-        Field::CourseColMgr::CollisionInfo *colInfo) {
+        Field::CollisionInfo *colInfo) {
     if (colInfo->perpendicularity <= 0.0f) {
         return;
     }
@@ -474,7 +474,7 @@ void KartCollide::calcSideCollision(CollisionData &collisionData, Hitbox &hitbox
         f32 sign = i == 1 ? -1.0f : 1.0f;
         f32 effectiveRadius = sign * hitbox.radius();
         EGG::Vector3f effectivePos = hitbox.worldPos() + effectiveRadius * right;
-        Field::CourseColMgr::CollisionInfoPartial tempColInfo;
+        Field::CollisionInfoPartial tempColInfo;
 
         if (Field::CollisionDirector::Instance()->checkSphereCachedPartial(hitbox.radius(),
                     effectivePos, hitbox.lastPos(), KCL_TYPE_DRIVER_WALL, &tempColInfo, nullptr,
@@ -559,13 +559,13 @@ void KartCollide::calcPoleTimer() {
 /// @brief Processes moving water and floor collision effects
 /// @addr{0x8056E8D4}
 void KartCollide::processWheel(CollisionData &collisionData, Hitbox &hitbox,
-        Field::CourseColMgr::CollisionInfo *colInfo, Field::KCLTypeMask *maskOut) {
+        Field::CollisionInfo *colInfo, Field::KCLTypeMask *maskOut) {
     processFloor(collisionData, hitbox, colInfo, maskOut, true);
 }
 
 /// @addr{0x8056E764}
 void KartCollide::processBody(CollisionData &collisionData, Hitbox &hitbox,
-        Field::CourseColMgr::CollisionInfo *colInfo, Field::KCLTypeMask *maskOut) {
+        Field::CollisionInfo *colInfo, Field::KCLTypeMask *maskOut) {
     bool hasWallCollision = processWall(collisionData, maskOut);
 
     processFloor(collisionData, hitbox, colInfo, maskOut, false);
@@ -612,7 +612,7 @@ bool KartCollide::processWall(CollisionData &collisionData, Field::KCLTypeMask *
 /// @param maskOut Stores the flags from the floor KCL
 /// @param wheel Differentiates between body and wheel floor collision (boost panels)
 void KartCollide::processFloor(CollisionData &collisionData, Hitbox &hitbox,
-        Field::CourseColMgr::CollisionInfo * /*colInfo*/, Field::KCLTypeMask *maskOut, bool wheel) {
+        Field::CollisionInfo * /*colInfo*/, Field::KCLTypeMask *maskOut, bool wheel) {
     constexpr Field::KCLTypeMask BOOST_RAMP_MASK = KCL_TYPE_BIT(COL_TYPE_BOOST_RAMP);
 
     if (collisionData.bSoftWall) {
@@ -804,7 +804,7 @@ void KartCollide::applySomeFloorMoment(f32 down, f32 rate, CollisionGroup *hitbo
 /// @rename
 bool KartCollide::FUN_805B6A9C(CollisionData &collisionData, const Hitbox &hitbox,
         EGG::BoundBox3f &minMax, EGG::Vector3f &relPos, s32 &count,
-        const Field::KCLTypeMask &maskOut, const Field::CourseColMgr::CollisionInfo &colInfo) {
+        const Field::KCLTypeMask &maskOut, const Field::CollisionInfo &colInfo) {
     if (maskOut & KCL_TYPE_WALL) {
         if (!(maskOut & KCL_TYPE_FLOOR) && state()->isHWG() &&
                 state()->softWallSpeed().dot(colInfo.wallNrm) < 0.3f) {

--- a/source/game/kart/KartCollide.hh
+++ b/source/game/kart/KartCollide.hh
@@ -83,18 +83,18 @@ public:
     void calcWheelCollision(u16 wheelIdx, CollisionGroup *hitboxGroup, const EGG::Vector3f &colVel,
             const EGG::Vector3f &center, f32 radius);
     void calcSideCollision(CollisionData &collisionData, Hitbox &hitbox,
-            Field::CourseColMgr::CollisionInfo *colInfo);
+            Field::CollisionInfo *colInfo);
     void calcBoundingRadius();
     void calcObjectCollision();
     void calcPoleTimer();
 
     void processWheel(CollisionData &collisionData, Hitbox &hitbox,
-            Field::CourseColMgr::CollisionInfo *colInfo, Field::KCLTypeMask *maskOut);
+            Field::CollisionInfo *colInfo, Field::KCLTypeMask *maskOut);
     void processBody(CollisionData &collisionData, Hitbox &hitbox,
-            Field::CourseColMgr::CollisionInfo *colInfo, Field::KCLTypeMask *maskOut);
+            Field::CollisionInfo *colInfo, Field::KCLTypeMask *maskOut);
     [[nodiscard]] bool processWall(CollisionData &collisionData, Field::KCLTypeMask *maskOut);
     void processFloor(CollisionData &collisionData, Hitbox &hitbox,
-            Field::CourseColMgr::CollisionInfo *colInfo, Field::KCLTypeMask *maskOut, bool wheel);
+            Field::CollisionInfo *colInfo, Field::KCLTypeMask *maskOut, bool wheel);
 
     void applySomeFloorMoment(f32 down, f32 rate, CollisionGroup *hitboxGroup,
             const EGG::Vector3f &forward, const EGG::Vector3f &nextDir, const EGG::Vector3f &speed,
@@ -102,7 +102,7 @@ public:
 
     [[nodiscard]] bool FUN_805B6A9C(CollisionData &collisionData, const Hitbox &hitbox,
             EGG::BoundBox3f &minMax, EGG::Vector3f &relPos, s32 &count,
-            const Field::KCLTypeMask &maskOut, const Field::CourseColMgr::CollisionInfo &colInfo);
+            const Field::KCLTypeMask &maskOut, const Field::CollisionInfo &colInfo);
     void applyBodyCollision(CollisionData &collisionData, const EGG::Vector3f &movement,
             const EGG::Vector3f &posRel, s32 count);
 

--- a/source/game/kart/KartHalfPipe.cc
+++ b/source/game/kart/KartHalfPipe.cc
@@ -163,8 +163,8 @@ void KartHalfPipe::calcLanding(bool) {
 
     constexpr f32 COS_PI_OVER_4 = 0.707f;
 
-    Field::CourseColMgr::CollisionInfo colInfo;
-    Field::CourseColMgr::CollisionInfo colInfo2;
+    Field::CollisionInfo colInfo;
+    Field::CollisionInfo colInfo2;
     Field::KCLTypeMask maskOut;
     EGG::Vector3f pos;
     EGG::Vector3f upLocal;

--- a/source/game/kart/KartMove.cc
+++ b/source/game/kart/KartMove.cc
@@ -228,7 +228,7 @@ void KartMove::setInitialPhysicsValues(const EGG::Vector3f &position, const EGG:
     EGG::Quatf quaternion;
     quaternion.setRPY(angles * DEG2RAD);
     EGG::Vector3f newPos = position;
-    Field::CourseColMgr::CollisionInfo info;
+    Field::CollisionInfo info;
     Field::KCLTypeMask kcl_flags = KCL_NONE;
 
     bool bColliding = Field::CollisionDirector::Instance()->checkSphereFullPush(100.0f, newPos,
@@ -592,7 +592,7 @@ void KartMove::calcStickyRoad() {
     EGG::Vector3f pos = dynamics()->pos();
     EGG::Vector3f vel = m_speed * m_vel1Dir;
     EGG::Vector3f down = -STICKY_RADIUS * componentYAxis();
-    Field::CourseColMgr::CollisionInfo colInfo;
+    Field::CollisionInfo colInfo;
     colInfo.bbox.setZero();
     Field::KCLTypeMask kcl_flags = KCL_NONE;
     bool stickyRoad = false;
@@ -1644,7 +1644,7 @@ void KartMove::calcRejectRoad() {
 /// @addr{0x80583F2C}
 bool KartMove::calcZipperCollision(f32 radius, f32 scale, EGG::Vector3f &pos,
         EGG::Vector3f &upLocal, const EGG::Vector3f &prevPos,
-        Field::CourseColMgr::CollisionInfo *colInfo, Field::KCLTypeMask *maskOut,
+        Field::CollisionInfo *colInfo, Field::KCLTypeMask *maskOut,
         Field::KCLTypeMask flags) const {
     upLocal = mainRot().rotateVector(EGG::Vector3f::ey);
     pos = dynamics()->pos() + (-scale * m_scale.y) * upLocal;

--- a/source/game/kart/KartMove.hh
+++ b/source/game/kart/KartMove.hh
@@ -84,7 +84,7 @@ public:
     void calcHopPhysics();
     void calcRejectRoad();
     bool calcZipperCollision(f32 radius, f32 scale, EGG::Vector3f &pos, EGG::Vector3f &upLocal,
-            const EGG::Vector3f &prevPos, Field::CourseColMgr::CollisionInfo *colInfo,
+            const EGG::Vector3f &prevPos, Field::CollisionInfo *colInfo,
             Field::KCLTypeMask *maskOut, Field::KCLTypeMask flags) const;
     f32 calcSlerpRate(f32 scale, const EGG::Quatf &from, const EGG::Quatf &to) const;
     virtual void calcVehicleRotation(f32 turn);

--- a/source/game/kart/KartReject.cc
+++ b/source/game/kart/KartReject.cc
@@ -93,7 +93,7 @@ void KartReject::calcRejectRoad() {
 
 /// @addr{0x805860BC}
 bool KartReject::calcRejection() {
-    Field::CourseColMgr::CollisionInfo colInfo;
+    Field::CollisionInfo colInfo;
     Field::KCLTypeMask mask = KCL_NONE;
     state()->setNoSparkInvisibleWall(false);
     EGG::Vector3f worldUpPos = dynamics()->pos() + bodyUp() * 100.0f;


### PR DESCRIPTION
Adds the abstract class ObjectDrivable which is the base of objects such as BCwii's "TwistedWay" and RR's "Aurora" wavy road.

`ObjectDrivable::initCollision` is nop for now, but I wanted to add it pre-emptively since ObjectKCL will need to override it anyway. Less diff noise for that PR if I just add it now.