### PR TITLE
Fix various bugs found during implementation of MH cars

### DIFF
--- a/source/game/field/ObjectCollisionConvexHull.cc
+++ b/source/game/field/ObjectCollisionConvexHull.cc
@@ -9,8 +9,6 @@ namespace Field {
 /// This overload enables conversion from std::array into a span, which initializes the points.
 ObjectCollisionConvexHull::ObjectCollisionConvexHull(const std::span<const EGG::Vector3f> &points)
     : ObjectCollisionConvexHull(points.size()) {
-    m_worldRadius = 70.0f;
-
     for (size_t i = 0; i < points.size(); ++i) {
         m_points[i] = points[i];
     }
@@ -33,7 +31,7 @@ void ObjectCollisionConvexHull::transform(const EGG::Matrix34f &mat, const EGG::
         }
     } else {
         EGG::Matrix34f temp;
-        temp.makeS(scale);
+        temp.makeS(EGG::Vector3f(scale.x, scale.x, scale.x));
         temp = mat.multiplyTo(temp);
 
         for (size_t i = 0; i < m_points.size(); ++i) {
@@ -68,6 +66,8 @@ const EGG::Vector3f &ObjectCollisionConvexHull::getSupport(const EGG::Vector3f &
 /// This overload enables avoiding immediate point initialization, which is useful for inheritance.
 ObjectCollisionConvexHull::ObjectCollisionConvexHull(size_t count) {
     ASSERT(count < 0x100);
+
+    m_worldRadius = 70.0f;
 
     m_points = std::span<EGG::Vector3f>(new EGG::Vector3f[count], count);
     m_worldPoints = std::span<EGG::Vector3f>(new EGG::Vector3f[count], count);

--- a/source/game/field/ObjectDirector.cc
+++ b/source/game/field/ObjectDirector.cc
@@ -41,7 +41,11 @@ void ObjectDirector::addObject(ObjectCollidable *obj) {
         m_calcObjects.push_back(obj);
     }
 
-    if (m_flowTable.set(m_flowTable.slot(obj->id()))->mode != 0) {
+    const auto *set = m_flowTable.set(m_flowTable.slot(obj->id()));
+
+    // In the base game, it's possible an object here will access slot -1 (e.g. Moonview Highway
+    // cars). We add a nullptr check here to prevent this.
+    if (set && set->mode != 0) {
         if (obj->collision()) {
             m_collisionObjects.push_back(obj);
         }

--- a/source/game/field/ObjectDirector.hh
+++ b/source/game/field/ObjectDirector.hh
@@ -63,7 +63,7 @@ private:
 
     static constexpr size_t MAX_UNIT_COUNT = 0x100;
 
-    std::array<ObjectBase *, MAX_UNIT_COUNT>
+    std::array<ObjectCollidable *, MAX_UNIT_COUNT>
             m_collidingObjects; ///< Objects we are currently colliding with
     std::array<EGG::Vector3f, MAX_UNIT_COUNT> m_hitDepths;
     std::array<Kart::Reaction, MAX_UNIT_COUNT> m_reactions;

--- a/source/game/field/RailInterpolator.cc
+++ b/source/game/field/RailInterpolator.cc
@@ -19,7 +19,7 @@ RailInterpolator::~RailInterpolator() = default;
 
 /// @addr{0806ED24C}
 const EGG::Vector3f &RailInterpolator::floorNrm(size_t idx) const {
-    return RailManager::Instance()->rail(idx)->floorNrm(idx);
+    return RailManager::Instance()->rail(m_railIdx)->floorNrm(idx);
 }
 
 /// @addr{0x806ED30C}

--- a/source/game/field/obj/ObjectCollidable.cc
+++ b/source/game/field/obj/ObjectCollidable.cc
@@ -45,7 +45,7 @@ void ObjectCollidable::calcCollisionTransform() {
 /// This does not imply that all collidable objects are boxes!
 f32 ObjectCollidable::getCollisionRadius() const {
     const auto &flowTable = ObjectDirector::Instance()->flowTable();
-    const auto *collisionSet = flowTable.set(flowTable.slot(m_id));
+    const auto *collisionSet = flowTable.set(flowTable.slot(id()));
 
     f32 zRadius = m_scale.z * static_cast<f32>(parse<s16>(collisionSet->params.box.z));
     f32 xRadius = m_scale.x * static_cast<f32>(parse<s16>(collisionSet->params.box.x));

--- a/source/game/field/obj/ObjectCollidable.hh
+++ b/source/game/field/obj/ObjectCollidable.hh
@@ -36,8 +36,6 @@ public:
 
     virtual void onWallCollision(Kart::KartObject *, const EGG::Vector3f &) {}
     virtual void onObjectCollision(Kart::KartObject *) {}
-
-    /// @addr{0x80681748}
     virtual bool checkCollision(ObjectCollisionBase *lhs, EGG::Vector3f &dist);
 
     /// @addr{0x8068173C}

--- a/source/game/kart/KartCollide.cc
+++ b/source/game/kart/KartCollide.cc
@@ -931,7 +931,11 @@ void KartCollide::startFloorMomentRate() {
 
 /// @addr{0x805713FC}
 void KartCollide::calcFloorMomentRate() {
-    m_floorMomentRate = state()->isInAction() ? 0.01f : std::min(m_floorMomentRate + 0.01f, 0.8f);
+    if (state()->isInAction() && action()->flags().onBit(KartAction::eFlags::Rotating)) {
+        m_floorMomentRate = 0.01f;
+    } else {
+        m_floorMomentRate = std::min(m_floorMomentRate + 0.01f, 0.8f);
+    }
 }
 
 /// @addr{0x8056E564}

--- a/source/game/kart/KartSub.cc
+++ b/source/game/kart/KartSub.cc
@@ -253,7 +253,7 @@ void KartSub::calcPass1() {
     }
 
     EGG::Vector3f forward = fullRot().rotateVector(EGG::Vector3f::ez);
-    m_someScale = scale().y;
+    m_someScale = std::max(scale().y, param()->stats().wheelDistance);
 
     const EGG::Vector3f gravity(0.0f, -1.3f, 0.0f);
     f32 speedFactor = 1.0f;


### PR DESCRIPTION
This is a collection of bugs discovered upon various desyncs when trying to synchronize the cars on Moonview Highway.

#### **ObjectCollisionConvexHull.cc**

If we construct a convex hull via the `ObjectCollisionConvexHull(size_t count)` overload (skipping initialization of the points, like ObjectCollisionBox does), then the `m_worldRadius` was not being initialized to `70.0f`.

#### **ObjectDirector.cc**
`ObjectHighwayManager` will be added via `ObjectDirector::addObject`. However, its id ends up corresponding to slot `-1`, which is not properly checked before being passed into `m_flowTable.set()`. In the base game, this is effectively reading out-of-bounds and coincidentally is parsed as having a mode of 0. Since we've added `ASSERT` statements in `set()`, we've caught this odd behavior and we need to adjust to compensate.

#### **ObjectDirector.hh**
At a later point, we will be accessing objects from `m_collidingObjects` and accessing functions which are only present in the `ObjectCollidable` vtable, which means we can prove that objects stored in this array are of type `ObjectCollidable *`.

#### **RailInterpolator.cc**
Typo here. We need to be passing in the `m_railidx` in order to get the corresponding rail object.

#### **ObjectCollidable.cc**
There's really a virtual function call here to get the id. It doesn't immediately pose any problems, but I'd rather address it now than forget later until an unfortunate desync investigation happens.

#### **ObjectCollidable.hh**
This is just a declaration, so we can get rid of this address comment. It's already present in the source file.

#### **KartCollide.cc**
This is less of an immediate bug fix and just one small change we'll have to apply in order to sync the flip animation when hitting a car.

#### **KartSub.cc**
Missing scale restriction causes a desync when you get squashed by a car.