### PR TITLE
Add missing invisible wall checks

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -28,7 +28,7 @@ Test Case                                                 | Frames      |     | 
 [`bc-rta-2-08-697`](https://youtu.be/1DEReKemoeI)         | 808 / 8126  | ❌ | KMP
 [`bc-ng-rta-2-20-001`](https://youtu.be/028nClzy7B4)      | 808 / 8803  | ❌ | KMP
 [`rr-rta-1-24-751`](https://youtu.be/dgNMHyFda14)         | 5491 / 5491 | ✔️ |
-[`rr-ng-rta-2-24-281`](https://youtu.be/O-BtWWsq82o)      | 4470 / 9060 | ❌ | Missing invis wall check
+[`rr-ng-rta-2-24-281`](https://youtu.be/O-BtWWsq82o)      | 9060 / 9060 | ✔️ |
 [`rpb-rta-0-59-978`](https://youtu.be/Z-lVl-7B-So)        | 1078 / 4007 | ❌ | Moving water
 [`rpb-ng-rta-1-12-656`](https://youtu.be/LujU0kJx-hU)     | 2491 / 4767 | ❌ | Moving water
 [`ryf-rta-0-58-648`](https://youtu.be/3IKzbmawUbk)        | 583 / 3927  | ❌ | Water

--- a/source/game/kart/CollisionGroup.cc
+++ b/source/game/kart/CollisionGroup.cc
@@ -19,6 +19,7 @@ void CollisionData::reset() {
 
     bFloor = false;
     bWall = false;
+    bInvisibleWall = false;
     bWall3 = false;
     bInvisibleWallOnly = false;
     bSoftWall = false;

--- a/source/game/kart/CollisionGroup.hh
+++ b/source/game/kart/CollisionGroup.hh
@@ -33,6 +33,7 @@ struct CollisionData {
 
     bool bFloor; ///< Set if colliding with KCL which satisfies #KCL_TYPE_FLOOR
     bool bWall;  ///< Set if colliding with KCL which satisfies #KCL_TYPE_WALL
+    bool bInvisibleWall;
     bool bWall3; ///< Set if colliding with #COL_TYPE_WALL_2
     bool bInvisibleWallOnly;
     bool bSoftWall;

--- a/source/game/kart/KartCollide.cc
+++ b/source/game/kart/KartCollide.cc
@@ -98,7 +98,8 @@ void KartCollide::FUN_80572F4C() {
     f32 fVar1;
 
     if (isInRespawn() || state()->isBoost() || state()->isOverZipper() ||
-            state()->isNoSparkInvisibleWall() || state()->isHalfPipeRamp()) {
+            state()->isZipperInvisibleWall() || state()->isNoSparkInvisibleWall() ||
+            state()->isHalfPipeRamp()) {
         fVar1 = 0.0f;
     } else {
         fVar1 = 0.05f;
@@ -811,16 +812,28 @@ bool KartCollide::FUN_805B6A9C(CollisionData &collisionData, const Hitbox &hitbo
             return true;
         }
 
+        bool skipWalls = false;
+
         collisionData.wallNrm += colInfo.wallNrm;
 
-        if ((maskOut & KCL_TYPE_ANY_INVISIBLE_WALL) && !(maskOut & KCL_TYPE_4010D000)) {
-            collisionData.bInvisibleWallOnly = true;
+        if (maskOut & KCL_TYPE_ANY_INVISIBLE_WALL) {
+            collisionData.bInvisibleWall = true;
+
+            if (!(maskOut & KCL_TYPE_4010D000)) {
+                collisionData.bInvisibleWallOnly = true;
+
+                if (maskOut & KCL_TYPE_BIT(COL_TYPE_HALFPIPE_INVISIBLE_WALL)) {
+                    skipWalls = true;
+                }
+            }
         }
 
-        if (maskOut & KCL_TYPE_BIT(COL_TYPE_WALL_2)) {
-            collisionData.bWall3 = true;
-        } else {
-            collisionData.bWall = true;
+        if (!skipWalls) {
+            if (maskOut & KCL_TYPE_BIT(COL_TYPE_WALL_2)) {
+                collisionData.bWall3 = true;
+            } else {
+                collisionData.bWall = true;
+            }
         }
     }
 

--- a/source/game/kart/KartMove.cc
+++ b/source/game/kart/KartMove.cc
@@ -1436,7 +1436,7 @@ f32 KartMove::calcWallCollisionSpeedFactor(f32 &f1) {
 
     onWallCollision();
 
-    if (state()->isOverZipper()) {
+    if (state()->isZipperInvisibleWall() || state()->isOverZipper()) {
         return 1.0f;
     }
 

--- a/source/game/kart/KartReject.cc
+++ b/source/game/kart/KartReject.cc
@@ -72,7 +72,7 @@ void KartReject::calcRejectRoad() {
         return;
     }
 
-    if (!state()->isRejectRoad()) {
+    if (!state()->isRejectRoad() || state()->isZipperInvisibleWall()) {
         return;
     }
 

--- a/source/game/kart/KartState.cc
+++ b/source/game/kart/KartState.cc
@@ -136,6 +136,8 @@ void KartState::resetFlags() {
     m_bAirStart = false;
     m_bStickRight = false;
 
+    m_bZipperInvisibleWall = false;
+
     m_bJumpPadDisableYsusForce = false;
 
     m_stickY = 0.0f;
@@ -273,6 +275,10 @@ void KartState::calcCollisions() {
                 hwg = true;
             }
         }
+    }
+
+    if (colData.bInvisibleWall && m_bHalfPipeRamp) {
+        m_bZipperInvisibleWall = true;
     }
 
     if (softWallCount > 0 || hwg) {
@@ -448,6 +454,7 @@ void KartState::clearBitfield1() {
     m_bBoostOffroadInvincibility = false;
     m_bHalfPipeRamp = false;
     m_bOverZipper = false;
+    m_bZipperInvisibleWall = false;
     m_bDisableBackwardsAccel = false;
     m_bZipperBoost = false;
     m_bZipperStick = false;

--- a/source/game/kart/KartState.hh
+++ b/source/game/kart/KartState.hh
@@ -413,6 +413,10 @@ public:
         return m_bOverZipper;
     }
 
+    [[nodiscard]] bool isZipperInvisibleWall() const {
+        return m_bZipperInvisibleWall;
+    }
+
     [[nodiscard]] bool isZipperBoost() const {
         return m_bZipperBoost;
     }
@@ -590,6 +594,7 @@ private:
     bool m_bBoostOffroadInvincibility; ///< Set if we should ignore offroad slowdown this frame.
     bool m_bHalfPipeRamp;              ///< Set while colliding with zipper KCL.
     bool m_bOverZipper;                ///< Set while mid-air from a zipper.
+    bool m_bZipperInvisibleWall;       ///< Set when colliding with invisible wall above a zipper.
     bool m_bZipperBoost;               ///< Set when boosting after landing from a zipper.
     bool m_bZipperStick;               ///< Set while mid-air and still influenced by the zipper.
     bool m_bZipperTrick;               ///< Set while tricking mid-air from a zipper.


### PR DESCRIPTION
After ObjectAurora, this will sync the RR NG WR. This can cause a desync when interacting with the invisible wall above a zipper along reject road.