### PR TITLE
Add missing KartAction check for zippers

### DIFF
--- a/source/game/kart/KartHalfPipe.cc
+++ b/source/game/kart/KartHalfPipe.cc
@@ -38,7 +38,8 @@ void KartHalfPipe::calc() {
 
     calcTrick();
 
-    if (collide()->surfaceFlags().offBit(KartCollide::eSurfaceFlags::StopHalfPipeState) &&
+    if (!state()->isInAction() &&
+            collide()->surfaceFlags().offBit(KartCollide::eSurfaceFlags::StopHalfPipeState) &&
             m_touchingZipper && state()->isAirStart()) {
         dynamics()->setExtVel(EGG::Vector3f::zero);
         state()->setOverZipper(true);


### PR DESCRIPTION
This could cause a desync on GCN Waluigi Stadium if you hit a firebar with enough speed such that you touch the zipper in the half-pipe section.