### PR TITLE
Implement KartState flag for spinout actions

### DIFF
--- a/source/game/kart/KartCollide.cc
+++ b/source/game/kart/KartCollide.cc
@@ -62,7 +62,8 @@ void KartCollide::calcHitboxes() {
 /// @stage All
 /// @addr{0x80572C20}
 void KartCollide::findCollision() {
-    const EGG::Quatf &rot = state()->isEndHalfPipe() ? mainRot() : fullRot();
+    bool wasHalfPipe = state()->isEndHalfPipe() || state()->isActionMidZipper();
+    const EGG::Quatf &rot = wasHalfPipe ? mainRot() : fullRot();
     calcBodyCollision(move()->totalScale(), body()->sinkDepth(), rot, scale());
 
     auto &colData = collisionData();
@@ -150,7 +151,7 @@ void KartCollide::FUN_805B72B8(f32 param_1, f32 param_2, bool lockXZ, bool addEx
     EGG::Vector3f step1 = relPos.cross(collisionDir);
     EGG::Vector3f step2 = rotMat.multVector33(step1);
     EGG::Vector3f step3 = step2.cross(relPos);
-    f32 val = (-directionalVelocity * (param_2 + 1.0f)) / (1.0f + collisionDir.dot(step3));
+    f32 val = (-directionalVelocity * (1.0f + param_2)) / (1.0f + collisionDir.dot(step3));
     EGG::Vector3f step4 = collisionDir.cross(-colData.vel);
     EGG::Vector3f step5 = step4.cross(collisionDir);
     step5.normalise();

--- a/source/game/kart/KartMove.cc
+++ b/source/game/kart/KartMove.cc
@@ -214,6 +214,10 @@ void KartMove::init(bool b1, bool b2) {
 
 /// @addr{0x8058348C}
 void KartMove::clear() {
+    if (state()->isOverZipper()) {
+        state()->setActionMidZipper(true);
+    }
+
     clearBoost();
     clearJumpPad();
     clearRampBoost();

--- a/source/game/kart/KartState.cc
+++ b/source/game/kart/KartState.cc
@@ -322,6 +322,7 @@ void KartState::calcCollisions() {
         m_bAfterCannon = false;
 
         if (!m_bInAction) {
+            m_bActionMidZipper = false;
             m_bEndHalfPipe = false;
         }
 
@@ -499,6 +500,7 @@ void KartState::clearBitfield3() {
     m_bSoftWallDrift = false;
     m_bHWG = false;
     m_bAfterCannon = false;
+    m_bActionMidZipper = false;
     m_bChargeStartBoost = false;
     m_bEndHalfPipe = false;
 }

--- a/source/game/kart/KartState.hh
+++ b/source/game/kart/KartState.hh
@@ -251,6 +251,10 @@ public:
         m_bAfterCannon = isSet;
     }
 
+    void setActionMidZipper(bool isSet) {
+        m_bActionMidZipper = isSet;
+    }
+
     void setEndHalfPipe(bool isSet) {
         m_bEndHalfPipe = isSet;
     }
@@ -367,6 +371,10 @@ public:
 
     [[nodiscard]] bool isAfterCannon() const {
         return m_bAfterCannon;
+    }
+
+    [[nodiscard]] bool isActionMidZipper() const {
+        return m_bActionMidZipper;
     }
 
     [[nodiscard]] bool isChargeStartBoost() const {
@@ -683,6 +691,7 @@ private:
     bool m_bSoftWallDrift;
     bool m_bHWG; ///< Set when "Horizontal Wall Glitch" is active.
     bool m_bAfterCannon;
+    bool m_bActionMidZipper;
     bool m_bChargeStartBoost; ///< Like @ref m_bAccelerate but during countdown.
     bool m_bEndHalfPipe;
     /// @}


### PR DESCRIPTION
This affects whether `mainRot` or `fullRot` is used in `KartCollide::findCollision()`.