### PR TITLE
Sync ObjectAmi (Maple Treeway net)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -18,8 +18,8 @@ Test Case                                                 | Frames      |     | 
 [`dc-rta-1-28-321`](https://youtu.be/Rs5AK3iHVno)         | 1058 / 5705 | ❌ | KMP
 [`kc-rta-1-55-250`](https://youtu.be/Elb5K7woV20)         | 1520 / 7320 | ❌ | Moving water
 [`kc-ng-rta-2-17-176`](https://youtu.be/UgSQj6RpDYM)      | 1424 / 8634 | ❌ | Moving water
-[`mt-rta-1-33-239`](https://youtu.be/FX89203m2iE)         | 1971 / 6000 | ❌ | KMP
-[`mt-ng-rta-2-13-126`](https://youtu.be/igcHE0-OV0g)      | 2647 / 8391 | ❌ | KMP
+[`mt-rta-1-33-239`](https://youtu.be/FX89203m2iE)         | 6000 / 6000 | ✔️ |
+[`mt-ng-rta-2-13-126`](https://youtu.be/igcHE0-OV0g)      | 8391 / 8391 | ✔️ |
 [`gv-rta-0-15-425`](https://youtu.be/bB0oUzdCHTA)         | 487 / 1336  | ❌ | KMP?
 [`gv-ng-rta-1-32-914`](https://youtu.be/J55Fo2ZMz9M)      | 570 / 5981  | ❌ | KMP?
 [`gv-nosc-rta-1-50-927`](https://youtu.be/R7oK3U7iZrk)    | 567 / 7060  | ❌ | KMP?

--- a/source/game/field/ObjectDirector.cc
+++ b/source/game/field/ObjectDirector.cc
@@ -245,6 +245,8 @@ ObjectBase *ObjectDirector::createObject(const System::MapdataGeoObj &params) {
         return new ObjectTuribashi(params);
     case ObjectId::Aurora:
         return new ObjectAurora(params);
+    case ObjectId::Ami:
+        return new ObjectAmi(params);
     // Non-specified objects are stock collidable objects by default
     // However, we need to specify an impl, so we don't use default
     case ObjectId::DummyPole:

--- a/source/game/field/obj/ObjectAmi.cc
+++ b/source/game/field/obj/ObjectAmi.cc
@@ -1,0 +1,240 @@
+#include "ObjectAmi.hh"
+
+#include "game/field/CollisionDirector.hh"
+
+#include "game/system/RaceManager.hh"
+
+#include <egg/math/Math.hh>
+
+namespace Field {
+
+/// @addr{0x80807ED0}
+ObjectAmi::ObjectAmi(const System::MapdataGeoObj &params) : ObjectDrivable(params) {}
+
+/// @addr{0x80808860}
+ObjectAmi::~ObjectAmi() = default;
+
+/// @addr{0x80808800}
+bool ObjectAmi::checkPointPartial(const EGG::Vector3f &v0, const EGG::Vector3f &v1,
+        KCLTypeMask flags, CollisionInfoPartial *pInfo, KCLTypeMask *pFlagsOut) {
+    return checkSpherePartialImpl(0.0f, v0, v1, flags, pInfo, pFlagsOut, 0);
+}
+
+/// @addr{0x80808810}
+bool ObjectAmi::checkPointPartialPush(const EGG::Vector3f &v0, const EGG::Vector3f &v1,
+        KCLTypeMask flags, CollisionInfoPartial *pInfo, KCLTypeMask *pFlagsOut) {
+    return checkSpherePartialPushImpl(0.0f, v0, v1, flags, pInfo, pFlagsOut, 0);
+}
+
+/// @addr{0x80808820}
+bool ObjectAmi::checkPointFull(const EGG::Vector3f &v0, const EGG::Vector3f &v1, KCLTypeMask flags,
+        CollisionInfo *pInfo, KCLTypeMask *pFlagsOut) {
+    return checkSphereFullImpl(0.0f, v0, v1, flags, pInfo, pFlagsOut, 0);
+}
+
+/// @addr{0x80808830}
+bool ObjectAmi::checkPointFullPush(const EGG::Vector3f &v0, const EGG::Vector3f &v1,
+        KCLTypeMask flags, CollisionInfo *pInfo, KCLTypeMask *pFlagsOut) {
+    return checkSphereFullPushImpl(0.0f, v0, v1, flags, pInfo, pFlagsOut, 0);
+}
+
+/// @addr{0x808087F0}
+bool ObjectAmi::checkSpherePartial(f32 radius, const EGG::Vector3f &v0, const EGG::Vector3f &v1,
+        KCLTypeMask flags, CollisionInfoPartial *pInfo, KCLTypeMask *pFlagsOut, u32 timeOffset) {
+    return checkSpherePartialImpl(radius, v0, v1, flags, pInfo, pFlagsOut, timeOffset);
+}
+
+/// @addr{0x808087F4}
+bool ObjectAmi::checkSpherePartialPush(f32 radius, const EGG::Vector3f &v0, const EGG::Vector3f &v1,
+        KCLTypeMask flags, CollisionInfoPartial *pInfo, KCLTypeMask *pFlagsOut, u32 timeOffset) {
+    return checkSpherePartialPushImpl(radius, v0, v1, flags, pInfo, pFlagsOut, timeOffset);
+}
+
+/// @addr{0x808087F8}
+bool ObjectAmi::checkSphereFull(f32 radius, const EGG::Vector3f &v0, const EGG::Vector3f &v1,
+        KCLTypeMask flags, CollisionInfo *pInfo, KCLTypeMask *pFlagsOut, u32 timeOffset) {
+    return checkSphereFullImpl(radius, v0, v1, flags, pInfo, pFlagsOut, timeOffset);
+}
+
+/// @addr{0x808087FC}
+bool ObjectAmi::checkSphereFullPush(f32 radius, const EGG::Vector3f &v0, const EGG::Vector3f &v1,
+        KCLTypeMask flags, CollisionInfo *pInfo, KCLTypeMask *pFlagsOut, u32 timeOffset) {
+    return checkSphereFullPushImpl(radius, v0, v1, flags, pInfo, pFlagsOut, timeOffset);
+}
+
+/// @addr{0x808087B0}
+bool ObjectAmi::checkPointCachedPartial(const EGG::Vector3f &v0, const EGG::Vector3f &v1,
+        KCLTypeMask flags, CollisionInfoPartial *pInfo, KCLTypeMask *pFlagsOut) {
+    return checkSpherePartialImpl(0.0f, v0, v1, flags, pInfo, pFlagsOut, 0);
+}
+
+/// @addr{0x808087C0}
+bool ObjectAmi::checkPointCachedPartialPush(const EGG::Vector3f &v0, const EGG::Vector3f &v1,
+        KCLTypeMask flags, CollisionInfoPartial *pInfo, KCLTypeMask *pFlagsOut) {
+    return checkSpherePartialPushImpl(0.0f, v0, v1, flags, pInfo, pFlagsOut, 0);
+}
+
+/// @addr{0x808087D0}
+bool ObjectAmi::checkPointCachedFull(const EGG::Vector3f &v0, const EGG::Vector3f &v1,
+        KCLTypeMask flags, CollisionInfo *pInfo, KCLTypeMask *pFlagsOut) {
+    return checkSphereFullImpl(0.0f, v0, v1, flags, pInfo, pFlagsOut, 0);
+}
+
+/// @addr{0x808087E0}
+bool ObjectAmi::checkPointCachedFullPush(const EGG::Vector3f &v0, const EGG::Vector3f &v1,
+        KCLTypeMask flags, CollisionInfo *pInfo, KCLTypeMask *pFlagsOut) {
+    return checkSphereFullPushImpl(0.0f, v0, v1, flags, pInfo, pFlagsOut, 0);
+}
+
+/// @addr{0x808087A0}
+bool ObjectAmi::checkSphereCachedPartial(f32 radius, const EGG::Vector3f &v0,
+        const EGG::Vector3f &v1, KCLTypeMask flags, CollisionInfoPartial *pInfo,
+        KCLTypeMask *pFlagsOut, u32 timeOffset) {
+    return checkSpherePartialImpl(radius, v0, v1, flags, pInfo, pFlagsOut, timeOffset);
+}
+
+/// @addr{0x808087A4}
+bool ObjectAmi::checkSphereCachedPartialPush(f32 radius, const EGG::Vector3f &v0,
+        const EGG::Vector3f &v1, KCLTypeMask flags, CollisionInfoPartial *pInfo,
+        KCLTypeMask *pFlagsOut, u32 timeOffset) {
+    return checkSpherePartialPushImpl(radius, v0, v1, flags, pInfo, pFlagsOut, timeOffset);
+}
+
+/// @addr{0x808087A8}
+bool ObjectAmi::checkSphereCachedFull(f32 radius, const EGG::Vector3f &v0, const EGG::Vector3f &v1,
+        KCLTypeMask flags, CollisionInfo *pInfo, KCLTypeMask *pFlagsOut, u32 timeOffset) {
+    return checkSphereFullImpl(radius, v0, v1, flags, pInfo, pFlagsOut, timeOffset);
+}
+
+/// @addr{0x808087AC}
+bool ObjectAmi::checkSphereCachedFullPush(f32 radius, const EGG::Vector3f &v0,
+        const EGG::Vector3f &v1, KCLTypeMask flags, CollisionInfo *pInfo, KCLTypeMask *pFlagsOut,
+        u32 timeOffset) {
+    return checkSphereFullPushImpl(radius, v0, v1, flags, pInfo, pFlagsOut, timeOffset);
+}
+
+/// @addr{0x808088A0}
+bool ObjectAmi::checkSpherePartialImpl(f32 radius, const EGG::Vector3f &v0, const EGG::Vector3f &v1,
+        KCLTypeMask flags, CollisionInfoPartial *pInfo, KCLTypeMask *pFlagsOut, u32 timeOffset) {
+    return checkSphereImpl(radius, v0, v1, flags, pInfo, pFlagsOut, timeOffset, false);
+}
+
+/// @addr{0x80808A8C}
+bool ObjectAmi::checkSpherePartialPushImpl(f32 radius, const EGG::Vector3f &v0,
+        const EGG::Vector3f &v1, KCLTypeMask flags, CollisionInfoPartial *pInfo,
+        KCLTypeMask *pFlagsOut, u32 timeOffset) {
+    return checkSphereImpl(radius, v0, v1, flags, pInfo, pFlagsOut, timeOffset, true);
+}
+
+/// @addr{0x80808CA8}
+bool ObjectAmi::checkSphereFullImpl(f32 radius, const EGG::Vector3f &v0, const EGG::Vector3f &v1,
+        KCLTypeMask flags, CollisionInfo *pInfo, KCLTypeMask *pFlagsOut, u32 timeOffset) {
+    return checkSphereImpl(radius, v0, v1, flags, pInfo, pFlagsOut, timeOffset, false);
+}
+
+/// @addr{0x80809060}
+bool ObjectAmi::checkSphereFullPushImpl(f32 radius, const EGG::Vector3f &v0,
+        const EGG::Vector3f &v1, KCLTypeMask flags, CollisionInfo *pInfo, KCLTypeMask *pFlagsOut,
+        u32 timeOffset) {
+    return checkSphereImpl(radius, v0, v1, flags, pInfo, pFlagsOut, timeOffset, true);
+}
+
+/// @brief Helper function which contains frequently re-used code. Behavior branches depending on
+/// whether it is a full or partial check (call CollisionInfo::updateFloor) or push (push entry in
+/// the CollisionDirector).
+/// @tparam T The CollisionInfo object type, either CollisionInfoPartial or CollisionInfo.
+/// @param push Whether to push a collision entry
+template <typename T>
+    requires std::is_same_v<T, CollisionInfo> || std::is_same_v<T, CollisionInfoPartial>
+bool ObjectAmi::checkSphereImpl(f32 radius, const EGG::Vector3f &v0, const EGG::Vector3f & /*v1*/,
+        KCLTypeMask flags, T *pInfo, KCLTypeMask *pFlagsOut, u32 timeOffset, bool push) {
+    // We check flags first to avoid unnecessary position posDelta computation.
+    if (!(flags & KCL_TYPE_FLOOR)) {
+        return false;
+    }
+
+    EGG::Vector3f posDelta = v0 - m_pos;
+    posDelta.z *= -1.0f;
+
+    if (posDelta.z < 0.0f || posDelta.z > DIMS.z || EGG::Mathf::abs(posDelta.x) > DIMS.x) {
+        return false;
+    }
+
+    u32 t = timeOffset + System::RaceManager::Instance()->timer();
+    EGG::Vector3f bbox;
+    EGG::Vector3f fnrm;
+    f32 dist;
+
+    if (!checkCollision(radius, posDelta, t, bbox, fnrm, dist)) {
+        return false;
+    }
+
+    if (pInfo) {
+        pInfo->bbox.min = pInfo->bbox.min.minimize(bbox);
+        pInfo->bbox.max = pInfo->bbox.max.maximize(bbox);
+
+        if constexpr (std::is_same_v<T, CollisionInfo>) {
+            pInfo->updateFloor(dist, fnrm);
+        }
+    }
+
+    if (pFlagsOut) {
+        if (push) {
+            auto *colDirector = CollisionDirector::Instance();
+            colDirector->pushCollisionEntry(dist, pFlagsOut, KCL_TYPE_BIT(COL_TYPE_ROTATING_ROAD),
+                    COL_TYPE_ROTATING_ROAD);
+            colDirector->setCurrentCollisionVariant(0);
+            colDirector->setCurrentCollisionTrickable(true);
+        } else {
+            *pFlagsOut |= KCL_TYPE_BIT(COL_TYPE_ROTATING_ROAD);
+        }
+
+        if (posDelta.z > DIMS.z) {
+            *pFlagsOut |= KCL_TYPE_BIT(COL_TYPE_BOOST_RAMP);
+        }
+    }
+
+    return true;
+}
+
+/// @addr{0x80808308}
+bool ObjectAmi::checkCollision(f32 radius, const EGG::Vector3f &posDelta, u32 time,
+        EGG::Vector3f &bbox, EGG::Vector3f &fnrm, f32 &dist) {
+    constexpr EGG::Vector3f FLOOR_NORMAL = EGG::Vector3f(0.0f, 1.5f, -0.5f);
+    constexpr f32 Z_SLOPE = 910.0f;
+
+    f32 zPhase = F_PI * (2.0f * posDelta.z) / DIMS.z;
+    f32 depth = radius - (posDelta.y - (SpatialSin(zPhase) * TemporalSin(time) - Z_SLOPE * zPhase));
+
+    // Not colliding if net is falling below the hitbox's radius or above by more than 600 units.
+    if (depth <= 0.0f || depth >= 600.0f) {
+        return false;
+    }
+
+    if (depth >= 300.0f) {
+        depth *= 0.2f;
+    }
+
+    fnrm = FLOOR_NORMAL;
+    fnrm.normalise();
+    bbox = fnrm * depth;
+    dist = depth;
+
+    return true;
+}
+
+/// @addr{0x80808578}
+/// @brief Computes a spatial sine wave as a function of the z-axis phase.
+/// @details The behavior is such that the net bounce is the most extreme when in the middle of the
+/// net and dampened as you approach the beginning or end along the z-axis.
+f32 ObjectAmi::SpatialSin(f32 phase) {
+    return 550.0f * EGG::Mathf::SinFIdx(RAD2FIDX * (phase * 0.5f));
+}
+
+/// @brief Not emitted by the game, but computes a sine wave as a function of time.
+/// @details This computes the up/down motion of the net, with a period of 70 frames.
+f32 ObjectAmi::TemporalSin(u32 t) {
+    return EGG::Mathf::SinFIdx(RAD2FIDX * (F_PI * static_cast<f32>(t) / 35.0f));
+}
+
+} // namespace Field

--- a/source/game/field/obj/ObjectAmi.hh
+++ b/source/game/field/obj/ObjectAmi.hh
@@ -1,0 +1,103 @@
+#pragma once
+
+#include "game/field/obj/ObjectDrivable.hh"
+
+namespace Field {
+
+class ObjectAmi final : public ObjectDrivable {
+public:
+    ObjectAmi(const System::MapdataGeoObj &params);
+    ~ObjectAmi() override;
+
+    /// @addr{0x80807F40}
+    void init() override {}
+
+    /// @addr{0x80807FF4}
+    void calc() override {}
+
+    /// @addr{0x80808858}
+    [[nodiscard]] u32 loadFlags() const override {
+        return 1;
+    }
+
+    /// @addr{0x80808854}
+    void createCollision() override {}
+
+    /// @addr{0x80808850}
+    void calcCollisionTransform() override {}
+
+    /// @addr{0x80808840}
+    [[nodiscard]] f32 getCollisionRadius() const override {
+        return 15000.0f;
+    }
+
+    [[nodiscard]] bool checkPointPartial(const EGG::Vector3f &v0, const EGG::Vector3f &v1,
+            KCLTypeMask flags, CollisionInfoPartial *pInfo, KCLTypeMask *pFlagsOut) override;
+    [[nodiscard]] bool checkPointPartialPush(const EGG::Vector3f &v0, const EGG::Vector3f &v1,
+            KCLTypeMask flags, CollisionInfoPartial *pInfo, KCLTypeMask *pFlagsOut) override;
+    [[nodiscard]] bool checkPointFull(const EGG::Vector3f &v0, const EGG::Vector3f &v1,
+            KCLTypeMask flags, CollisionInfo *pInfo, KCLTypeMask *pFlagsOut) override;
+    [[nodiscard]] bool checkPointFullPush(const EGG::Vector3f &v0, const EGG::Vector3f &v1,
+            KCLTypeMask flags, CollisionInfo *pInfo, KCLTypeMask *pFlagsOut) override;
+    [[nodiscard]] bool checkSpherePartial(f32 radius, const EGG::Vector3f &v0,
+            const EGG::Vector3f &v1, KCLTypeMask flags, CollisionInfoPartial *pInfo,
+            KCLTypeMask *pFlagsOut, u32 timeOffset) override;
+    [[nodiscard]] bool checkSpherePartialPush(f32 radius, const EGG::Vector3f &v0,
+            const EGG::Vector3f &v1, KCLTypeMask flags, CollisionInfoPartial *pInfo,
+            KCLTypeMask *pFlagsOut, u32 timeOffset) override;
+    [[nodiscard]] bool checkSphereFull(f32 radius, const EGG::Vector3f &v0, const EGG::Vector3f &v1,
+            KCLTypeMask flags, CollisionInfo *pInfo, KCLTypeMask *pFlagsOut,
+            u32 timeOffset) override;
+    [[nodiscard]] bool checkSphereFullPush(f32 radius, const EGG::Vector3f &v0,
+            const EGG::Vector3f &v1, KCLTypeMask flags, CollisionInfo *pInfo,
+            KCLTypeMask *pFlagsOut, u32 timeOffset) override;
+    [[nodiscard]] bool checkPointCachedPartial(const EGG::Vector3f &v0, const EGG::Vector3f &v1,
+            KCLTypeMask flags, CollisionInfoPartial *pInfo, KCLTypeMask *pFlagsOut) override;
+    [[nodiscard]] bool checkPointCachedPartialPush(const EGG::Vector3f &v0, const EGG::Vector3f &v1,
+            KCLTypeMask flags, CollisionInfoPartial *pInfo, KCLTypeMask *pFlagsOut) override;
+    [[nodiscard]] bool checkPointCachedFull(const EGG::Vector3f &v0, const EGG::Vector3f &v1,
+            KCLTypeMask flags, CollisionInfo *pInfo, KCLTypeMask *pFlagsOut) override;
+    [[nodiscard]] bool checkPointCachedFullPush(const EGG::Vector3f &v0, const EGG::Vector3f &v1,
+            KCLTypeMask flags, CollisionInfo *pInfo, KCLTypeMask *pFlagsOut) override;
+    [[nodiscard]] bool checkSphereCachedPartial(f32 radius, const EGG::Vector3f &v0,
+            const EGG::Vector3f &v1, KCLTypeMask flags, CollisionInfoPartial *pInfo,
+            KCLTypeMask *pFlagsOut, u32 timeOffset) override;
+    [[nodiscard]] bool checkSphereCachedPartialPush(f32 radius, const EGG::Vector3f &v0,
+            const EGG::Vector3f &v1, KCLTypeMask flags, CollisionInfoPartial *pInfo,
+            KCLTypeMask *pFlagsOut, u32 timeOffset) override;
+    [[nodiscard]] bool checkSphereCachedFull(f32 radius, const EGG::Vector3f &v0,
+            const EGG::Vector3f &v1, KCLTypeMask flags, CollisionInfo *pInfo,
+            KCLTypeMask *pFlagsOut, u32 timeOffset) override;
+    [[nodiscard]] bool checkSphereCachedFullPush(f32 radius, const EGG::Vector3f &v0,
+            const EGG::Vector3f &v1, KCLTypeMask flags, CollisionInfo *pInfo,
+            KCLTypeMask *pFlagsOut, u32 timeOffset) override;
+
+private:
+    [[nodiscard]] bool checkSpherePartialImpl(f32 radius, const EGG::Vector3f &v0,
+            const EGG::Vector3f &v1, KCLTypeMask flags, CollisionInfoPartial *pInfo,
+            KCLTypeMask *pFlagsOut, u32 timeOffset);
+    [[nodiscard]] bool checkSpherePartialPushImpl(f32 radius, const EGG::Vector3f &v0,
+            const EGG::Vector3f &v1, KCLTypeMask flags, CollisionInfoPartial *pInfo,
+            KCLTypeMask *pFlagsOut, u32 timeOffset);
+    [[nodiscard]] bool checkSphereFullImpl(f32 radius, const EGG::Vector3f &v0,
+            const EGG::Vector3f &v1, KCLTypeMask flags, CollisionInfo *pInfo,
+            KCLTypeMask *pFlagsOut, u32 timeOffset);
+    [[nodiscard]] bool checkSphereFullPushImpl(f32 radius, const EGG::Vector3f &v0,
+            const EGG::Vector3f &v1, KCLTypeMask flags, CollisionInfo *pInfo,
+            KCLTypeMask *pFlagsOut, u32 timeOffset);
+
+    template <typename T>
+        requires std::is_same_v<T, CollisionInfo> || std::is_same_v<T, CollisionInfoPartial>
+    [[nodiscard]] bool checkSphereImpl(f32 radius, const EGG::Vector3f &v0, const EGG::Vector3f &v1,
+            KCLTypeMask flags, T *pInfo, KCLTypeMask *pFlagsOut, u32 timeOffset, bool push);
+
+    [[nodiscard]] bool checkCollision(f32 radius, const EGG::Vector3f &vel, u32 time,
+            EGG::Vector3f &bbox, EGG::Vector3f &fnrm, f32 &dist);
+
+    [[nodiscard]] static f32 SpatialSin(f32 phase);
+    [[nodiscard]] static f32 TemporalSin(u32 t);
+
+    static constexpr EGG::Vector3f DIMS = EGG::Vector3f(2600.0f, 2000.0f, 13800.0f);
+};
+
+} // namespace Field

--- a/source/game/field/obj/ObjectId.hh
+++ b/source/game/field/obj/ObjectId.hh
@@ -41,6 +41,7 @@ enum class ObjectId {
     Crane = 0x1fb,
     Turibashi = 0x202,
     Aurora = 0x204,
+    Ami = 0x20e,
     Mdush = 0x217,
 };
 

--- a/source/game/field/obj/ObjectRegistry.hh
+++ b/source/game/field/obj/ObjectRegistry.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "game/field/obj/ObjectAmi.hh"
 #include "game/field/obj/ObjectAurora.hh"
 #include "game/field/obj/ObjectBoble.hh"
 #include "game/field/obj/ObjectCarTGE.hh"

--- a/source/game/field/obj/ObjectTuribashi.cc
+++ b/source/game/field/obj/ObjectTuribashi.cc
@@ -158,15 +158,15 @@ bool ObjectTuribashi::checkSphereImpl(f32 radius, const EGG::Vector3f &v0,
     constexpr u16 PERIOD = 160;     // Framecount of a full bridge swing.
     constexpr f32 HEIGHT = 2000.0f; // Distance between min/max positions along the angled bridge.
 
-    EGG::Vector3f deltaPos = v0 - m_pos;
-
-    if (EGG::Mathf::abs(deltaPos.z) > RADIUS) {
-        return false;
-    }
-
     // This check normally happens after the stage check,
     // but there's no difference in behavior if we check earlier.
     if ((flags & 1) == 0) {
+        return false;
+    }
+
+    EGG::Vector3f deltaPos = v0 - m_pos;
+
+    if (EGG::Mathf::abs(deltaPos.z) > RADIUS) {
         return false;
     }
 


### PR DESCRIPTION
This syncs the Maple Treeway net.

- The net works by combining a spatial sin wave and a temporal sin wave. If you are on the z-axis edge of the net, the bounce effect is dampened compared to when you are in the center. The temporal sin wave has a period of 70 frames for which the net moves up-and-down.
- For Turibashi, I noticed the same flag check ordering improvement, so I applied it here as well.