### PR TITLE
Add name-based Object constructors

### DIFF
--- a/source/game/field/ObjectFlowTable.cc
+++ b/source/game/field/ObjectFlowTable.cc
@@ -2,6 +2,8 @@
 
 #include "game/system/ResourceManager.hh"
 
+#include <cstring>
+
 namespace Field {
 
 /// @addr{0x8082C10C}
@@ -16,5 +18,19 @@ ObjectFlowTable::ObjectFlowTable(const char *filename) {
 
 /// @addr{0x8082C1F4}
 ObjectFlowTable::~ObjectFlowTable() = default;
+
+/// @addr{0x8082C178}
+ObjectId ObjectFlowTable::getIdfFromName(const char *name) const {
+    for (s16 i = 0; i < m_count; ++i) {
+        const auto *curSet = set(i);
+        ASSERT(curSet);
+
+        if (strncmp(name, curSet->name, sizeof(curSet->name)) == 0) {
+            return static_cast<ObjectId>(parse<u16>(curSet->id));
+        }
+    }
+
+    return ObjectId::None;
+}
 
 } // namespace Field

--- a/source/game/field/ObjectFlowTable.hh
+++ b/source/game/field/ObjectFlowTable.hh
@@ -57,6 +57,8 @@ public:
         return i < SLOT_COUNT ? parse<s16>(m_slots[i]) : -1;
     }
 
+    [[nodiscard]] ObjectId getIdfFromName(const char *name) const;
+
 private:
     struct SFile {
         s16 count;

--- a/source/game/field/obj/ObjectBase.cc
+++ b/source/game/field/obj/ObjectBase.cc
@@ -18,6 +18,14 @@ ObjectBase::ObjectBase(const System::MapdataGeoObj &params)
       m_flags(0x3), m_pos(params.pos()), m_rot(params.rot() * DEG2RAD), m_scale(params.scale()),
       m_transform(EGG::Matrix34f::ident), m_mapObj(&params) {}
 
+/// @addr{0x8081FB04}
+ObjectBase::ObjectBase(const char *name, const EGG::Vector3f &pos, const EGG::Vector3f &rot,
+        const EGG::Vector3f &scale)
+    : m_drawMdl(nullptr), m_resFile(nullptr), m_flags(11), m_pos(pos), m_rot(rot), m_scale(scale),
+      m_transform(EGG::Matrix34f::ident), m_mapObj(nullptr) {
+    m_id = ObjectDirector::Instance()->flowTable().getIdfFromName(name);
+}
+
 /// @addr{0x8067E3C4}
 ObjectBase::~ObjectBase() {
     delete m_resFile;
@@ -75,6 +83,12 @@ void ObjectBase::loadRail() {
     } else {
         m_railInterpolator = new RailSmoothInterpolator(speed, pathId);
     }
+}
+
+/// @addr{0x80680784}
+[[nodiscard]] const char *ObjectBase::getName() const {
+    const auto &flowTable = ObjectDirector::Instance()->flowTable();
+    return flowTable.set(flowTable.slot(id()))->name;
 }
 
 /// @addr{0x806806DC}

--- a/source/game/field/obj/ObjectBase.hh
+++ b/source/game/field/obj/ObjectBase.hh
@@ -15,6 +15,8 @@ namespace Field {
 class ObjectBase {
 public:
     ObjectBase(const System::MapdataGeoObj &params);
+    ObjectBase(const char *name, const EGG::Vector3f &pos, const EGG::Vector3f &rot,
+            const EGG::Vector3f &scale);
     virtual ~ObjectBase();
 
     virtual void init() {}
@@ -27,6 +29,8 @@ public:
     virtual void createCollision() = 0;
     virtual void loadRail();
     virtual void calcCollisionTransform() = 0;
+
+    [[nodiscard]] virtual const char *getName() const;
 
     /// @addr{0x806BF434}
     [[nodiscard]] virtual u32 loadFlags() const {

--- a/source/game/field/obj/ObjectCollidable.cc
+++ b/source/game/field/obj/ObjectCollidable.cc
@@ -13,6 +13,11 @@ namespace Field {
 ObjectCollidable::ObjectCollidable(const System::MapdataGeoObj &params)
     : ObjectBase(params), m_collision(nullptr) {}
 
+/// @addr{0x8081F064}
+ObjectCollidable::ObjectCollidable(const char *name, const EGG::Vector3f &pos,
+        const EGG::Vector3f &rot, const EGG::Vector3f &scale)
+    : ObjectBase(name, pos, rot, scale), m_collision(nullptr) {}
+
 /// @addr{0x8067E384}
 ObjectCollidable::~ObjectCollidable() {
     delete m_collision;

--- a/source/game/field/obj/ObjectCollidable.hh
+++ b/source/game/field/obj/ObjectCollidable.hh
@@ -16,6 +16,8 @@ namespace Field {
 class ObjectCollidable : public ObjectBase {
 public:
     ObjectCollidable(const System::MapdataGeoObj &params);
+    ObjectCollidable(const char *name, const EGG::Vector3f &pos, const EGG::Vector3f &rot,
+            const EGG::Vector3f &scale);
     ~ObjectCollidable() override;
 
     void load() override;

--- a/source/game/field/obj/ObjectId.hh
+++ b/source/game/field/obj/ObjectId.hh
@@ -5,6 +5,7 @@
 namespace Field {
 
 enum class ObjectId {
+    None = 0x0,
     DummyPole = 0x066,
     WLWallGC = 0xcb,
     Boble = 0xdd,


### PR DESCRIPTION
This PR adds the overloaded `ObjectBase` and `ObjectCollidable` constructors which take in a name, pos, rot, and scale rather than the typical params.