### PR TITLE
Implement ObjectPressSenko

### DIFF
--- a/source/game/field/ObjectDirector.cc
+++ b/source/game/field/ObjectDirector.cc
@@ -219,6 +219,8 @@ ObjectBase *ObjectDirector::createObject(const System::MapdataGeoObj &params) {
     case ObjectId::KartTruck:
     case ObjectId::CarBody:
         return new ObjectCarTGE(params);
+    case ObjectId::ItemboxLine:
+        return new ObjectItemboxLine(params);
     case ObjectId::Boble:
         return new ObjectBoble(params);
     case ObjectId::DokanSFC:

--- a/source/game/field/obj/ObjectBase.hh
+++ b/source/game/field/obj/ObjectBase.hh
@@ -60,7 +60,7 @@ public:
     }
 
     /// @addr{0x80572574}
-    [[nodiscard]] ObjectId id() const {
+    [[nodiscard]] virtual ObjectId id() const {
         return m_id;
     }
 

--- a/source/game/field/obj/ObjectId.hh
+++ b/source/game/field/obj/ObjectId.hh
@@ -6,11 +6,13 @@ namespace Field {
 
 enum class ObjectId {
     None = 0x0,
+    Itembox = 0x65,
     DummyPole = 0x066,
     Woodbox = 0x70,
     WLWallGC = 0xcb,
     KartTruck = 0xd0,
     CarBody = 0xd1,
+    ItemboxLine = 0xd5,
     Boble = 0xdd,
     DokanSFC = 0x12e,
     CastleTree1c = 0x130,

--- a/source/game/field/obj/ObjectItemboxLine.cc
+++ b/source/game/field/obj/ObjectItemboxLine.cc
@@ -1,0 +1,60 @@
+#include "ObjectItemboxLine.hh"
+
+#include "game/field/obj/ObjectItemboxPress.hh"
+#include "game/field/obj/ObjectPress.hh"
+
+namespace Field {
+
+/// @addr{0x8076D044}
+ObjectItemboxLine::ObjectItemboxLine(const System::MapdataGeoObj &params)
+    : ObjectCollidable(params) {
+    constexpr u32 DEFAULT_PRESS_COUNT = 5;
+
+    auto *senko = new ObjectPressSenko(params);
+    senko->load();
+
+    u32 pressCount = params.setting(6);
+    if (pressCount == 0) {
+        pressCount = DEFAULT_PRESS_COUNT;
+    }
+
+    m_press = std::span<ObjectItemboxPress *>(new ObjectItemboxPress *[pressCount], pressCount);
+
+    for (auto *&press : m_press) {
+        press = new ObjectItemboxPress(params);
+        press->load();
+        press->setSenko(senko);
+    }
+}
+
+/// @addr{0x8076D558}
+ObjectItemboxLine::~ObjectItemboxLine() {
+    // Individual objects' lifecycle is managed by the ObjectDirector.
+    delete[] m_press.data();
+}
+
+/// @addr{0x8076D604}
+void ObjectItemboxLine::init() {
+    u32 timer = static_cast<u32>(m_mapObj->setting(4));
+
+    if (timer == 0) {
+        timer = static_cast<u32>(m_mapObj->setting(5));
+    }
+
+    m_stompCooldown = timer;
+    m_curPressIdx = 0;
+}
+
+/// @addr{0x8076D64C}
+void ObjectItemboxLine::calc() {
+    if (--m_stompCooldown > 0) {
+        return;
+    }
+
+    m_stompCooldown = static_cast<u32>(m_mapObj->setting(5));
+
+    m_press[m_curPressIdx]->startPress();
+    m_curPressIdx = (m_curPressIdx + 1) % m_press.size();
+}
+
+} // namespace Field

--- a/source/game/field/obj/ObjectItemboxLine.hh
+++ b/source/game/field/obj/ObjectItemboxLine.hh
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "game/field/obj/ObjectCollidable.hh"
+
+namespace Field {
+
+class ObjectItemboxPress;
+
+/// @brief Object which represents a line of itemboxes, a brick block which may be pressed into an
+/// itembox, and a stomper. The stomper is held and managed by @ref ObjectItemboxPress.
+class ObjectItemboxLine final : public ObjectCollidable {
+public:
+    ObjectItemboxLine(const System::MapdataGeoObj &params);
+    ~ObjectItemboxLine() override;
+
+    void init() override;
+    void calc() override;
+
+    /// @addr{0x8076E9BC}
+    [[nodiscard]] u32 loadFlags() const override {
+        return 1;
+    }
+
+private:
+    std::span<ObjectItemboxPress *> m_press;
+    u32 m_stompCooldown; ///< Number of frames in between stomps
+    u32 m_curPressIdx;
+};
+
+} // namespace Field

--- a/source/game/field/obj/ObjectItemboxPress.cc
+++ b/source/game/field/obj/ObjectItemboxPress.cc
@@ -1,0 +1,52 @@
+#include "ObjectItemboxPress.hh"
+
+#include "game/field/obj/ObjectPress.hh"
+
+namespace Field {
+
+/// @addr{0x8076D9E4}
+ObjectItemboxPress::ObjectItemboxPress(const System::MapdataGeoObj &params)
+    : ObjectCollidable(params) {}
+
+/// @addr{0x8076DA48}
+ObjectItemboxPress::~ObjectItemboxPress() = default;
+
+/// @addr{0x8076DAF4}
+void ObjectItemboxPress::calc() {
+    switch (m_state) {
+    case 1:
+    case 2:
+        calcPosition();
+        break;
+    default:
+        break;
+    }
+}
+
+/// @brief Used by @ref ObjectItemboxLine to activate the stomper.
+void ObjectItemboxPress::startPress() {
+    m_state = 2;
+    m_railInterpolator->init(0.0f, 0);
+    m_railInterpolator->setPerPointVelocities(true);
+}
+
+/// @addr{0x8076DF44}
+void ObjectItemboxPress::calcPosition() {
+    constexpr f32 HEIGHT_OFFSET = 180.0f;
+
+    auto result = m_railInterpolator->calc();
+
+    if (result == RailInterpolator::Status::SegmentEnd) {
+        if (m_railInterpolator->curPoint().setting[1] == 1) {
+            m_senko->setWindup(true);
+        }
+    } else if (result == RailInterpolator::Status::ChangingDirection) {
+        m_state = 0;
+    }
+
+    m_pos = m_railInterpolator->curPos();
+    m_pos.y = HEIGHT_OFFSET + m_pos.y;
+    m_flags.setBit(eFlags::Position);
+}
+
+} // namespace Field

--- a/source/game/field/obj/ObjectItemboxPress.hh
+++ b/source/game/field/obj/ObjectItemboxPress.hh
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "game/field/obj/ObjectCollidable.hh"
+
+namespace Field {
+
+class ObjectPressSenko;
+
+/// @brief Responsible for stomper state management.
+/// @details Actually inherits from ObjectItembox, but we don't need to implement.
+class ObjectItemboxPress final : public ObjectCollidable {
+public:
+    ObjectItemboxPress(const System::MapdataGeoObj &params);
+    ~ObjectItemboxPress() override;
+
+    /// @addr{0x8076DA88}
+    void init() override {
+        m_state = 0;
+    }
+
+    void calc() override;
+
+    /// @addr{0x8076E9E4}
+    [[nodiscard]] ObjectId id() const override {
+        return ObjectId::Itembox;
+    }
+
+    /// @addr{0x8076E9C4}
+    [[nodiscard]] u32 loadFlags() const override {
+        return 1;
+    }
+
+    /// @addr{0x8076E9CC}
+    [[nodiscard]] const char *getResources() const override {
+        return "itembox";
+    }
+
+    /// @addr{0x8076E9D8}
+    [[nodiscard]] const char *getKclName() const override {
+        return "itembox";
+    }
+
+    void startPress();
+
+    void setState(u32 state) {
+        m_state = state;
+    }
+
+    void setSenko(ObjectPressSenko *senko) {
+        m_senko = senko;
+    }
+
+private:
+    void calcPosition();
+
+    u32 m_state;
+    ObjectPressSenko *m_senko;
+};
+
+} // namespace Field

--- a/source/game/field/obj/ObjectPress.cc
+++ b/source/game/field/obj/ObjectPress.cc
@@ -221,4 +221,27 @@ void ObjectPress::checkCollisionLowering() {
     m_startedLowered = true;
 }
 
+/// @addr{0x8076E7AC}
+ObjectPressSenko::ObjectPressSenko(const System::MapdataGeoObj &params)
+    : ObjectPress(params), m_startingWindup(false) {}
+
+/// @addr{0x8076E818}
+ObjectPressSenko::~ObjectPressSenko() = default;
+
+/// @addr{0x8076E870}
+void ObjectPressSenko::calcRaised() {
+    if (m_startingWindup) {
+        startWindup();
+        m_startingWindup = false;
+    }
+}
+
+/// @addr{0x8077808C}
+void ObjectPressSenko::startWindup() {
+    constexpr u32 WINDUP_DURATION = 10;
+
+    m_state = State::WindUp;
+    m_windUpTimer = WINDUP_DURATION;
+}
+
 } // namespace Field

--- a/source/game/field/obj/ObjectPress.hh
+++ b/source/game/field/obj/ObjectPress.hh
@@ -31,7 +31,7 @@ public:
 
     virtual void calcRaised();
 
-private:
+protected:
     enum class State {
         Raised,
         WindUp,   ///< Rising up a bit before stomping down
@@ -40,15 +40,17 @@ private:
         Raising,
     };
 
+    State m_state;
+    u32 m_windUpTimer; ///< Number of frames remaining in windup state
+
+private:
     void calcWindUp();
     void calcLowering();
     void checkCollisionLowering();
     void calcLowered();
     void calcRaising();
 
-    State m_state;
     bool m_startingRise; ///< Used to delay state change by 1 frame
-    u32 m_windUpTimer;   ///< Number of frames remaining in windup state
     u32 m_raisedTimer;   ///< Number of frames remaining in raised state
     u32 m_anmDuration;
     f32 m_loweringVelocity;
@@ -57,6 +59,45 @@ private:
     bool m_startedLowered; ///< Used to induce crush effect even if it hit floor this frame
 
     static constexpr f32 ANM_RATE = 2.0f;
+};
+
+/// @brief The stompers on the left and right side of the first TF factory room.
+/// @details These stompers don't stomp down until @ref ObjectItemboxPress tells them to.
+class ObjectPressSenko final : public ObjectPress {
+public:
+    ObjectPressSenko(const System::MapdataGeoObj &params);
+    ~ObjectPressSenko() override;
+
+    /// @addr{0x8076EA28}
+    [[nodiscard]] ObjectId id() const override {
+        return ObjectId::Press;
+    }
+
+    /// @addr{0x8076EA20}
+    [[nodiscard]] u32 loadFlags() const override {
+        return 1;
+    }
+
+    /// @addr{0x8076EA30}
+    [[nodiscard]] const char *getResources() const override {
+        return "Press";
+    }
+
+    /// @addr{0x8076EA3C}
+    [[nodiscard]] const char *getKclName() const override {
+        return "Press";
+    }
+
+    void calcRaised() override;
+
+    void setWindup(bool isSet) {
+        m_startingWindup = isSet;
+    }
+
+private:
+    void startWindup();
+
+    bool m_startingWindup;
 };
 
 } // namespace Field

--- a/source/game/field/obj/ObjectRegistry.hh
+++ b/source/game/field/obj/ObjectRegistry.hh
@@ -10,6 +10,7 @@
 #include "game/field/obj/ObjectFireRing.hh"
 #include "game/field/obj/ObjectFirebar.hh"
 #include "game/field/obj/ObjectHighwayManager.hh"
+#include "game/field/obj/ObjectItemboxLine.hh"
 #include "game/field/obj/ObjectKCL.hh"
 #include "game/field/obj/ObjectKinoko.hh"
 #include "game/field/obj/ObjectKuribo.hh"


### PR DESCRIPTION
These are the left/right side stompers on Toad's Factory. They're managed by ObjectItemboxLine and ObjectItemboxPress since the stompers interact with itemboxes in GP mode. We omit a lot of implementation since we only care about the stompers themselves.