### PR TITLE
Fix formatting action for Pull Request branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,8 +46,14 @@ jobs:
     name: Format
     runs-on: ubuntu-22.04
     steps:
-      - name: Checkout
+      - name: Checkout (Push)
+        if: github.event_name == 'push'
         uses: actions/checkout@v4
+      - name: Checkout (Pull Request)
+        if: github.event_name == 'pull_request_target'
+        uses: actions/checkout@v4
+        with:
+          ref: "refs/pull/${{ github.event.number }}/merge"
       - name: Download llvm
         run: wget https://apt.llvm.org/llvm.sh
       - name: Install clang-format


### PR DESCRIPTION
Tested with my fork
https://github.com/malleoz/Kinoko/pull/2

The `push` action only appears in the list because this action exists in the same repo as the PR. This shows that we check out the correct commit to check against formatting.