### PR TITLE
Unconditionally call calcRejection

### DIFF
--- a/source/game/kart/KartReject.cc
+++ b/source/game/kart/KartReject.cc
@@ -63,7 +63,9 @@ void KartReject::calcRejectRoad() {
 
         state()->setHop(false);
 
-        if (!state()->isNoSparkInvisibleWall() && !calcRejection()) {
+        bool didReject = calcRejection();
+
+        if (!state()->isNoSparkInvisibleWall() && !didReject) {
             state()->setRejectRoadTrigger(false);
         }
 


### PR DESCRIPTION
Independently ran into this issue separately from John's PR https://github.com/vabold/Kinoko/pull/264

Short-circuiting prevented some calls to `calcRejection`.

**NOTE**: This will affect `STATUS.md` for #271 as follows:
```
rr-rta-1-24-751         3194    ->      5491    [LABEL]
rr-ng-rta-2-24-281      1207    ->      2217    [LATER]
```