### PR TITLE
Fix memory leaks and improve deleting nullptr

### DIFF
--- a/source/egg/core/Heap.cc
+++ b/source/egg/core/Heap.cc
@@ -93,6 +93,11 @@ void *Heap::alloc(size_t size, int align, Heap *pHeap) {
 
 /// @addr{0x80229B84}
 void Heap::free(void *block, Heap *pHeap) {
+    // Deleting nullptr should be no-op
+    if (!block) {
+        return;
+    }
+
     if (!pHeap) {
         MEMiHeapHead *handle = MEMiHeapHead::findContainHeap(block);
         if (!handle) {

--- a/source/game/field/ObjectDrivableDirector.cc
+++ b/source/game/field/ObjectDrivableDirector.cc
@@ -223,6 +223,10 @@ ObjectDrivableDirector::~ObjectDrivableDirector() {
         s_instance = nullptr;
         WARN("ObjectDrivableDirector instance not explicitly handled!");
     }
+
+    for (auto *&obj : m_objects) {
+        delete obj;
+    }
 }
 
 ObjectDrivableDirector *ObjectDrivableDirector::s_instance = nullptr; ///< @addr{0x809C4310}

--- a/source/game/field/RailManager.cc
+++ b/source/game/field/RailManager.cc
@@ -25,7 +25,22 @@ void RailManager::DestroyInstance() {
 RailManager::RailManager() = default;
 
 /// @addr{0x806F0A98}
-RailManager::~RailManager() = default;
+RailManager::~RailManager() {
+    if (s_instance) {
+        s_instance = nullptr;
+        WARN("RailManager instance not explicitly handled!");
+    }
+
+    for (auto *&rail : m_rails) {
+        delete rail;
+    }
+
+    for (auto *&interpolator : m_interpolators) {
+        delete interpolator;
+    }
+
+    delete m_interpolators.data();
+}
 
 /// @addr{0x806F0AD8}
 void RailManager::createPaths() {
@@ -44,6 +59,11 @@ void RailManager::createPaths() {
     // The base game indexes based on i and j, so we need to resize regardless of isObjectRoute.
     m_interpolators = std::span<RailInterpolator *>(new RailInterpolator *[m_interpolatorTotal],
             m_interpolatorTotal);
+
+    // Avoid deallocation headache later
+    for (auto *&interpolator : m_interpolators) {
+        interpolator = nullptr;
+    }
 
     for (u16 i = 0; i < m_pointCount; ++i) {
         bool isObjectRoute = false;


### PR DESCRIPTION
Previously, deleting nullptr would be no-op because nullptr would not be found in a containing heap. Rather than search through all of the heaps just to end up not finding anything, we simply return immediately.