### PR TITLE
Implement ObjectCrane

### DIFF
--- a/source/egg/math/Matrix.cc
+++ b/source/egg/math/Matrix.cc
@@ -232,6 +232,7 @@ Vector3f Matrix34f::ps_multVector(const Vector3f &vec) const {
 }
 
 /// @brief Multiplies a 3x3 matrix by a vector.
+/// @addr{0x8059A4F8}
 Vector3f Matrix34f::multVector33(const Vector3f &vec) const {
     Vector3f ret;
 

--- a/source/game/field/ObjectDirector.cc
+++ b/source/game/field/ObjectDirector.cc
@@ -239,6 +239,8 @@ ObjectBase *ObjectDirector::createObject(const System::MapdataGeoObj &params) {
         return new ObjectKinokoBend(params);
     case ObjectId::KinokoNm:
         return new ObjectKinokoNm(params);
+    case ObjectId::Crane:
+        return new ObjectCrane(params);
     case ObjectId::Aurora:
         return new ObjectAurora(params);
     // Non-specified objects are stock collidable objects by default

--- a/source/game/field/obj/ObjectCrane.cc
+++ b/source/game/field/obj/ObjectCrane.cc
@@ -1,0 +1,48 @@
+#include "ObjectCrane.hh"
+
+namespace Field {
+
+/// @addr{0x807FE658}
+ObjectCrane::ObjectCrane(const System::MapdataGeoObj &params)
+    : ObjectKCL(params), m_startPos(m_pos) {
+    m_xt = params.setting(3);
+    m_yt = 0;
+    m_xPeriod = std::max(static_cast<u16>(2), params.setting(1));
+    m_yPeriod = std::max(static_cast<u16>(2), params.setting(4));
+    m_xAmplitude = params.setting(2);
+    m_yAmplitude = params.setting(5);
+
+    m_xFreq = 2 * F_PI / static_cast<f32>(m_xPeriod);
+    m_yFreq = 2 * F_PI / static_cast<f32>(m_yPeriod);
+}
+
+/// @addr{0x807FEB28}
+ObjectCrane::~ObjectCrane() = default;
+
+/// @addr{0x807FE7EC}
+void ObjectCrane::calc() {
+    const EGG::Vector3f prevPos = m_pos;
+
+    f32 xDelta = EGG::Mathf::cos(m_xFreq * static_cast<f32>(m_xt));
+    EGG::Vector3f scaledX = EGG::Vector3f::ex * xDelta * static_cast<f32>(m_xAmplitude);
+
+    f32 yDelta = EGG::Mathf::cos(m_yFreq * static_cast<f32>(m_yt));
+    EGG::Vector3f scaledY = EGG::Vector3f::ey * yDelta * static_cast<f32>(m_yAmplitude);
+
+    calcTransform();
+
+    m_pos = m_startPos + m_transform.multVector33(scaledX + scaledY);
+    m_flags |= 1;
+
+    if (m_yt++ > m_yPeriod) {
+        m_yt = 0;
+    }
+
+    if (m_xt++ > m_xPeriod) {
+        m_xt = 0;
+    }
+
+    setMovingObjVel(m_pos - prevPos);
+}
+
+} // namespace Field

--- a/source/game/field/obj/ObjectCrane.hh
+++ b/source/game/field/obj/ObjectCrane.hh
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "game/field/obj/ObjectKCL.hh"
+
+namespace Field {
+
+/// @brief The moving crane platforms after the second turn of Toad's Factory.
+/// @details Moves in a simple sine wave. There is both an x-axis and y-axis wave, though the
+/// platforms in the base game have a y amplitude of 0.
+class ObjectCrane final : public ObjectKCL {
+public:
+    ObjectCrane(const System::MapdataGeoObj &params);
+    ~ObjectCrane() override;
+
+    void calc() override;
+
+    /// @addr{0x807FEB20}
+    [[nodiscard]] u32 loadFlags() const override {
+        return 1;
+    }
+
+    /// @addr{0x807FEAF0}
+    [[nodiscard]] f32 colRadiusAdditionalLength() const override {
+        return m_xAmplitude;
+    }
+
+private:
+    const EGG::Vector3f m_startPos; ///< Initial starting position
+    u16 m_xt;                       ///< Current time along the x-axis period
+    u16 m_yt;                       ///< Current time along the y-axis period
+    u16 m_xPeriod;                  ///< Framecount of a full oscillation on x-axis
+    u16 m_yPeriod;                  ///< Framecount of a full oscillation on y-axis
+    u16 m_xAmplitude;               ///< Max x-position delta from starting position
+    u16 m_yAmplitude;               ///< Max y-position delta from starting position
+    f32 m_xFreq;                    ///< 2pi / m_xPeriod
+    f32 m_yFreq;                    ///< 2pi / m_yPeriod
+};
+
+} // namespace Field

--- a/source/game/field/obj/ObjectId.hh
+++ b/source/game/field/obj/ObjectId.hh
@@ -38,6 +38,7 @@ enum class ObjectId {
     KinokoUd = 0x1f5,
     KinokoBend = 0x1f6,
     KinokoNm = 0x1fa,
+    Crane = 0x1fb,
     Aurora = 0x204,
     Mdush = 0x217,
 };

--- a/source/game/field/obj/ObjectRegistry.hh
+++ b/source/game/field/obj/ObjectRegistry.hh
@@ -3,6 +3,7 @@
 #include "game/field/obj/ObjectAurora.hh"
 #include "game/field/obj/ObjectBoble.hh"
 #include "game/field/obj/ObjectCarTGE.hh"
+#include "game/field/obj/ObjectCrane.hh"
 #include "game/field/obj/ObjectDokan.hh"
 #include "game/field/obj/ObjectFireRing.hh"
 #include "game/field/obj/ObjectFirebar.hh"

--- a/source/game/kart/KartMove.cc
+++ b/source/game/kart/KartMove.cc
@@ -604,7 +604,7 @@ void KartMove::calcStickyRoad() {
     }
 
     EGG::Vector3f pos = dynamics()->pos();
-    EGG::Vector3f vel = m_speed * m_vel1Dir;
+    EGG::Vector3f vel = dynamics()->movingObjVel() + m_speed * m_vel1Dir;
     EGG::Vector3f down = -STICKY_RADIUS * componentYAxis();
     Field::CollisionInfo colInfo;
     colInfo.bbox.setZero();
@@ -616,6 +616,7 @@ void KartMove::calcStickyRoad() {
         if (Field::CollisionDirector::Instance()->checkSphereFull(STICKY_RADIUS, newPos,
                     EGG::Vector3f::inf, STICKY_MASK, &colInfo, &kcl_flags, 0)) {
             m_vel1Dir = m_vel1Dir.perpInPlane(colInfo.floorNrm, true);
+            dynamics()->setMovingObjVel(dynamics()->movingObjVel().rej(colInfo.floorNrm));
             stickyRoad = true;
 
             break;


### PR DESCRIPTION
This syncs the two moving platforms after the second turn of Toad's Factory. Nothing special here, besides me using `final` for the class definition. We probably want to start doing this.