### PR TITLE
Allow ghost and krkg args in test mode

### DIFF
--- a/source/host/KTestSystem.cc
+++ b/source/host/KTestSystem.cc
@@ -1,6 +1,5 @@
 #include "KTestSystem.hh"
 
-#include "host/Option.hh"
 #include "host/SceneCreatorDynamic.hh"
 
 #include <game/kart/KartObjectManager.hh>
@@ -28,20 +27,29 @@ struct TestHeader {
     u32 dataOffset;
 };
 
-/// @brief Initializes the system.
-/// @details This reads over the KRKG and generates the list of test cases,
-/// before starting the first test case and initializing the race scene.
+/// @brief Initializes the system (if necessary).
 void KTestSystem::init() {
-    constexpr u32 TEST_HEADER_SIGNATURE = 0x54535448; // TSTH
-    constexpr u32 TEST_FOOTER_SIGNATURE = 0x54535446; // TSTF
-    constexpr u16 SUITE_MAJOR_VER = 1;
-    constexpr u16 SUITE_MAX_MINOR_VER = 0;
-
     auto *sceneCreator = new Host::SceneCreatorDynamic;
     m_sceneMgr = new EGG::SceneManager(sceneCreator);
 
     System::RaceConfig::RegisterInitCallback(OnInit, nullptr);
     Abstract::File::Remove("results.txt");
+
+    if (m_testMode == Host::EOption::Suite) {
+        initSuite();
+    }
+
+    startNextTestCase();
+    m_sceneMgr->changeScene(0);
+}
+
+/// @details This reads over the KRKG and generates the list of test cases,
+/// before starting the first test case and initializing the race scene.
+void KTestSystem::initSuite() {
+    constexpr u32 TEST_HEADER_SIGNATURE = 0x54535448; // TSTH
+    constexpr u32 TEST_FOOTER_SIGNATURE = 0x54535446; // TSTF
+    constexpr u16 SUITE_MAJOR_VER = 1;
+    constexpr u16 SUITE_MAX_MINOR_VER = 0;
 
     u16 numTestCases = m_stream.read_u16();
     u16 testMajorVer = m_stream.read_u16();
@@ -92,9 +100,6 @@ void KTestSystem::init() {
 
         m_testCases.push(testCase);
     }
-
-    startNextTestCase();
-    m_sceneMgr->changeScene(0);
 }
 
 /// @brief Executes a frame.
@@ -142,6 +147,8 @@ void KTestSystem::parseOptions(int argc, char **argv) {
 
         switch (*flag) {
         case Host::EOption::Suite: {
+            m_testMode = Host::EOption::Suite;
+
             ASSERT(i + 1 < argc);
 
             size_t size;
@@ -153,6 +160,18 @@ void KTestSystem::parseOptions(int argc, char **argv) {
 
             m_stream = EGG::RamStream(data, size);
             m_stream.setEndian(std::endian::big);
+
+        } break;
+        case Host::EOption::Ghost: {
+            m_testMode = Host::EOption::Ghost;
+
+            // Expect ghost, -k, and krkg file arguments
+            ASSERT(i + 3 < argc);
+            char *rkgPath = argv[++i];
+            ASSERT(Host::Option::CheckFlag(argv[++i]) == Host::EOption::KRKG);
+            char *krkgPath = argv[++i];
+
+            m_testCases.emplace(rkgPath, rkgPath, krkgPath, 0);
         } break;
         case Host::EOption::Invalid:
         default:
@@ -221,13 +240,17 @@ bool KTestSystem::popTestCase() {
 /// @brief Checks one frame in the test.
 /// @return Whether the test can continue.
 bool KTestSystem::calcTest() {
-    // Check if we're out of frames
-    u16 targetFrame = getCurrentTestCase().targetFrame;
-    ASSERT(targetFrame <= m_frameCount);
-    if (++m_currentFrame > targetFrame) {
-        REPORT("Test Case Passed: %s [%d / %d]", getCurrentTestCase().name.c_str(), targetFrame,
-                m_frameCount);
-        return false;
+    ++m_currentFrame;
+
+    // Check if we're out of frames (only applicable for test suite)
+    if (m_testMode == Host::EOption::Suite) {
+        u16 targetFrame = getCurrentTestCase().targetFrame;
+        ASSERT(targetFrame <= m_frameCount);
+        if (m_currentFrame > targetFrame) {
+            REPORT("Test Case Passed: %s [%d / %d]", getCurrentTestCase().name.c_str(), targetFrame,
+                    m_frameCount);
+            return false;
+        }
     }
 
     // Test the current frame

--- a/source/host/KTestSystem.hh
+++ b/source/host/KTestSystem.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "host/KSystem.hh"
+#include "host/Option.hh"
 
 #include <egg/core/SceneManager.hh>
 #include <egg/math/Quat.hh>
@@ -122,6 +123,8 @@ private:
         m_sync = false;
     }
 
+    void initSuite();
+
     void startNextTestCase();
     bool popTestCase();
 
@@ -139,6 +142,7 @@ private:
     EGG::SceneManager *m_sceneMgr;
     EGG::RamStream m_stream;
     std::queue<TestCase> m_testCases;
+    Host::EOption m_testMode; ///< Differentiates between test suite and ghost+krkg
 
     u16 m_versionMajor;
     u16 m_versionMinor;

--- a/source/host/Option.cc
+++ b/source/host/Option.cc
@@ -26,6 +26,10 @@ std::optional<EOption> CheckFlag(const char *arg) {
             return EOption::Ghost;
         }
 
+        if (strcmp(verbose_arg, "krkg") == 0) {
+            return EOption::KRKG;
+        }
+
         return EOption::Invalid;
     } else {
         switch (arg[1]) {
@@ -38,6 +42,9 @@ std::optional<EOption> CheckFlag(const char *arg) {
         case 'G':
         case 'g':
             return EOption::Ghost;
+        case 'K':
+        case 'k':
+            return EOption::KRKG;
         default:
             return EOption::Invalid;
         }

--- a/source/host/Option.hh
+++ b/source/host/Option.hh
@@ -11,6 +11,7 @@ enum class EOption {
     Mode,
     Suite,
     Ghost,
+    KRKG,
 };
 
 namespace Option {


### PR DESCRIPTION
Fixes #329 
Run as `./kinoko -m test (-g | -G | -ghost) ghostFile.rkg (-k | -K | -krkg) krkgFile.krkg`
Example output:
```
[KTestSystem.hh:88] REPORT: Test Case Failed: ghostFile.rkg [809 / 8803]
[KTestSystem.hh:92] REPORT: DESYNC! Name: extVel
[KTestSystem.hh:95] REPORT: Expected: [0xBA8303F2, 0x3EF27BBB, 0xB74C5304] | [-0.0009995683, 0.47360024, -1.2178676e-05]
[KTestSystem.hh:96] REPORT: Observed: [0xBA0B076B, 0x3EF27BBA, 0xB6D9E609] | [-0.00053035346, 0.4736002, -6.4938836e-06]
```
This will be really useful for the Discord bot. Have it take in a RKG, it can generate the KRKG, then pass both into test mode to show user why it desynced.