### PR TITLE
Implement KartScale

### DIFF
--- a/source/game/kart/KartMove.cc
+++ b/source/game/kart/KartMove.cc
@@ -5,6 +5,7 @@
 #include "game/kart/KartJump.hh"
 #include "game/kart/KartParam.hh"
 #include "game/kart/KartPhysics.hh"
+#include "game/kart/KartScale.hh"
 #include "game/kart/KartSub.hh"
 #include "game/kart/KartSuspension.hh"
 
@@ -50,12 +51,14 @@ KartMove::KartMove() : m_smoothedUp(EGG::Vector3f::ey), m_scale(1.0f, 1.0f, 1.0f
 KartMove::~KartMove() {
     delete m_jump;
     delete m_halfPipe;
+    delete m_kartScale;
 }
 
 /// @addr{0x8057821C}
 void KartMove::createSubsystems() {
     m_jump = new KartJump(this);
     m_halfPipe = new KartHalfPipe();
+    m_kartScale = new KartScale();
 }
 
 /// @stage All
@@ -121,6 +124,7 @@ void KartMove::setTurnParams() {
     m_landingDir = m_dir;
     m_outsideDriftLastDir = m_dir;
     m_driftingParams = &DRIFTING_PARAMS_ARRAY[static_cast<u32>(param()->stats().driftType)];
+    m_kartScale->reset();
 }
 
 /// @addr{0x805784D4}
@@ -299,6 +303,7 @@ void KartMove::calc() {
     calcBoost();
     calcMushroomBoost();
     calcZipperBoost();
+    calcScale();
 
     if (state()->isInCannon()) {
         calcCannon();
@@ -2079,6 +2084,12 @@ void KartMove::landTrick() {
     activateBoost(KartBoost::Type::TrickAndZipper, duration);
 }
 
+/// @addr{0x8058160C}
+void KartMove::calcScale() {
+    m_kartScale->calc();
+    setScale(m_kartScale->currScale());
+}
+
 /// @addr{0x8058498C}
 void KartMove::enterCannon() {
     init(true, true);
@@ -2244,6 +2255,7 @@ void KartMoveBike::cancelWheelie() {
 void KartMoveBike::createSubsystems() {
     m_jump = new KartJumpBike(this);
     m_halfPipe = new KartHalfPipe();
+    m_kartScale = new KartScale();
 }
 
 /// @stage All

--- a/source/game/kart/KartMove.hh
+++ b/source/game/kart/KartMove.hh
@@ -141,6 +141,7 @@ public:
     void calcMushroomBoost();
     void calcZipperBoost();
     void landTrick();
+    void calcScale();
 
     void enterCannon();
     void calcCannon();
@@ -186,6 +187,11 @@ public:
     void setKartSpeedLimit() {
         constexpr f32 LIMIT = 120.0f;
         m_hardSpeedLimit = LIMIT;
+    }
+
+    /// @addr{0x80581720}
+    void setScale(const EGG::Vector3f &v) {
+        m_scale = v;
     }
     /// @endSetters
 
@@ -286,6 +292,10 @@ public:
         return m_halfPipe;
     }
 
+    [[nodiscard]] KartScale *kartScale() const {
+        return m_kartScale;
+    }
+
     [[nodiscard]] KartBurnout &burnout() {
         return m_burnout;
     }
@@ -379,7 +389,7 @@ protected:
     s16 m_ssmtDisableAccelTimer; ///< Counter that tracks delay before starting to reverse.
     f32 m_realTurn; ///< The "true" turn magnitude. Equal to @ref m_weightedTurn unless drifting.
     f32 m_weightedTurn;    ///< Magnitude+direction of stick input, factoring in the kart's stats.
-    EGG::Vector3f m_scale; ///< @unused Always 1.0f
+    EGG::Vector3f m_scale; ///< Normally the unit vector, but may vary due to crush animations.
     f32 m_totalScale;      ///< @unused Always 1.0f
     f32 m_hitboxScale;
     u16 m_mushroomBoostTimer; ///< Number of frames until the mushroom boost runs out.
@@ -410,6 +420,7 @@ protected:
     Flags m_flags;
     KartJump *m_jump;
     KartHalfPipe *m_halfPipe;                   ///< Pertains to zipper physics.
+    KartScale *m_kartScale;                     ///< Manages scaling due to TF stompers and MH cars.
     KartBurnout m_burnout;                      ///< Manages the state of start boost burnout.
     const DriftingParameters *m_driftingParams; ///< Drift-type-specific parameters.
     f32 m_rawTurn; ///< Float in range [-1, 1]. Represents stick magnitude + direction.

--- a/source/game/kart/KartObjectManager.hh
+++ b/source/game/kart/KartObjectManager.hh
@@ -2,6 +2,8 @@
 
 #include "game/kart/KartObject.hh"
 
+#include <abstract/g3d/ResAnmChr.hh>
+
 namespace Kart {
 
 /// @brief Responsible for the lifecycle and calculation of KartObjects.
@@ -23,6 +25,10 @@ public:
     static KartObjectManager *CreateInstance();
     static void DestroyInstance();
 
+    [[nodiscard]] static const Abstract::g3d::ResAnmChr *PressScaleUpAnmChr() {
+        return s_pressScaleUpAnmChr;
+    }
+
     [[nodiscard]] static KartObjectManager *Instance() {
         return s_instance;
     }
@@ -31,10 +37,13 @@ private:
     KartObjectManager();
     ~KartObjectManager() override;
 
+    void loadScaleAnimations();
+
     size_t m_count;
     KartObject **m_objects;
 
-    static KartObjectManager *s_instance; ///< @addr{0x809C18F8}
+    static Abstract::g3d::ResAnmChr *s_pressScaleUpAnmChr; ///< @addr{0x809C18B0}
+    static KartObjectManager *s_instance;                  ///< @addr{0x809C18F8}
 };
 
 } // namespace Kart

--- a/source/game/kart/KartObjectProxy.cc
+++ b/source/game/kart/KartObjectProxy.cc
@@ -100,6 +100,14 @@ const KartHalfPipe *KartObjectProxy::halfPipe() const {
     return m_accessor->move->halfPipe();
 }
 
+KartScale *KartObjectProxy::kartScale() {
+    return m_accessor->move->kartScale();
+}
+
+const KartScale *KartObjectProxy::kartScale() const {
+    return m_accessor->move->kartScale();
+}
+
 /// @addr{0x80591914}
 KartJump *KartObjectProxy::jump() {
     return m_accessor->move->jump();

--- a/source/game/kart/KartObjectProxy.hh
+++ b/source/game/kart/KartObjectProxy.hh
@@ -36,6 +36,7 @@ class KartMove;
 class KartParam;
 struct BSP;
 class KartPhysics;
+class KartScale;
 class KartState;
 class KartSub;
 class KartSuspension;
@@ -89,6 +90,8 @@ public:
     [[nodiscard]] const KartMove *move() const;
     [[nodiscard]] KartHalfPipe *halfPipe();
     [[nodiscard]] const KartHalfPipe *halfPipe() const;
+    [[nodiscard]] KartScale *kartScale();
+    [[nodiscard]] const KartScale *kartScale() const;
     [[nodiscard]] KartJump *jump();
     [[nodiscard]] const KartJump *jump() const;
     [[nodiscard]] KartParam *param();

--- a/source/game/kart/KartScale.cc
+++ b/source/game/kart/KartScale.cc
@@ -1,0 +1,77 @@
+#include "KartScale.hh"
+
+#include "game/kart/KartObjectManager.hh"
+
+namespace Kart {
+
+/// @addr{0x8056AD44}
+KartScale::KartScale() {
+    reset();
+}
+
+/// @addr{0x8056B5A8}
+KartScale::~KartScale() = default;
+
+/// @addr{0x8056AF10}
+void KartScale::reset() {
+    m_pressState = PressState::None;
+    m_calcPress = false;
+    m_pressUpAnmFrame = 0.0f;
+    m_currScale = EGG::Vector3f(1.0f, 1.0f, 1.0f);
+}
+
+/// @addr{0x8056B218}
+void KartScale::calc() {
+    calcPress();
+}
+
+/// @addr{0x8056B060}
+void KartScale::startPressDown() {
+    m_pressState = PressState::Down;
+    m_currScale = EGG::Vector3f(1.0f, 1.0f, 1.0f);
+    m_pressUpAnmFrame = 0.0f;
+    m_calcPress = true;
+}
+
+/// @addr{0x8056B094}
+void KartScale::startPressUp() {
+    m_pressState = PressState::Up;
+    m_currScale = EGG::Vector3f(1.0f, CRUSH_SCALE, 1.0f);
+    m_pressUpAnmFrame = 0.0f;
+    m_calcPress = true;
+}
+
+/// @addr{0x8056B45C}
+void KartScale::calcPress() {
+    constexpr f32 SCALE_SPEED = 0.2f;
+
+    if (!m_calcPress || m_pressState == PressState::None) {
+        return;
+    }
+
+    if (m_pressState == PressState::Down) {
+        m_currScale.y -= SCALE_SPEED;
+        if (m_currScale.y < CRUSH_SCALE) {
+            m_currScale.y = CRUSH_SCALE;
+            m_calcPress = false;
+        }
+    } else {
+        m_currScale = getAnmScale(m_pressUpAnmFrame);
+
+        const auto *scaleAnm = KartObjectManager::PressScaleUpAnmChr();
+        ASSERT(scaleAnm);
+
+        if (++m_pressUpAnmFrame > static_cast<f32>(scaleAnm->frameCount())) {
+            m_calcPress = false;
+        }
+    }
+}
+
+/// @addr{0x8056ACF4}
+EGG::Vector3f KartScale::getAnmScale(f32 frame) const {
+    const auto *scaleAnm = KartObjectManager::PressScaleUpAnmChr();
+    ASSERT(scaleAnm);
+    return scaleAnm->getAnmResult(frame, 0).scale();
+}
+
+} // namespace Kart

--- a/source/game/kart/KartScale.hh
+++ b/source/game/kart/KartScale.hh
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "game/kart/KartObjectProxy.hh"
+
+namespace Kart {
+
+/// @brief Mainly responsible for calculating scaling for the squish/unsquish animation.
+class KartScale : protected KartObjectProxy {
+public:
+    KartScale();
+    ~KartScale();
+
+    void reset();
+    void calc();
+
+    void startPressDown();
+    void startPressUp();
+
+    [[nodiscard]] const EGG::Vector3f &currScale() const {
+        return m_currScale;
+    }
+
+private:
+    enum class PressState {
+        None = -1,
+        Down = 0,
+        Up = 1,
+    };
+
+    void calcPress();
+
+    [[nodiscard]] EGG::Vector3f getAnmScale(f32 frame) const;
+
+    PressState m_pressState;   ///< Specifies squish/unsquish state
+    bool m_calcPress;          ///< Set while crush scaling is occurring
+    f32 m_pressUpAnmFrame;     ///< Current frame of the unsquish animation
+    EGG::Vector3f m_currScale; ///< The computed scale for the current frame
+
+    static constexpr f32 CRUSH_SCALE = 0.3f;
+};
+
+} // namespace Kart


### PR DESCRIPTION
This class is used to compute changes in the kart's scale due to hitting TF stompers or MH cars. There is initially a scaling down to `{1.0f, 0.3f, 1.0f}` followed by an eventual unsquash animation. These functions won't effectively do anything until some more code is added in a future PR.