### PR TITLE
Add ObjColMgr

### DIFF
--- a/source/egg/math/Matrix.cc
+++ b/source/egg/math/Matrix.cc
@@ -250,6 +250,18 @@ Vector3f Matrix34f::multVector33(const Vector3f &vec) const {
     return ret;
 }
 
+/// @addr{0x8019A970}
+/// @brief Paired-singles impl. of @ref multVector33.
+Vector3f Matrix34f::ps_multVector33(const Vector3f &vec) const {
+    Vector3f ret;
+
+    ret.x = fma(mtx[0][2], vec.z, fma(mtx[0][0], vec.x, mtx[0][1] * vec.y));
+    ret.y = fma(mtx[1][2], vec.z, fma(mtx[1][0], vec.x, mtx[1][1] * vec.y));
+    ret.z = fma(mtx[2][2], vec.z, fma(mtx[2][0], vec.x, mtx[2][1] * vec.y));
+
+    return ret;
+}
+
 /// @addr{0x8022F90C}
 /// @brief Inverts the 3x3 portion of the 3x4 matrix.
 /// @details Unlike a typical matrix inversion, if the determinant is 0, then this function returns

--- a/source/egg/math/Matrix.hh
+++ b/source/egg/math/Matrix.hh
@@ -46,6 +46,7 @@ public:
     [[nodiscard]] Vector3f multVector(const Vector3f &vec) const;
     [[nodiscard]] Vector3f ps_multVector(const Vector3f &vec) const;
     [[nodiscard]] Vector3f multVector33(const Vector3f &vec) const;
+    [[nodiscard]] Vector3f ps_multVector33(const Vector3f &vec) const;
     void inverseTo33(Matrix34f &out) const;
     [[nodiscard]] Matrix34f transpose() const;
 

--- a/source/game/field/CourseColMgr.hh
+++ b/source/game/field/CourseColMgr.hh
@@ -90,6 +90,10 @@ public:
     void clearNoBounceWallInfo() {
         m_noBounceWallInfo = nullptr;
     }
+
+    void setLocalMtx(EGG::Matrix34f *mtx) {
+        m_localMtx = mtx;
+    }
     /// @endSetters
 
     /// @beginGetters

--- a/source/game/field/KColData.cc
+++ b/source/game/field/KColData.cc
@@ -279,10 +279,6 @@ const u16 *KColData::searchBlock(const EGG::Vector3f &point) {
     return reinterpret_cast<const u16 *>(curBlock + (offset & ~0x80000000));
 }
 
-u16 KColData::prismCache(u32 idx) const {
-    return m_prismCache[idx];
-}
-
 /// @brief Computes a prism vertex based off of the triangle's normal vectors
 /// @addr{0x807BDF54}
 /// @par Triangle Vertices Formula
@@ -699,6 +695,32 @@ void CollisionInfo::update(f32 now_dist, const EGG::Vector3f &offset, const EGG:
 
         updateWall(now_dist, fnrm);
     }
+}
+
+/// @addr{0x807C26AC}
+void CollisionInfo::transformInfo(CollisionInfo &rhs, const EGG::Matrix34f &mtx) {
+    rhs.bbox.min = mtx.ps_multVector33(rhs.bbox.min);
+    rhs.bbox.max = mtx.ps_multVector33(rhs.bbox.max);
+
+    EGG::Vector3f min = rhs.bbox.min;
+
+    rhs.bbox.min = min.minimize(rhs.bbox.max);
+    rhs.bbox.max = min.maximize(rhs.bbox.max);
+
+    bbox.min = bbox.min.minimize(rhs.bbox.min);
+    bbox.max = bbox.max.maximize(rhs.bbox.max);
+
+    if (floorDist < rhs.floorDist) {
+        floorDist = rhs.floorDist;
+        floorNrm = mtx.ps_multVector33(rhs.floorNrm);
+    }
+
+    if (wallDist < rhs.wallDist) {
+        wallDist = rhs.wallDist;
+        wallNrm = mtx.ps_multVector33(rhs.wallNrm);
+    }
+
+    perpendicularity = std::max(perpendicularity, rhs.perpendicularity);
 }
 
 } // namespace Field

--- a/source/game/field/KColData.hh
+++ b/source/game/field/KColData.hh
@@ -3,6 +3,7 @@
 #include "game/field/KCollisionTypes.hh"
 
 #include <egg/math/BoundBox.hh>
+#include <egg/math/Matrix.hh>
 
 // Credit: em-eight/mkw
 // Credit: stblr/Hanachan
@@ -39,8 +40,16 @@ struct CollisionInfo {
         }
     }
 
+    void reset() {
+        bbox.setZero();
+        wallDist = -std::numeric_limits<f32>::min();
+        floorDist = -std::numeric_limits<f32>::min();
+        perpendicularity = 0.0f;
+    }
+
     void update(f32 now_dist, const EGG::Vector3f &offset, const EGG::Vector3f &fnrm,
             u32 kclAttributeTypeBit);
+    void transformInfo(CollisionInfo &rhs, const EGG::Matrix34f &mtx);
 };
 
 /// @brief Performs lookups for KCL triangles
@@ -89,7 +98,13 @@ public:
     [[nodiscard]] const u16 *searchBlock(const EGG::Vector3f &pos);
 
     /// @beginGetters
-    [[nodiscard]] u16 prismCache(u32 idx) const;
+    [[nodiscard]] const EGG::BoundBox3f &bbox() const {
+        return m_bbox;
+    }
+
+    [[nodiscard]] u16 prismCache(u32 idx) const {
+        return m_prismCache[idx];
+    }
     /// @endGetters
 
     [[nodiscard]] static EGG::Vector3f GetVertex(f32 height, const EGG::Vector3f &vertex1,

--- a/source/game/field/ObjColMgr.cc
+++ b/source/game/field/ObjColMgr.cc
@@ -1,0 +1,621 @@
+#include "ObjColMgr.hh"
+
+#include "game/field/CourseColMgr.hh"
+
+namespace Field {
+
+/// @addr{0x807C4CE8}
+ObjColMgr::ObjColMgr(const void *file)
+    : m_mtx(EGG::Matrix34f::ident), m_mtxInv(EGG::Matrix34f::ident), m_kclScale(1.0f) {
+    m_data = new KColData(file);
+}
+
+/// @addr{0x807C4D6C}
+ObjColMgr::~ObjColMgr() {
+    ASSERT(m_data);
+    delete m_data;
+}
+
+/// @addr{0x807C4DC8}
+void ObjColMgr::narrScLocal(f32 radius, const EGG::Vector3f &pos, KCLTypeMask flags) {
+    EGG::Vector3f posWrtModel = m_mtxInv.ps_multVector(pos);
+    CourseColMgr::Instance()->scaledNarrowScopeLocal(m_kclScale, radius, m_data, posWrtModel,
+            flags);
+}
+
+/// @addr{0x807C4E4C}
+EGG::Vector3f ObjColMgr::kclLowWorld() const {
+    EGG::Vector3f posLocal = m_data->bbox().min * m_kclScale;
+    return m_mtx.ps_multVector(posLocal);
+}
+
+/// @addr{0x807C4E7C}
+EGG::Vector3f ObjColMgr::kclHighWorld() const {
+    EGG::Vector3f posLocal = m_data->bbox().max * m_kclScale;
+    return m_mtx.ps_multVector(posLocal);
+}
+
+/// @addr{0x807C4EAC}
+bool ObjColMgr::checkPointPartial(const EGG::Vector3f &pos, const EGG::Vector3f &prevPos,
+        KCLTypeMask flags, CollisionInfoPartial *info, KCLTypeMask *typeMaskOut) {
+    EGG::Vector3f posWrtModel = m_mtxInv.ps_multVector(pos);
+    bool hasPrevY = prevPos.y != std::numeric_limits<f32>::infinity();
+    EGG::Vector3f prevPosWrtModel = hasPrevY ? m_mtxInv.ps_multVector(prevPos) : EGG::Vector3f::inf;
+    auto *courseColMgr = CourseColMgr::Instance();
+
+    if (info) {
+        CollisionInfoPartial tempInfo;
+        tempInfo.bbox.setZero();
+
+        if (courseColMgr->noBounceWallInfo()) {
+            courseColMgr->setLocalMtx(&m_mtx);
+        }
+
+        if (courseColMgr->checkPointPartial(m_kclScale, m_data, posWrtModel, prevPosWrtModel, flags,
+                    &tempInfo, typeMaskOut)) {
+            tempInfo.bbox.min = m_mtx.ps_multVector33(tempInfo.bbox.min);
+            tempInfo.bbox.max = m_mtx.ps_multVector33(tempInfo.bbox.max);
+
+            EGG::Vector3f min = tempInfo.bbox.min;
+            tempInfo.bbox.min = min.minimize(tempInfo.bbox.max);
+            tempInfo.bbox.max = min.maximize(tempInfo.bbox.max);
+
+            info->bbox.min = info->bbox.min.minimize(tempInfo.bbox.min);
+            info->bbox.max = info->bbox.max.maximize(tempInfo.bbox.max);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    return courseColMgr->checkPointPartial(m_kclScale, m_data, posWrtModel, prevPosWrtModel, flags,
+            info, typeMaskOut);
+}
+
+/// @addr{0x807C506C}
+bool ObjColMgr::checkPointPartialPush(const EGG::Vector3f &pos, const EGG::Vector3f &prevPos,
+        KCLTypeMask flags, CollisionInfoPartial *info, KCLTypeMask *typeMaskOut) {
+    EGG::Vector3f posWrtModel = m_mtxInv.ps_multVector(pos);
+    bool hasPrevY = prevPos.y != std::numeric_limits<f32>::infinity();
+    EGG::Vector3f prevPosWrtModel = hasPrevY ? m_mtxInv.ps_multVector(prevPos) : EGG::Vector3f::inf;
+    auto *courseColMgr = CourseColMgr::Instance();
+
+    if (info) {
+        CollisionInfoPartial tempInfo;
+        tempInfo.bbox.setZero();
+
+        if (courseColMgr->noBounceWallInfo()) {
+            courseColMgr->setLocalMtx(&m_mtx);
+        }
+
+        if (courseColMgr->checkPointPartialPush(m_kclScale, m_data, posWrtModel, prevPosWrtModel,
+                    flags, &tempInfo, typeMaskOut)) {
+            tempInfo.bbox.min = m_mtx.ps_multVector33(tempInfo.bbox.min);
+            tempInfo.bbox.max = m_mtx.ps_multVector33(tempInfo.bbox.max);
+
+            EGG::Vector3f min = tempInfo.bbox.min;
+            tempInfo.bbox.min = min.minimize(tempInfo.bbox.max);
+            tempInfo.bbox.max = min.maximize(tempInfo.bbox.max);
+
+            info->bbox.min = info->bbox.min.minimize(tempInfo.bbox.min);
+            info->bbox.max = info->bbox.max.maximize(tempInfo.bbox.max);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    return courseColMgr->checkPointPartialPush(m_kclScale, m_data, posWrtModel, prevPosWrtModel,
+            flags, info, typeMaskOut);
+}
+
+/// @addr{0x807C522C}
+bool ObjColMgr::checkPointFull(const EGG::Vector3f &pos, const EGG::Vector3f &prevPos,
+        KCLTypeMask flags, CollisionInfo *info, KCLTypeMask *typeMaskOut) {
+    EGG::Vector3f posWrtModel = m_mtxInv.ps_multVector(pos);
+    bool hasPrevY = prevPos.y != std::numeric_limits<f32>::infinity();
+    EGG::Vector3f prevPosWrtModel = hasPrevY ? m_mtxInv.ps_multVector(prevPos) : EGG::Vector3f::inf;
+    auto *courseColMgr = CourseColMgr::Instance();
+
+    if (info) {
+        CollisionInfo tempInfo;
+        tempInfo.reset();
+
+        if (courseColMgr->noBounceWallInfo()) {
+            courseColMgr->setLocalMtx(&m_mtx);
+        }
+
+        if (courseColMgr->checkPointFull(m_kclScale, m_data, posWrtModel, prevPosWrtModel, flags,
+                    &tempInfo, typeMaskOut)) {
+            info->transformInfo(tempInfo, m_mtx);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    return courseColMgr->checkPointFull(m_kclScale, m_data, posWrtModel, prevPosWrtModel, flags,
+            info, typeMaskOut);
+}
+
+/// @addr{0x807C53A4}
+bool ObjColMgr::checkPointFullPush(const EGG::Vector3f &pos, const EGG::Vector3f &prevPos,
+        KCLTypeMask flags, CollisionInfo *info, KCLTypeMask *typeMaskOut) {
+    EGG::Vector3f posWrtModel = m_mtxInv.ps_multVector(pos);
+    bool hasPrevY = prevPos.y != std::numeric_limits<f32>::infinity();
+    EGG::Vector3f prevPosWrtModel = hasPrevY ? m_mtxInv.ps_multVector(prevPos) : EGG::Vector3f::inf;
+    auto *courseColMgr = CourseColMgr::Instance();
+
+    if (info) {
+        CollisionInfo tempInfo;
+        tempInfo.reset();
+
+        if (courseColMgr->noBounceWallInfo()) {
+            courseColMgr->setLocalMtx(&m_mtx);
+        }
+
+        if (courseColMgr->checkPointFullPush(m_kclScale, m_data, posWrtModel, prevPosWrtModel,
+                    flags, &tempInfo, typeMaskOut)) {
+            info->transformInfo(tempInfo, m_mtx);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    return courseColMgr->checkPointFullPush(m_kclScale, m_data, posWrtModel, prevPosWrtModel, flags,
+            info, typeMaskOut);
+}
+
+/// @addr{0x807C551C}
+bool ObjColMgr::checkSpherePartial(f32 radius, const EGG::Vector3f &pos,
+        const EGG::Vector3f &prevPos, KCLTypeMask flags, CollisionInfoPartial *info,
+        KCLTypeMask *typeMaskOut) {
+    EGG::Vector3f posWrtModel = m_mtxInv.ps_multVector(pos);
+    bool hasPrevY = prevPos.y != std::numeric_limits<f32>::infinity();
+    EGG::Vector3f prevPosWrtModel = hasPrevY ? m_mtxInv.ps_multVector(prevPos) : EGG::Vector3f::inf;
+    auto *courseColMgr = CourseColMgr::Instance();
+
+    if (info) {
+        CollisionInfoPartial tempInfo;
+        tempInfo.bbox.setZero();
+
+        if (courseColMgr->noBounceWallInfo()) {
+            courseColMgr->setLocalMtx(&m_mtx);
+        }
+
+        if (courseColMgr->checkSpherePartial(m_kclScale, radius, m_data, posWrtModel,
+                    prevPosWrtModel, flags, &tempInfo, typeMaskOut)) {
+            tempInfo.bbox.min = m_mtx.ps_multVector33(tempInfo.bbox.min);
+            tempInfo.bbox.max = m_mtx.ps_multVector33(tempInfo.bbox.max);
+
+            EGG::Vector3f min = tempInfo.bbox.min;
+            tempInfo.bbox.min = min.minimize(tempInfo.bbox.max);
+            tempInfo.bbox.max = min.maximize(tempInfo.bbox.max);
+
+            info->bbox.min = info->bbox.min.minimize(tempInfo.bbox.min);
+            info->bbox.max = info->bbox.max.maximize(tempInfo.bbox.max);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    return courseColMgr->checkSpherePartial(m_kclScale, radius, m_data, posWrtModel,
+            prevPosWrtModel, flags, info, typeMaskOut);
+}
+
+/// @addr{0x807C56F8}
+bool ObjColMgr::checkSpherePartialPush(f32 radius, const EGG::Vector3f &pos,
+        const EGG::Vector3f &prevPos, KCLTypeMask flags, CollisionInfoPartial *info,
+        KCLTypeMask *typeMaskOut) {
+    EGG::Vector3f posWrtModel = m_mtxInv.ps_multVector(pos);
+    bool hasPrevY = prevPos.y != std::numeric_limits<f32>::infinity();
+    EGG::Vector3f prevPosWrtModel = hasPrevY ? m_mtxInv.ps_multVector(prevPos) : EGG::Vector3f::inf;
+    auto *courseColMgr = CourseColMgr::Instance();
+
+    if (info) {
+        CollisionInfoPartial tempInfo;
+        tempInfo.bbox.setZero();
+
+        if (courseColMgr->noBounceWallInfo()) {
+            courseColMgr->setLocalMtx(&m_mtx);
+        }
+
+        if (courseColMgr->checkSpherePartialPush(m_kclScale, radius, m_data, posWrtModel,
+                    prevPosWrtModel, flags, &tempInfo, typeMaskOut)) {
+            tempInfo.bbox.min = m_mtx.ps_multVector33(tempInfo.bbox.min);
+            tempInfo.bbox.max = m_mtx.ps_multVector33(tempInfo.bbox.max);
+
+            EGG::Vector3f min = tempInfo.bbox.min;
+            tempInfo.bbox.min = min.minimize(tempInfo.bbox.max);
+            tempInfo.bbox.max = min.maximize(tempInfo.bbox.max);
+
+            info->bbox.min = info->bbox.min.minimize(tempInfo.bbox.min);
+            info->bbox.max = info->bbox.max.maximize(tempInfo.bbox.max);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    return courseColMgr->checkSpherePartialPush(m_kclScale, radius, m_data, posWrtModel,
+            prevPosWrtModel, flags, info, typeMaskOut);
+}
+
+/// @addr{0x807C58D4}
+bool ObjColMgr::checkSphereFull(f32 radius, const EGG::Vector3f &pos, const EGG::Vector3f &prevPos,
+        KCLTypeMask flags, CollisionInfo *info, KCLTypeMask *typeMaskOut) {
+    EGG::Vector3f posWrtModel = m_mtxInv.ps_multVector(pos);
+    bool hasPrevY = prevPos.y != std::numeric_limits<f32>::infinity();
+    EGG::Vector3f prevPosWrtModel = hasPrevY ? m_mtxInv.ps_multVector(prevPos) : EGG::Vector3f::inf;
+    auto *courseColMgr = CourseColMgr::Instance();
+
+    if (info) {
+        CollisionInfo tempInfo;
+        tempInfo.reset();
+
+        if (courseColMgr->noBounceWallInfo()) {
+            courseColMgr->setLocalMtx(&m_mtx);
+        }
+
+        if (courseColMgr->checkSphereFull(m_kclScale, radius, m_data, posWrtModel, prevPosWrtModel,
+                    flags, &tempInfo, typeMaskOut)) {
+            info->transformInfo(tempInfo, m_mtx);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    return courseColMgr->checkSphereFull(m_kclScale, radius, m_data, posWrtModel, prevPosWrtModel,
+            flags, info, typeMaskOut);
+}
+
+/// @addr{0x807C5A68}
+bool ObjColMgr::checkSphereFullPush(f32 radius, const EGG::Vector3f &pos,
+        const EGG::Vector3f &prevPos, KCLTypeMask flags, CollisionInfo *info,
+        KCLTypeMask *typeMaskOut) {
+    EGG::Vector3f posWrtModel = m_mtxInv.ps_multVector(pos);
+    bool hasPrevY = prevPos.y != std::numeric_limits<f32>::infinity();
+    EGG::Vector3f prevPosWrtModel = hasPrevY ? m_mtxInv.ps_multVector(prevPos) : EGG::Vector3f::inf;
+    auto *courseColMgr = CourseColMgr::Instance();
+
+    if (info) {
+        CollisionInfo tempInfo;
+        tempInfo.reset();
+
+        if (courseColMgr->noBounceWallInfo()) {
+            courseColMgr->setLocalMtx(&m_mtx);
+        }
+
+        if (courseColMgr->checkSphereFullPush(m_kclScale, radius, m_data, posWrtModel,
+                    prevPosWrtModel, flags, &tempInfo, typeMaskOut)) {
+            info->transformInfo(tempInfo, m_mtx);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    return courseColMgr->checkSphereFullPush(m_kclScale, radius, m_data, posWrtModel,
+            prevPosWrtModel, flags, info, typeMaskOut);
+}
+
+/// @addr{0x807C5BFC}
+bool ObjColMgr::checkPointCachedPartial(const EGG::Vector3f &pos, const EGG::Vector3f &prevPos,
+        KCLTypeMask flags, CollisionInfoPartial *info, KCLTypeMask *typeMaskOut) {
+    if (m_data->prismCache(0) == 0) {
+        return false;
+    }
+
+    EGG::Vector3f posWrtModel = m_mtxInv.ps_multVector(pos);
+    bool hasPrevY = prevPos.y != std::numeric_limits<f32>::infinity();
+    EGG::Vector3f prevPosWrtModel = hasPrevY ? m_mtxInv.ps_multVector(prevPos) : EGG::Vector3f::inf;
+    auto *courseColMgr = CourseColMgr::Instance();
+
+    if (info) {
+        CollisionInfoPartial tempInfo;
+        tempInfo.bbox.setZero();
+
+        if (courseColMgr->noBounceWallInfo()) {
+            courseColMgr->setLocalMtx(&m_mtx);
+        }
+
+        if (courseColMgr->checkPointCachedPartial(m_kclScale, m_data, posWrtModel, prevPosWrtModel,
+                    flags, &tempInfo, typeMaskOut)) {
+            tempInfo.bbox.min = m_mtx.ps_multVector33(tempInfo.bbox.min);
+            tempInfo.bbox.max = m_mtx.ps_multVector33(tempInfo.bbox.max);
+
+            EGG::Vector3f min = tempInfo.bbox.min;
+            tempInfo.bbox.min = min.minimize(tempInfo.bbox.max);
+            tempInfo.bbox.max = min.maximize(tempInfo.bbox.max);
+
+            info->bbox.min = info->bbox.min.minimize(tempInfo.bbox.min);
+            info->bbox.max = info->bbox.max.maximize(tempInfo.bbox.max);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    return courseColMgr->checkPointCachedPartial(m_kclScale, m_data, posWrtModel, prevPosWrtModel,
+            flags, info, typeMaskOut);
+}
+
+/// @addr{0x807C5DD4}
+bool ObjColMgr::checkPointCachedPartialPush(const EGG::Vector3f &pos, const EGG::Vector3f &prevPos,
+        KCLTypeMask flags, CollisionInfoPartial *info, KCLTypeMask *typeMaskOut) {
+    if (m_data->prismCache(0) == 0) {
+        return false;
+    }
+
+    EGG::Vector3f posWrtModel = m_mtxInv.ps_multVector(pos);
+    bool hasPrevY = prevPos.y != std::numeric_limits<f32>::infinity();
+    EGG::Vector3f prevPosWrtModel = hasPrevY ? m_mtxInv.ps_multVector(prevPos) : EGG::Vector3f::inf;
+    auto *courseColMgr = CourseColMgr::Instance();
+
+    if (info) {
+        CollisionInfoPartial tempInfo;
+        tempInfo.bbox.setZero();
+
+        if (courseColMgr->noBounceWallInfo()) {
+            courseColMgr->setLocalMtx(&m_mtx);
+        }
+
+        if (courseColMgr->checkPointCachedPartialPush(m_kclScale, m_data, posWrtModel,
+                    prevPosWrtModel, flags, &tempInfo, typeMaskOut)) {
+            tempInfo.bbox.min = m_mtx.ps_multVector33(tempInfo.bbox.min);
+            tempInfo.bbox.max = m_mtx.ps_multVector33(tempInfo.bbox.max);
+
+            EGG::Vector3f min = tempInfo.bbox.min;
+            tempInfo.bbox.min = min.minimize(tempInfo.bbox.max);
+            tempInfo.bbox.max = min.maximize(tempInfo.bbox.max);
+
+            info->bbox.min = info->bbox.min.minimize(tempInfo.bbox.min);
+            info->bbox.max = info->bbox.max.maximize(tempInfo.bbox.max);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    return courseColMgr->checkPointCachedPartialPush(m_kclScale, m_data, posWrtModel,
+            prevPosWrtModel, flags, info, typeMaskOut);
+}
+
+/// @addr{0x807C5FAC}
+bool ObjColMgr::checkPointCachedFull(const EGG::Vector3f &pos, const EGG::Vector3f &prevPos,
+        KCLTypeMask flags, CollisionInfo *info, KCLTypeMask *typeMaskOut) {
+    if (m_data->prismCache(0) == 0) {
+        return false;
+    }
+
+    EGG::Vector3f posWrtModel = m_mtxInv.ps_multVector(pos);
+    bool hasPrevY = prevPos.y != std::numeric_limits<f32>::infinity();
+    EGG::Vector3f prevPosWrtModel = hasPrevY ? m_mtxInv.ps_multVector(prevPos) : EGG::Vector3f::inf;
+    auto *courseColMgr = CourseColMgr::Instance();
+
+    if (info) {
+        CollisionInfo tempInfo;
+        tempInfo.reset();
+
+        if (courseColMgr->noBounceWallInfo()) {
+            courseColMgr->setLocalMtx(&m_mtx);
+        }
+
+        if (courseColMgr->checkPointCachedFull(m_kclScale, m_data, posWrtModel, prevPosWrtModel,
+                    flags, &tempInfo, typeMaskOut)) {
+            info->transformInfo(tempInfo, m_mtx);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    return courseColMgr->checkPointCachedFull(m_kclScale, m_data, posWrtModel, prevPosWrtModel,
+            flags, info, typeMaskOut);
+}
+
+/// @addr{0x807C613C}
+bool ObjColMgr::checkPointCachedFullPush(const EGG::Vector3f &pos, const EGG::Vector3f &prevPos,
+        KCLTypeMask flags, CollisionInfo *info, KCLTypeMask *typeMaskOut) {
+    if (m_data->prismCache(0) == 0) {
+        return false;
+    }
+
+    EGG::Vector3f posWrtModel = m_mtxInv.ps_multVector(pos);
+    bool hasPrevY = prevPos.y != std::numeric_limits<f32>::infinity();
+    EGG::Vector3f prevPosWrtModel = hasPrevY ? m_mtxInv.ps_multVector(prevPos) : EGG::Vector3f::inf;
+    auto *courseColMgr = CourseColMgr::Instance();
+
+    if (info) {
+        CollisionInfo tempInfo;
+        tempInfo.reset();
+
+        if (courseColMgr->noBounceWallInfo()) {
+            courseColMgr->setLocalMtx(&m_mtx);
+        }
+
+        if (courseColMgr->checkPointCachedFullPush(m_kclScale, m_data, posWrtModel, prevPosWrtModel,
+                    flags, &tempInfo, typeMaskOut)) {
+            info->transformInfo(tempInfo, m_mtx);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    return courseColMgr->checkPointCachedFullPush(m_kclScale, m_data, posWrtModel, prevPosWrtModel,
+            flags, info, typeMaskOut);
+}
+
+/// @addr{0x807C62CC}
+bool ObjColMgr::checkSphereCachedPartial(f32 radius, const EGG::Vector3f &pos,
+        const EGG::Vector3f &prevPos, KCLTypeMask typeflags, CollisionInfoPartial *info,
+        KCLTypeMask *typeMaskOut) {
+    if (m_data->prismCache(0) == 0) {
+        return false;
+    }
+
+    EGG::Vector3f posWrtModel = m_mtxInv.ps_multVector(pos);
+    bool hasPrevY = prevPos.y != std::numeric_limits<f32>::infinity();
+    EGG::Vector3f prevPosWrtModel = hasPrevY ? m_mtxInv.ps_multVector(prevPos) : EGG::Vector3f::inf;
+    auto *courseColMgr = CourseColMgr::Instance();
+
+    if (info) {
+        CollisionInfoPartial tempInfo;
+        tempInfo.bbox.setZero();
+
+        if (courseColMgr->noBounceWallInfo()) {
+            courseColMgr->setLocalMtx(&m_mtx);
+        }
+
+        if (courseColMgr->checkSphereCachedPartial(m_kclScale, radius, m_data, posWrtModel,
+                    prevPosWrtModel, typeflags, &tempInfo, typeMaskOut)) {
+            tempInfo.bbox.min = m_mtx.ps_multVector33(tempInfo.bbox.min);
+            tempInfo.bbox.max = m_mtx.ps_multVector33(tempInfo.bbox.max);
+
+            EGG::Vector3f min = tempInfo.bbox.min;
+            tempInfo.bbox.min = min.minimize(tempInfo.bbox.max);
+            tempInfo.bbox.max = min.maximize(tempInfo.bbox.max);
+
+            info->bbox.min = info->bbox.min.minimize(tempInfo.bbox.min);
+            info->bbox.max = info->bbox.max.maximize(tempInfo.bbox.max);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    return courseColMgr->checkSphereCachedPartial(m_kclScale, radius, m_data, posWrtModel,
+            prevPosWrtModel, typeflags, info, typeMaskOut);
+}
+
+/// @addr{0x807C64C0}
+bool ObjColMgr::checkSphereCachedPartialPush(f32 radius, const EGG::Vector3f &pos,
+        const EGG::Vector3f &prevPos, KCLTypeMask typeflags, CollisionInfoPartial *info,
+        KCLTypeMask *typeMaskOut) {
+    if (m_data->prismCache(0) == 0) {
+        return false;
+    }
+
+    EGG::Vector3f posWrtModel = m_mtxInv.ps_multVector(pos);
+    bool hasPrevY = prevPos.y != std::numeric_limits<f32>::infinity();
+    EGG::Vector3f prevPosWrtModel = hasPrevY ? m_mtxInv.ps_multVector(prevPos) : EGG::Vector3f::inf;
+    auto *courseColMgr = CourseColMgr::Instance();
+
+    if (info) {
+        CollisionInfoPartial tempInfo;
+        tempInfo.bbox.setZero();
+
+        if (courseColMgr->noBounceWallInfo()) {
+            courseColMgr->setLocalMtx(&m_mtx);
+        }
+
+        if (courseColMgr->checkSphereCachedPartialPush(m_kclScale, radius, m_data, posWrtModel,
+                    prevPosWrtModel, typeflags, &tempInfo, typeMaskOut)) {
+            tempInfo.bbox.min = m_mtx.ps_multVector33(tempInfo.bbox.min);
+            tempInfo.bbox.max = m_mtx.ps_multVector33(tempInfo.bbox.max);
+
+            EGG::Vector3f min = tempInfo.bbox.min;
+            tempInfo.bbox.min = min.minimize(tempInfo.bbox.max);
+            tempInfo.bbox.max = min.maximize(tempInfo.bbox.max);
+
+            info->bbox.min = info->bbox.min.minimize(tempInfo.bbox.min);
+            info->bbox.max = info->bbox.max.maximize(tempInfo.bbox.max);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    return courseColMgr->checkSphereCachedPartialPush(m_kclScale, radius, m_data, posWrtModel,
+            prevPosWrtModel, typeflags, info, typeMaskOut);
+}
+
+/// @addr{0x807C66B4}
+bool ObjColMgr::checkSphereCachedFull(f32 radius, const EGG::Vector3f &pos,
+        const EGG::Vector3f &prevPos, KCLTypeMask typeflags, CollisionInfo *info,
+        KCLTypeMask *typeMaskOut) {
+    if (m_data->prismCache(0) == 0) {
+        return false;
+    }
+
+    EGG::Vector3f posWrtModel = m_mtxInv.ps_multVector(pos);
+    bool hasPrevY = prevPos.y != std::numeric_limits<f32>::infinity();
+    EGG::Vector3f prevPosWrtModel = hasPrevY ? m_mtxInv.ps_multVector(prevPos) : EGG::Vector3f::inf;
+    auto *courseColMgr = CourseColMgr::Instance();
+
+    if (info) {
+        CollisionInfo tempInfo;
+        tempInfo.reset();
+
+        if (courseColMgr->noBounceWallInfo()) {
+            courseColMgr->setLocalMtx(&m_mtx);
+        }
+
+        if (courseColMgr->checkSphereCachedFull(m_kclScale, radius, m_data, posWrtModel,
+                    prevPosWrtModel, typeflags, &tempInfo, typeMaskOut)) {
+            info->transformInfo(tempInfo, m_mtx);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    return courseColMgr->checkSphereCachedFull(m_kclScale, radius, m_data, posWrtModel,
+            prevPosWrtModel, typeflags, info, typeMaskOut);
+}
+
+/// @addr{0x807C6860}
+bool ObjColMgr::checkSphereCachedFullPush(f32 radius, const EGG::Vector3f &pos,
+        const EGG::Vector3f &prevPos, KCLTypeMask typeflags, CollisionInfo *info,
+        KCLTypeMask *typeMaskOut) {
+    if (m_data->prismCache(0) == 0) {
+        return false;
+    }
+
+    EGG::Vector3f posWrtModel = m_mtxInv.ps_multVector(pos);
+    bool hasPrevY = prevPos.y != std::numeric_limits<f32>::infinity();
+    EGG::Vector3f prevPosWrtModel = hasPrevY ? m_mtxInv.ps_multVector(prevPos) : EGG::Vector3f::inf;
+    auto *courseColMgr = CourseColMgr::Instance();
+
+    if (info) {
+        CollisionInfo tempInfo;
+        tempInfo.reset();
+
+        if (courseColMgr->noBounceWallInfo()) {
+            courseColMgr->setLocalMtx(&m_mtx);
+        }
+
+        if (courseColMgr->checkSphereCachedFullPush(m_kclScale, radius, m_data, posWrtModel,
+                    prevPosWrtModel, typeflags, &tempInfo, typeMaskOut)) {
+            info->transformInfo(tempInfo, m_mtx);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    return courseColMgr->checkSphereCachedFullPush(m_kclScale, radius, m_data, posWrtModel,
+            prevPosWrtModel, typeflags, info, typeMaskOut);
+}
+
+} // namespace Field

--- a/source/game/field/ObjColMgr.hh
+++ b/source/game/field/ObjColMgr.hh
@@ -1,0 +1,87 @@
+#pragma once
+
+#include "game/field/KColData.hh"
+
+namespace Field {
+
+/// @brief Manager for an object's KCL interactions.
+/// @nosubgrouping
+class ObjColMgr {
+public:
+    ObjColMgr(const void *file);
+    ~ObjColMgr();
+
+    void narrScLocal(f32 radius, const EGG::Vector3f &pos, KCLTypeMask flags);
+
+    [[nodiscard]] EGG::Vector3f kclLowWorld() const;
+    [[nodiscard]] EGG::Vector3f kclHighWorld() const;
+
+    [[nodiscard]] bool checkPointPartial(const EGG::Vector3f &pos, const EGG::Vector3f &prevPos,
+            KCLTypeMask flags, CollisionInfoPartial *infoOut, KCLTypeMask *typeMaskOut);
+    [[nodiscard]] bool checkPointPartialPush(const EGG::Vector3f &pos, const EGG::Vector3f &prevPos,
+            KCLTypeMask flags, CollisionInfoPartial *info, KCLTypeMask *typeMaskOut);
+    [[nodiscard]] bool checkPointFull(const EGG::Vector3f &pos, const EGG::Vector3f &prevPos,
+            KCLTypeMask flags, CollisionInfo *pInfo, KCLTypeMask *typeMaskOut);
+    [[nodiscard]] bool checkPointFullPush(const EGG::Vector3f &pos, const EGG::Vector3f &prevPos,
+            KCLTypeMask flags, CollisionInfo *pInfo, KCLTypeMask *typeMaskOut);
+
+    [[nodiscard]] bool checkSpherePartial(f32 radius, const EGG::Vector3f &pos,
+            const EGG::Vector3f &prevPos, KCLTypeMask flags, CollisionInfoPartial *info,
+            KCLTypeMask *typeMaskOut);
+    [[nodiscard]] bool checkSpherePartialPush(f32 radius, const EGG::Vector3f &pos,
+            const EGG::Vector3f &prevPos, KCLTypeMask flags, CollisionInfoPartial *info,
+            KCLTypeMask *typeMaskOut);
+    [[nodiscard]] bool checkSphereFull(f32 radius, const EGG::Vector3f &pos,
+            const EGG::Vector3f &prevPos, KCLTypeMask flags, CollisionInfo *info,
+            KCLTypeMask *typeMaskOut);
+    [[nodiscard]] bool checkSphereFullPush(f32 radius, const EGG::Vector3f &pos,
+            const EGG::Vector3f &prevPos, KCLTypeMask flags, CollisionInfo *info,
+            KCLTypeMask *typeMaskOut);
+
+    [[nodiscard]] bool checkPointCachedPartial(const EGG::Vector3f &pos,
+            const EGG::Vector3f &prevPos, KCLTypeMask flags, CollisionInfoPartial *info,
+            KCLTypeMask *typeMaskOut);
+    [[nodiscard]] bool checkPointCachedPartialPush(const EGG::Vector3f &pos,
+            const EGG::Vector3f &prevPos, KCLTypeMask flags, CollisionInfoPartial *info,
+            KCLTypeMask *typeMaskOut);
+    [[nodiscard]] bool checkPointCachedFull(const EGG::Vector3f &pos, const EGG::Vector3f &prevPos,
+            KCLTypeMask mask, CollisionInfo *pInfo, KCLTypeMask *typeMaskOut);
+    [[nodiscard]] bool checkPointCachedFullPush(const EGG::Vector3f &pos,
+            const EGG::Vector3f &prevPos, KCLTypeMask flags, CollisionInfo *pInfo,
+            KCLTypeMask *typeMaskOut);
+
+    [[nodiscard]] bool checkSphereCachedPartial(f32 radius, const EGG::Vector3f &pos,
+            const EGG::Vector3f &prevPos, KCLTypeMask flags, CollisionInfoPartial *info,
+            KCLTypeMask *typeMaskOut);
+    [[nodiscard]] bool checkSphereCachedPartialPush(f32 radius, const EGG::Vector3f &pos,
+            const EGG::Vector3f &prevPos, KCLTypeMask flags, CollisionInfoPartial *info,
+            KCLTypeMask *typeMaskOut);
+    [[nodiscard]] bool checkSphereCachedFull(f32 radius, const EGG::Vector3f &pos,
+            const EGG::Vector3f &prevPos, KCLTypeMask flags, CollisionInfo *pInfo,
+            KCLTypeMask *typeMaskOut);
+    [[nodiscard]] bool checkSphereCachedFullPush(f32 radius, const EGG::Vector3f &pos,
+            const EGG::Vector3f &prevPos, KCLTypeMask flags, CollisionInfo *pInfo,
+            KCLTypeMask *typeMaskOut);
+
+    /// @beginSetters
+    void setMtx(const EGG::Matrix34f &mtx) {
+        m_mtx = mtx;
+    }
+
+    void setInvMtx(const EGG::Matrix34f &mtx) {
+        m_mtxInv = mtx;
+    }
+
+    void setScale(f32 val) {
+        m_kclScale = val;
+    }
+    /// @endSetters
+
+private:
+    KColData *m_data;
+    EGG::Matrix34f m_mtx;
+    EGG::Matrix34f m_mtxInv;
+    f32 m_kclScale;
+};
+
+} // namespace Field


### PR DESCRIPTION
This is a prerequisite for `ObjectKCL`, since each `ObjectKCL` holds its own `ObjColMgr` member in order to perform collision checks.