### PR TITLE
Implement REL wrapper for AnmObjChrRes

### DIFF
--- a/source/game/field/obj/ObjectBase.cc
+++ b/source/game/field/obj/ObjectBase.cc
@@ -2,25 +2,57 @@
 
 #include "game/field/ObjectDirector.hh"
 
-#include <game/system/CourseMap.hh>
-#include <game/system/map/MapdataPointInfo.hh>
+#include "game/system/CourseMap.hh"
+#include "game/system/ResourceManager.hh"
+#include "game/system/map/MapdataPointInfo.hh"
 
 #include <egg/math/Math.hh>
+
+#include <cstring>
 
 namespace Field {
 
 /// @addr{0x8081F828}
 ObjectBase::ObjectBase(const System::MapdataGeoObj &params)
-    : m_id(static_cast<ObjectId>(params.id())), m_flags(0x3), m_pos(params.pos()),
-      m_rot(params.rot() * DEG2RAD), m_scale(params.scale()), m_transform(EGG::Matrix34f::ident),
-      m_mapObj(&params) {}
+    : m_drawMdl(nullptr), m_resFile(nullptr), m_id(static_cast<ObjectId>(params.id())),
+      m_flags(0x3), m_pos(params.pos()), m_rot(params.rot() * DEG2RAD), m_scale(params.scale()),
+      m_transform(EGG::Matrix34f::ident), m_mapObj(&params) {}
 
 /// @addr{0x8067E3C4}
-ObjectBase::~ObjectBase() = default;
+ObjectBase::~ObjectBase() {
+    delete m_resFile;
+    delete m_drawMdl;
+}
 
 /// @addr{0x808217B8}
 void ObjectBase::calcModel() {
     calcTransform();
+}
+
+/// @addr{0x80680730}
+const char *ObjectBase::getResources() const {
+    const auto &flowTable = ObjectDirector::Instance()->flowTable();
+    const auto *collisionSet = flowTable.set(flowTable.slot(m_id));
+    ASSERT(collisionSet);
+    return collisionSet->resources;
+}
+
+/// @addr{0x8081FD10}
+void ObjectBase::loadGraphics() {
+    const char *name = getResources();
+    if (strcmp(name, "-") == 0) {
+        return;
+    }
+
+    char filename[128];
+    snprintf(filename, sizeof(filename), "%s.brres", name);
+
+    auto *resMgr = System::ResourceManager::Instance();
+    const void *resFile = resMgr->getFile(filename, nullptr, System::ArchiveId::Course);
+    if (resFile) {
+        m_resFile = new Abstract::g3d::ResFile(resFile);
+        m_drawMdl = new Render::DrawMdl;
+    }
 }
 
 /// @addr{0x80820980}
@@ -61,6 +93,20 @@ void ObjectBase::calcTransform() {
     } else if (m_flags & 1) {
         m_transform.setBase(3, m_pos);
         m_flags |= 4;
+    }
+}
+
+/// @addr{0x80820EB8}
+void ObjectBase::linkAnims(const std::span<const char *> &names,
+        const std::span<Render::AnmType> types) {
+    if (!m_drawMdl) {
+        return;
+    }
+
+    ASSERT(names.size() == types.size());
+
+    for (size_t i = 0; i < names.size(); ++i) {
+        m_drawMdl->linkAnims(i, m_resFile, names[i], types[i]);
     }
 }
 

--- a/source/game/field/obj/ObjectBase.hh
+++ b/source/game/field/obj/ObjectBase.hh
@@ -4,6 +4,8 @@
 #include "game/field/RailInterpolator.hh"
 #include "game/field/obj/ObjectId.hh"
 
+#include "game/render/DrawMdl.hh"
+
 #include "game/system/map/MapdataGeoObj.hh"
 
 #include <egg/math/Matrix.hh>
@@ -19,6 +21,9 @@ public:
     virtual void calc() {}
     virtual void calcModel();
     virtual void load() = 0;
+    [[nodiscard]] virtual const char *getResources() const;
+    virtual void loadGraphics();
+    virtual void loadAnims() {}
     virtual void createCollision() = 0;
     virtual void loadRail();
     virtual void calcCollisionTransform() = 0;
@@ -48,7 +53,10 @@ public:
 
 protected:
     void calcTransform();
+    void linkAnims(const std::span<const char *> &names, const std::span<Render::AnmType> types);
 
+    Render::DrawMdl *m_drawMdl;
+    Abstract::g3d::ResFile *m_resFile;
     ObjectId m_id;
     RailInterpolator *m_railInterpolator;
     BoxColUnit *m_boxColUnit;

--- a/source/game/field/obj/ObjectCollidable.cc
+++ b/source/game/field/obj/ObjectCollidable.cc
@@ -19,6 +19,8 @@ ObjectCollidable::~ObjectCollidable() {
 
 /// @addr{0x8081F0A0}
 void ObjectCollidable::load() {
+    loadGraphics();
+    loadAnims();
     createCollision();
 
     if (m_collision) {

--- a/source/game/render/AnmMgr.cc
+++ b/source/game/render/AnmMgr.cc
@@ -1,0 +1,25 @@
+#include "AnmMgr.hh"
+
+namespace Render {
+
+/// @addr{0x8055597C}
+void AnmMgr::linkAnims(size_t idx, const Abstract::g3d::ResFile *resFile, const char *name,
+        AnmType anmType) {
+    // For now, we only care about Chr
+    switch (anmType) {
+    case AnmType::Chr:
+        m_anmList.emplace_back(resFile->resAnmChr(name), anmType, idx);
+        break;
+    default:
+        break;
+    }
+}
+
+/// @addr{0x805573CC}
+void AnmMgr::playAnim(f32 /*frame*/, f32 /*rate*/, size_t idx) {
+    ASSERT(idx < m_anmList.size());
+    AnmNodeChr *&activeChrAnim = m_activeAnims[static_cast<size_t>(AnmType::Chr)];
+    activeChrAnim = &(*std::next(m_anmList.begin(), idx));
+}
+
+} // namespace Render

--- a/source/game/render/AnmMgr.hh
+++ b/source/game/render/AnmMgr.hh
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "game/system/ResourceManager.hh"
+
+#include <abstract/g3d/ResFile.hh>
+
+namespace Render {
+
+class DrawMdl;
+
+enum class AnmType : s32 {
+    Empty = -1,
+    Chr = 0,
+    Clr = 1,
+    Srt = 2,
+    Pat = 3,
+    Shp = 4,
+    Max = 5,
+};
+
+class AnmNodeChr {
+public:
+    AnmNodeChr(Abstract::g3d::AnmObjChrRes anmObjChrRes, AnmType anmType, size_t idx)
+        : m_anmObjChrRes(anmObjChrRes), m_anmType(anmType), m_idx(idx) {}
+
+    [[nodiscard]] f32 frameCount() const {
+        return static_cast<f32>(m_anmObjChrRes.frameCount());
+    }
+
+private:
+    Abstract::g3d::AnmObjChrRes m_anmObjChrRes;
+    AnmType m_anmType;
+    size_t m_idx;
+};
+
+class AnmMgr {
+public:
+    /// @addr{0x80555750}
+    AnmMgr(DrawMdl *drawMdl) : m_parent(drawMdl) {}
+
+    void linkAnims(size_t idx, const Abstract::g3d::ResFile *resFile, const char *name,
+            AnmType anmType);
+    void playAnim(f32 frame, f32 rate, size_t idx);
+
+    /// @addr{0x80557340}
+    [[nodiscard]] const AnmNodeChr *activeAnim(AnmType anmType) const {
+        return m_activeAnims[static_cast<size_t>(anmType)];
+    }
+
+private:
+    DrawMdl *m_parent;
+    std::list<AnmNodeChr> m_anmList;
+    std::array<AnmNodeChr *, static_cast<size_t>(AnmType::Max) - 1> m_activeAnims;
+};
+
+} // namespace Render

--- a/source/game/render/DrawMdl.cc
+++ b/source/game/render/DrawMdl.cc
@@ -1,0 +1,15 @@
+#include "DrawMdl.hh"
+
+namespace Render {
+
+/// @addr{0x8055DDEC}
+void DrawMdl::linkAnims(size_t idx, const Abstract::g3d::ResFile *resFile, const char *name,
+        AnmType anmType) {
+    if (!m_anmMgr) {
+        m_anmMgr = new AnmMgr(this);
+    }
+
+    m_anmMgr->linkAnims(idx, resFile, name, anmType);
+}
+
+} // namespace Render

--- a/source/game/render/DrawMdl.hh
+++ b/source/game/render/DrawMdl.hh
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "game/render/AnmMgr.hh"
+
+namespace Render {
+
+class DrawMdl {
+public:
+    DrawMdl() : m_anmMgr(nullptr) {}
+
+    void linkAnims(size_t idx, const Abstract::g3d::ResFile *resFile, const char *name,
+            AnmType anmType);
+
+    [[nodiscard]] AnmMgr *anmMgr() {
+        return m_anmMgr;
+    }
+
+private:
+    AnmMgr *m_anmMgr;
+};
+
+} // namespace Render


### PR DESCRIPTION
In `ObjectBase::loadGraphics` I skipped the use of `0x8055BA00` since it ends up causing a duplicate call to `getFile` which seemed unnecessary and taxing.

`playAnim` is required because when we query for a Goomba's animation framecount, it does so by querying into the active Chr animation.