### PR TITLE
Collision entry attribute bitfield

### DIFF
--- a/source/game/field/CollisionDirector.cc
+++ b/source/game/field/CollisionDirector.cc
@@ -216,7 +216,7 @@ void CollisionDirector::resetCollisionEntries(KCLTypeMask *ptr) {
 /// @param kclTypeBit The attribute and additional info about the tri we are colliding with
 /// @param attribute The base type of the tri we are colliding with
 void CollisionDirector::pushCollisionEntry(f32 dist, KCLTypeMask *typeMask, KCLTypeMask kclTypeBit,
-        u16 attribute) {
+        CollisionAttribute attribute) {
     *typeMask = *typeMask | kclTypeBit;
     if (m_collisionEntryCount >= m_entries.size()) {
         m_collisionEntryCount = m_entries.size() - 1;

--- a/source/game/field/CollisionDirector.hh
+++ b/source/game/field/CollisionDirector.hh
@@ -22,14 +22,13 @@ class CollisionDirector : EGG::Disposer {
     friend class Host::Context;
 
 public:
+    /// @brief Collision Entry Attribute fields.
+    /// @details |  0 - 4   |  5 - 7  | 8 | 9 | 10 |  11 - 12  |     13    |   14    |  15  |
+    ///          | BaseType | Variant |   |   |    | Intensity | Trickable | Offroad | Soft |
     enum class eCollisionAttribute {
-        /*
-            |  0 - 4   |  5 - 7  | 8 | 9 | 10 |  11 - 12  |     13    |   14    |  15  |
-            | BaseType | Variant |   |   |    | Intensity | Trickable | Offroad | Soft |
-        */
         Trickable = 13,
-        Offroad = 14,
-        Soft = 15
+        RejectRoad = 14,
+        Soft = 15,
     };
     typedef EGG::TBitFlag<u16, eCollisionAttribute> CollisionAttribute;
 
@@ -38,18 +37,15 @@ public:
         CollisionAttribute attribute;
         f32 dist;
 
-        // Credit: em-eight/mkw
-        /// Computes the "Base Type" portion of the KCL flags. It's the lower 5 bits of the flag.
-        u16 attributeBaseType() const {
+        u16 baseType() const {
             return attribute & 0x1F;
         }
 
-        /// Extracts the "Variant" portion of the KCL flag. It's the 3 bits before the "Bast Type".
-        u16 attributeVariant() const {
+        u16 variant() const {
             return (attribute >> 5) & 7;
         }
 
-        u16 attributeIntensity() const {
+        u16 intensity() const {
             return (attribute >> 11) & 3;
         }
 
@@ -92,8 +88,7 @@ public:
     void setCurrentCollisionTrickable(bool trickable) {
         ASSERT(m_collisionEntryCount > 0);
         CollisionEntry &entry = m_entries[m_collisionEntryCount - 1];
-        trickable ? entry.attribute.setBit(eCollisionAttribute::Trickable) :
-                    entry.attribute.resetBit(eCollisionAttribute::Trickable);
+        entry.attribute.changeBit(trickable, eCollisionAttribute::Trickable);
     }
 
     bool findClosestCollisionEntry(KCLTypeMask *typeMask, KCLTypeMask type);

--- a/source/game/field/CollisionDirector.hh
+++ b/source/game/field/CollisionDirector.hh
@@ -37,7 +37,7 @@ public:
         KCLTypeMask typeMask;
         CollisionAttribute attribute;
         f32 dist;
-        
+
         // Credit: em-eight/mkw
         /// Computes the "Base Type" portion of the KCL flags. It's the lower 5 bits of the flag.
         u16 attributeBaseType() const {
@@ -45,7 +45,7 @@ public:
         }
 
         /// Extracts the "Variant" portion of the KCL flag. It's the 3 bits before the "Bast Type".
-        u16 attributeVariant() const { 
+        u16 attributeVariant() const {
             return (attribute >> 5) & 7;
         }
 
@@ -55,9 +55,7 @@ public:
 
         void setVariant(u16 variant) {
             u16 current = static_cast<u16>(attribute);
-            attribute = static_cast<CollisionAttribute>(
-                (current & ~0xE0) | ((variant & 7) << 5)
-            );
+            attribute = static_cast<CollisionAttribute>((current & ~0xE0) | ((variant & 7) << 5));
         }
     };
 
@@ -81,7 +79,8 @@ public:
             KCLTypeMask *typeMaskOut, u32 timeOffset);
 
     void resetCollisionEntries(KCLTypeMask *ptr);
-    void pushCollisionEntry(f32 dist, KCLTypeMask *typeMask, KCLTypeMask kclTypeBit, CollisionAttribute attribute);
+    void pushCollisionEntry(f32 dist, KCLTypeMask *typeMask, KCLTypeMask kclTypeBit,
+            CollisionAttribute attribute);
 
     /// @addr{0x807BDB5C}
     void setCurrentCollisionVariant(u16 attribute) {
@@ -93,8 +92,8 @@ public:
     void setCurrentCollisionTrickable(bool trickable) {
         ASSERT(m_collisionEntryCount > 0);
         CollisionEntry &entry = m_entries[m_collisionEntryCount - 1];
-        trickable ? entry.attribute.setBit(eCollisionAttribute::Trickable)
-                  : entry.attribute.resetBit(eCollisionAttribute::Trickable);
+        trickable ? entry.attribute.setBit(eCollisionAttribute::Trickable) :
+                    entry.attribute.resetBit(eCollisionAttribute::Trickable);
     }
 
     bool findClosestCollisionEntry(KCLTypeMask *typeMask, KCLTypeMask type);

--- a/source/game/field/CollisionDirector.hh
+++ b/source/game/field/CollisionDirector.hh
@@ -23,7 +23,13 @@ class CollisionDirector : EGG::Disposer {
 
 public:
     enum class eCollisionAttribute {
-        Trickable = 13
+        /*
+            |  0 - 4   |  5 - 7  | 8 | 9 | 10 |  11 - 12  |     13    |   14    |  15  |
+            | BaseType | Variant |   |   |    | Intensity | Trickable | Offroad | Soft |
+        */
+        Trickable = 13,
+        Offroad = 14,
+        Soft = 15
     };
     typedef EGG::TBitFlag<u16, eCollisionAttribute> CollisionAttribute;
 
@@ -33,13 +39,18 @@ public:
         f32 dist;
         
         // Credit: em-eight/mkw
+        /// Computes the "Base Type" portion of the KCL flags. It's the lower 5 bits of the flag.
+        u16 attributeBaseType() const {
+            return attribute & 0x1F;
+        }
+
         /// Extracts the "Variant" portion of the KCL flag. It's the 3 bits before the "Bast Type".
         u16 attributeVariant() const { 
             return (attribute >> 5) & 7;
         }
 
-        u16 attributeBaseType() const {
-            return attribute & 0x1F;
+        u16 attributeIntensity() const {
+            return (attribute >> 11) & 3;
         }
 
         void setVariant(u16 variant) {
@@ -70,7 +81,7 @@ public:
             KCLTypeMask *typeMaskOut, u32 timeOffset);
 
     void resetCollisionEntries(KCLTypeMask *ptr);
-    void pushCollisionEntry(f32 dist, KCLTypeMask *typeMask, KCLTypeMask kclTypeBit, u16 attribute);
+    void pushCollisionEntry(f32 dist, KCLTypeMask *typeMask, KCLTypeMask kclTypeBit, CollisionAttribute attribute);
 
     /// @addr{0x807BDB5C}
     void setCurrentCollisionVariant(u16 attribute) {

--- a/source/game/field/CollisionDirector.hh
+++ b/source/game/field/CollisionDirector.hh
@@ -34,8 +34,12 @@ public:
         
         // Credit: em-eight/mkw
         /// Extracts the "Variant" portion of the KCL flag. It's the 3 bits before the "Bast Type".
-        u16 variant() const { 
+        u16 attributeVariant() const { 
             return (attribute >> 5) & 7;
+        }
+
+        u16 attributeBaseType() const {
+            return attribute & 0x1F;
         }
 
         void setVariant(u16 variant) {

--- a/source/game/field/KCollisionTypes.hh
+++ b/source/game/field/KCollisionTypes.hh
@@ -22,7 +22,7 @@
 // Credit: em-eight/mkw
 
 /// Computes the "Base Type" portion of the KCL flags. It's the lower 5 bits of the flag.
-#define KCL_ATTRIBUTE_TYPE(x) ((x)&0x1f)
+#define KCL_ATTRIBUTE_TYPE(x) ((x) & 0x1f)
 /// Converts an attribute to the type mask bitfield for that attribute. The game uses this method in
 /// order to create a mask that represents multiple KCL attributes.
 #define KCL_TYPE_BIT(x) (1 << (x))

--- a/source/game/field/KCollisionTypes.hh
+++ b/source/game/field/KCollisionTypes.hh
@@ -28,8 +28,6 @@
 #define KCL_TYPE_BIT(x) (1 << (x))
 /// Given the full 2 byte KCL flag for a triangle, extracts the "Base Type" portion of the flag.
 #define KCL_ATTRIBUTE_TYPE_BIT(x) KCL_TYPE_BIT(KCL_ATTRIBUTE_TYPE(x))
-/// Extracts the "Variant" portion of the 2 byte KCL flag. It's the 3 bits before the "Bast Type".
-#define KCL_VARIANT_TYPE(x) ((x >> 5) & 7)
 
 // KCL attribute types
 typedef enum {

--- a/source/game/field/KCollisionTypes.hh
+++ b/source/game/field/KCollisionTypes.hh
@@ -22,7 +22,7 @@
 // Credit: em-eight/mkw
 
 /// Computes the "Base Type" portion of the KCL flags. It's the lower 5 bits of the flag.
-#define KCL_ATTRIBUTE_TYPE(x) ((x) & 0x1f)
+#define KCL_ATTRIBUTE_TYPE(x) ((x)&0x1f)
 /// Converts an attribute to the type mask bitfield for that attribute. The game uses this method in
 /// order to create a mask that represents multiple KCL attributes.
 #define KCL_TYPE_BIT(x) (1 << (x))

--- a/source/game/field/obj/ObjectBelt.cc
+++ b/source/game/field/obj/ObjectBelt.cc
@@ -26,13 +26,13 @@ bool ObjectBelt::calcCollision(const EGG::Vector3f &v0, const EGG::Vector3f & /*
     }
 
     const auto *entry = colDir->closestCollisionEntry();
-    if (!isMoving(entry->variant(), v0)) {
+    if (!isMoving(entry->attributeVariant(), v0)) {
         return false;
     }
 
     if (entry->dist > info->movingFloorDist) {
         info->movingFloorDist = entry->dist;
-        info->roadVelocity = calcRoadVelocity(entry->variant(), v0,
+        info->roadVelocity = calcRoadVelocity(entry->attributeVariant(), v0,
                 System::RaceManager::Instance()->timer() - timeOffset);
     }
 

--- a/source/game/field/obj/ObjectBelt.cc
+++ b/source/game/field/obj/ObjectBelt.cc
@@ -26,13 +26,13 @@ bool ObjectBelt::calcCollision(const EGG::Vector3f &v0, const EGG::Vector3f & /*
     }
 
     const auto *entry = colDir->closestCollisionEntry();
-    if (!isMoving(entry->attributeVariant(), v0)) {
+    if (!isMoving(entry->variant(), v0)) {
         return false;
     }
 
     if (entry->dist > info->movingFloorDist) {
         info->movingFloorDist = entry->dist;
-        info->roadVelocity = calcRoadVelocity(entry->attributeVariant(), v0,
+        info->roadVelocity = calcRoadVelocity(entry->variant(), v0,
                 System::RaceManager::Instance()->timer() - timeOffset);
     }
 

--- a/source/game/field/obj/ObjectBelt.cc
+++ b/source/game/field/obj/ObjectBelt.cc
@@ -26,13 +26,13 @@ bool ObjectBelt::calcCollision(const EGG::Vector3f &v0, const EGG::Vector3f & /*
     }
 
     const auto *entry = colDir->closestCollisionEntry();
-    if (!isMoving(KCL_VARIANT_TYPE(entry->attribute), v0)) {
+    if (!isMoving(entry->variant(), v0)) {
         return false;
     }
 
     if (entry->dist > info->movingFloorDist) {
         info->movingFloorDist = entry->dist;
-        info->roadVelocity = calcRoadVelocity(KCL_VARIANT_TYPE(entry->attribute), v0,
+        info->roadVelocity = calcRoadVelocity(entry->variant(), v0,
                 System::RaceManager::Instance()->timer() - timeOffset);
     }
 

--- a/source/game/kart/KartCollide.cc
+++ b/source/game/kart/KartCollide.cc
@@ -344,7 +344,7 @@ void KartCollide::handleTriggers(Field::KCLTypeMask *mask) {
     if (*mask & KCL_TYPE_BIT(COL_TYPE_EFFECT_TRIGGER)) {
         auto *colDir = Field::CollisionDirector::Instance();
         if (colDir->findClosestCollisionEntry(mask, KCL_TYPE_BIT(COL_TYPE_EFFECT_TRIGGER))) {
-            if (colDir->closestCollisionEntry()->attributeVariant() == 4) {
+            if (colDir->closestCollisionEntry()->variant() == 4) {
                 halfPipe()->end(true);
                 state()->setEndHalfPipe(true);
                 m_surfaceFlags.setBit(eSurfaceFlags::StopHalfPipeState);
@@ -620,8 +620,8 @@ bool KartCollide::processWall(CollisionData &collisionData, Field::KCLTypeMask *
                     KCL_TYPE_DRIVER_WALL_NO_INVISIBLE_WALL)) {
         auto *entry = colDirector->closestCollisionEntry();
 
-        collisionData.closestWallFlags = entry->attributeBaseType();
-        collisionData.closestWallSettings = entry->attributeVariant();
+        collisionData.closestWallFlags = entry->baseType();
+        collisionData.closestWallSettings = entry->variant();
 
         if (entry->attribute.onBit(Field::CollisionDirector::eCollisionAttribute::Soft)) {
             collisionData.bSoftWall = true;
@@ -667,17 +667,18 @@ void KartCollide::processFloor(CollisionData &collisionData, Hitbox &hitbox,
     }
 
     collisionData.speedFactor = std::min(collisionData.speedFactor,
-            param()->stats().kclSpeed[closestColEntry->attributeBaseType()]);
+            param()->stats().kclSpeed[closestColEntry->baseType()]);
 
-    collisionData.intensity = closestColEntry->attributeIntensity();
-    collisionData.rotFactor += param()->stats().kclRot[closestColEntry->attributeBaseType()];
+    collisionData.intensity = closestColEntry->intensity();
+    collisionData.rotFactor += param()->stats().kclRot[closestColEntry->baseType()];
 
-    if (closestColEntry->attribute.onBit(Field::CollisionDirector::eCollisionAttribute::Offroad)) {
+    if (closestColEntry->attribute.onBit(
+                Field::CollisionDirector::eCollisionAttribute::RejectRoad)) {
         state()->setRejectRoad(true);
     }
 
     collisionData.closestFloorFlags = closestColEntry->typeMask;
-    collisionData.closestFloorSettings = closestColEntry->attributeVariant();
+    collisionData.closestFloorSettings = closestColEntry->variant();
 
     if (wheel && !!(*maskOut & KCL_TYPE_BIT(COL_TYPE_BOOST_PAD))) {
         move()->padType().setBit(KartMove::ePadType::BoostPanel);
@@ -687,7 +688,7 @@ void KartCollide::processFloor(CollisionData &collisionData, Hitbox &hitbox,
             colDirector->findClosestCollisionEntry(maskOut, BOOST_RAMP_MASK)) {
         closestColEntry = colDirector->closestCollisionEntry();
         move()->padType().setBit(KartMove::ePadType::BoostRamp);
-        state()->setBoostRampType(closestColEntry->attributeVariant());
+        state()->setBoostRampType(closestColEntry->variant());
         m_surfaceFlags.setBit(eSurfaceFlags::BoostRamp, eSurfaceFlags::Trickable);
     } else {
         state()->setBoostRampType(-1);
@@ -708,7 +709,7 @@ void KartCollide::processFloor(CollisionData &collisionData, Hitbox &hitbox,
             colDirector->findClosestCollisionEntry(maskOut, halfPipeRampMask)) {
         state()->setHalfPipeRamp(true);
         state()->setHalfPipeInvisibilityTimer(2);
-        if (colDirector->closestCollisionEntry()->attributeVariant() == 1) {
+        if (colDirector->closestCollisionEntry()->variant() == 1) {
             move()->padType().setBit(KartMove::ePadType::BoostPanel);
         }
     }
@@ -719,7 +720,7 @@ void KartCollide::processFloor(CollisionData &collisionData, Hitbox &hitbox,
                 !state()->isJumpPadMushroomVelYInc()) {
             move()->padType().setBit(KartMove::ePadType::JumpPad);
             closestColEntry = colDirector->closestCollisionEntry();
-            state()->setJumpPadVariant(closestColEntry->attributeVariant());
+            state()->setJumpPadVariant(closestColEntry->variant());
         }
         collisionData.bTrickable = true;
     }
@@ -730,7 +731,7 @@ void KartCollide::processFloor(CollisionData &collisionData, Hitbox &hitbox,
 void KartCollide::processCannon(Field::KCLTypeMask *maskOut) {
     auto *colDirector = Field::CollisionDirector::Instance();
     if (colDirector->findClosestCollisionEntry(maskOut, KCL_TYPE_BIT(COL_TYPE_CANNON_TRIGGER))) {
-        state()->setCannonPointId(colDirector->closestCollisionEntry()->attributeVariant());
+        state()->setCannonPointId(colDirector->closestCollisionEntry()->variant());
         state()->setCannonStart(true);
     }
 }

--- a/source/game/kart/KartCollide.cc
+++ b/source/game/kart/KartCollide.cc
@@ -623,7 +623,7 @@ bool KartCollide::processWall(CollisionData &collisionData, Field::KCLTypeMask *
         collisionData.closestWallFlags = entry->attributeBaseType();
         collisionData.closestWallSettings = entry->attributeVariant();
 
-        if (entry->attribute & KCL_TYPE_BIT(COL_TYPE_WALL_2)) {
+        if (entry->attribute.onBit(Field::CollisionDirector::eCollisionAttribute::Soft)) {
             collisionData.bSoftWall = true;
         }
     }
@@ -658,8 +658,7 @@ void KartCollide::processFloor(CollisionData &collisionData, Hitbox &hitbox,
 
     const auto *closestColEntry = colDirector->closestCollisionEntry();
 
-    u16 attribute = closestColEntry->attribute;
-    if (!(attribute & 0x2000)) {
+    if (closestColEntry->attribute.offBit(Field::CollisionDirector::eCollisionAttribute::Trickable)) {
         m_surfaceFlags.setBit(eSurfaceFlags::NotTrickable);
     } else {
         collisionData.bTrickable = true;
@@ -669,10 +668,10 @@ void KartCollide::processFloor(CollisionData &collisionData, Hitbox &hitbox,
     collisionData.speedFactor = std::min(collisionData.speedFactor,
             param()->stats().kclSpeed[closestColEntry->attributeBaseType()]);
 
-    collisionData.intensity = (attribute >> 0xb) & 3;
+    collisionData.intensity = closestColEntry->attributeIntensity();
     collisionData.rotFactor += param()->stats().kclRot[closestColEntry->attributeBaseType()];
 
-    if (attribute & 0x4000) {
+    if (closestColEntry->attribute.onBit(Field::CollisionDirector::eCollisionAttribute::Offroad)) {
         state()->setRejectRoad(true);
     }
 

--- a/source/game/kart/KartCollide.cc
+++ b/source/game/kart/KartCollide.cc
@@ -344,7 +344,7 @@ void KartCollide::handleTriggers(Field::KCLTypeMask *mask) {
     if (*mask & KCL_TYPE_BIT(COL_TYPE_EFFECT_TRIGGER)) {
         auto *colDir = Field::CollisionDirector::Instance();
         if (colDir->findClosestCollisionEntry(mask, KCL_TYPE_BIT(COL_TYPE_EFFECT_TRIGGER))) {
-            if (colDir->closestCollisionEntry()->variant() == 4) {
+            if (colDir->closestCollisionEntry()->attributeVariant() == 4) {
                 halfPipe()->end(true);
                 state()->setEndHalfPipe(true);
                 m_surfaceFlags.setBit(eSurfaceFlags::StopHalfPipeState);
@@ -620,8 +620,8 @@ bool KartCollide::processWall(CollisionData &collisionData, Field::KCLTypeMask *
                     KCL_TYPE_DRIVER_WALL_NO_INVISIBLE_WALL)) {
         auto *entry = colDirector->closestCollisionEntry();
 
-        collisionData.closestWallFlags = KCL_ATTRIBUTE_TYPE(entry->attribute);
-        collisionData.closestWallSettings = entry->variant();
+        collisionData.closestWallFlags = entry->attributeBaseType();
+        collisionData.closestWallSettings = entry->attributeVariant();
 
         if (entry->attribute & KCL_TYPE_BIT(COL_TYPE_WALL_2)) {
             collisionData.bSoftWall = true;
@@ -667,17 +667,17 @@ void KartCollide::processFloor(CollisionData &collisionData, Hitbox &hitbox,
     }
 
     collisionData.speedFactor = std::min(collisionData.speedFactor,
-            param()->stats().kclSpeed[KCL_ATTRIBUTE_TYPE(attribute)]);
+            param()->stats().kclSpeed[closestColEntry->attributeBaseType()]);
 
     collisionData.intensity = (attribute >> 0xb) & 3;
-    collisionData.rotFactor += param()->stats().kclRot[KCL_ATTRIBUTE_TYPE(attribute)];
+    collisionData.rotFactor += param()->stats().kclRot[closestColEntry->attributeBaseType()];
 
     if (attribute & 0x4000) {
         state()->setRejectRoad(true);
     }
 
     collisionData.closestFloorFlags = closestColEntry->typeMask;
-    collisionData.closestFloorSettings = closestColEntry->variant();
+    collisionData.closestFloorSettings = closestColEntry->attributeVariant();
 
     if (wheel && !!(*maskOut & KCL_TYPE_BIT(COL_TYPE_BOOST_PAD))) {
         move()->padType().setBit(KartMove::ePadType::BoostPanel);
@@ -687,7 +687,7 @@ void KartCollide::processFloor(CollisionData &collisionData, Hitbox &hitbox,
             colDirector->findClosestCollisionEntry(maskOut, BOOST_RAMP_MASK)) {
         closestColEntry = colDirector->closestCollisionEntry();
         move()->padType().setBit(KartMove::ePadType::BoostRamp);
-        state()->setBoostRampType(closestColEntry->variant());
+        state()->setBoostRampType(closestColEntry->attributeVariant());
         m_surfaceFlags.setBit(eSurfaceFlags::BoostRamp, eSurfaceFlags::Trickable);
     } else {
         state()->setBoostRampType(-1);
@@ -708,7 +708,7 @@ void KartCollide::processFloor(CollisionData &collisionData, Hitbox &hitbox,
             colDirector->findClosestCollisionEntry(maskOut, halfPipeRampMask)) {
         state()->setHalfPipeRamp(true);
         state()->setHalfPipeInvisibilityTimer(2);
-        if (colDirector->closestCollisionEntry()->variant() == 1) {
+        if (colDirector->closestCollisionEntry()->attributeVariant() == 1) {
             move()->padType().setBit(KartMove::ePadType::BoostPanel);
         }
     }
@@ -719,7 +719,7 @@ void KartCollide::processFloor(CollisionData &collisionData, Hitbox &hitbox,
                 !state()->isJumpPadMushroomVelYInc()) {
             move()->padType().setBit(KartMove::ePadType::JumpPad);
             closestColEntry = colDirector->closestCollisionEntry();
-            state()->setJumpPadVariant(closestColEntry->variant());
+            state()->setJumpPadVariant(closestColEntry->attributeVariant());
         }
         collisionData.bTrickable = true;
     }
@@ -731,7 +731,7 @@ void KartCollide::processCannon(Field::KCLTypeMask *maskOut) {
     auto *colDirector = Field::CollisionDirector::Instance();
     if (colDirector->findClosestCollisionEntry(maskOut, KCL_TYPE_BIT(COL_TYPE_CANNON_TRIGGER))) {
         state()->setCannonPointId(
-                colDirector->closestCollisionEntry()->variant());
+                colDirector->closestCollisionEntry()->attributeVariant());
         state()->setCannonStart(true);
     }
 }

--- a/source/game/kart/KartCollide.cc
+++ b/source/game/kart/KartCollide.cc
@@ -344,7 +344,7 @@ void KartCollide::handleTriggers(Field::KCLTypeMask *mask) {
     if (*mask & KCL_TYPE_BIT(COL_TYPE_EFFECT_TRIGGER)) {
         auto *colDir = Field::CollisionDirector::Instance();
         if (colDir->findClosestCollisionEntry(mask, KCL_TYPE_BIT(COL_TYPE_EFFECT_TRIGGER))) {
-            if (KCL_VARIANT_TYPE(colDir->closestCollisionEntry()->attribute) == 4) {
+            if (colDir->closestCollisionEntry()->variant() == 4) {
                 halfPipe()->end(true);
                 state()->setEndHalfPipe(true);
                 m_surfaceFlags.setBit(eSurfaceFlags::StopHalfPipeState);
@@ -621,7 +621,7 @@ bool KartCollide::processWall(CollisionData &collisionData, Field::KCLTypeMask *
         auto *entry = colDirector->closestCollisionEntry();
 
         collisionData.closestWallFlags = KCL_ATTRIBUTE_TYPE(entry->attribute);
-        collisionData.closestWallSettings = KCL_VARIANT_TYPE(entry->attribute);
+        collisionData.closestWallSettings = entry->variant();
 
         if (entry->attribute & KCL_TYPE_BIT(COL_TYPE_WALL_2)) {
             collisionData.bSoftWall = true;
@@ -677,7 +677,7 @@ void KartCollide::processFloor(CollisionData &collisionData, Hitbox &hitbox,
     }
 
     collisionData.closestFloorFlags = closestColEntry->typeMask;
-    collisionData.closestFloorSettings = KCL_VARIANT_TYPE(attribute);
+    collisionData.closestFloorSettings = closestColEntry->variant();
 
     if (wheel && !!(*maskOut & KCL_TYPE_BIT(COL_TYPE_BOOST_PAD))) {
         move()->padType().setBit(KartMove::ePadType::BoostPanel);
@@ -687,7 +687,7 @@ void KartCollide::processFloor(CollisionData &collisionData, Hitbox &hitbox,
             colDirector->findClosestCollisionEntry(maskOut, BOOST_RAMP_MASK)) {
         closestColEntry = colDirector->closestCollisionEntry();
         move()->padType().setBit(KartMove::ePadType::BoostRamp);
-        state()->setBoostRampType(KCL_VARIANT_TYPE(closestColEntry->attribute));
+        state()->setBoostRampType(closestColEntry->variant());
         m_surfaceFlags.setBit(eSurfaceFlags::BoostRamp, eSurfaceFlags::Trickable);
     } else {
         state()->setBoostRampType(-1);
@@ -708,7 +708,7 @@ void KartCollide::processFloor(CollisionData &collisionData, Hitbox &hitbox,
             colDirector->findClosestCollisionEntry(maskOut, halfPipeRampMask)) {
         state()->setHalfPipeRamp(true);
         state()->setHalfPipeInvisibilityTimer(2);
-        if (KCL_VARIANT_TYPE(colDirector->closestCollisionEntry()->attribute) == 1) {
+        if (colDirector->closestCollisionEntry()->variant() == 1) {
             move()->padType().setBit(KartMove::ePadType::BoostPanel);
         }
     }
@@ -719,7 +719,7 @@ void KartCollide::processFloor(CollisionData &collisionData, Hitbox &hitbox,
                 !state()->isJumpPadMushroomVelYInc()) {
             move()->padType().setBit(KartMove::ePadType::JumpPad);
             closestColEntry = colDirector->closestCollisionEntry();
-            state()->setJumpPadVariant(KCL_VARIANT_TYPE(closestColEntry->attribute));
+            state()->setJumpPadVariant(closestColEntry->variant());
         }
         collisionData.bTrickable = true;
     }
@@ -731,7 +731,7 @@ void KartCollide::processCannon(Field::KCLTypeMask *maskOut) {
     auto *colDirector = Field::CollisionDirector::Instance();
     if (colDirector->findClosestCollisionEntry(maskOut, KCL_TYPE_BIT(COL_TYPE_CANNON_TRIGGER))) {
         state()->setCannonPointId(
-                KCL_VARIANT_TYPE(colDirector->closestCollisionEntry()->attribute));
+                colDirector->closestCollisionEntry()->variant());
         state()->setCannonStart(true);
     }
 }

--- a/source/game/kart/KartCollide.cc
+++ b/source/game/kart/KartCollide.cc
@@ -658,7 +658,8 @@ void KartCollide::processFloor(CollisionData &collisionData, Hitbox &hitbox,
 
     const auto *closestColEntry = colDirector->closestCollisionEntry();
 
-    if (closestColEntry->attribute.offBit(Field::CollisionDirector::eCollisionAttribute::Trickable)) {
+    if (closestColEntry->attribute.offBit(
+                Field::CollisionDirector::eCollisionAttribute::Trickable)) {
         m_surfaceFlags.setBit(eSurfaceFlags::NotTrickable);
     } else {
         collisionData.bTrickable = true;
@@ -729,8 +730,7 @@ void KartCollide::processFloor(CollisionData &collisionData, Hitbox &hitbox,
 void KartCollide::processCannon(Field::KCLTypeMask *maskOut) {
     auto *colDirector = Field::CollisionDirector::Instance();
     if (colDirector->findClosestCollisionEntry(maskOut, KCL_TYPE_BIT(COL_TYPE_CANNON_TRIGGER))) {
-        state()->setCannonPointId(
-                colDirector->closestCollisionEntry()->attributeVariant());
+        state()->setCannonPointId(colDirector->closestCollisionEntry()->attributeVariant());
         state()->setCannonStart(true);
     }
 }

--- a/source/game/kart/KartReject.cc
+++ b/source/game/kart/KartReject.cc
@@ -124,7 +124,7 @@ bool KartReject::calcRejection() {
         }
 
         const auto *closestColEntry = colDir->closestCollisionEntry();
-        if (hasInvisibleWallCollision && closestColEntry->variant() == 0) {
+        if (hasInvisibleWallCollision && closestColEntry->attributeVariant() == 0) {
             hasRejectCollision = true;
             tangentOff = colInfo.wallNrm;
             state()->setNoSparkInvisibleWall(true);

--- a/source/game/kart/KartReject.cc
+++ b/source/game/kart/KartReject.cc
@@ -136,7 +136,9 @@ bool KartReject::calcRejection() {
             }
 
             closestColEntry = colDir->closestCollisionEntry();
-            if (hasFloorCollision && closestColEntry->attribute.onBit(Field::CollisionDirector::eCollisionAttribute::Offroad)) {
+            if (hasFloorCollision &&
+                    closestColEntry->attribute.onBit(
+                            Field::CollisionDirector::eCollisionAttribute::Offroad)) {
                 hasRejectCollision = true;
                 tangentOff = colInfo.floorNrm;
             }

--- a/source/game/kart/KartReject.cc
+++ b/source/game/kart/KartReject.cc
@@ -136,7 +136,7 @@ bool KartReject::calcRejection() {
             }
 
             closestColEntry = colDir->closestCollisionEntry();
-            if (hasFloorCollision && closestColEntry->attribute & 0x4000) {
+            if (hasFloorCollision && closestColEntry->attribute.onBit(Field::CollisionDirector::eCollisionAttribute::Offroad)) {
                 hasRejectCollision = true;
                 tangentOff = colInfo.floorNrm;
             }

--- a/source/game/kart/KartReject.cc
+++ b/source/game/kart/KartReject.cc
@@ -124,7 +124,7 @@ bool KartReject::calcRejection() {
         }
 
         const auto *closestColEntry = colDir->closestCollisionEntry();
-        if (hasInvisibleWallCollision && closestColEntry->attributeVariant() == 0) {
+        if (hasInvisibleWallCollision && closestColEntry->variant() == 0) {
             hasRejectCollision = true;
             tangentOff = colInfo.wallNrm;
             state()->setNoSparkInvisibleWall(true);
@@ -138,7 +138,7 @@ bool KartReject::calcRejection() {
             closestColEntry = colDir->closestCollisionEntry();
             if (hasFloorCollision &&
                     closestColEntry->attribute.onBit(
-                            Field::CollisionDirector::eCollisionAttribute::Offroad)) {
+                            Field::CollisionDirector::eCollisionAttribute::RejectRoad)) {
                 hasRejectCollision = true;
                 tangentOff = colInfo.floorNrm;
             }

--- a/source/game/kart/KartReject.cc
+++ b/source/game/kart/KartReject.cc
@@ -124,7 +124,7 @@ bool KartReject::calcRejection() {
         }
 
         const auto *closestColEntry = colDir->closestCollisionEntry();
-        if (hasInvisibleWallCollision && KCL_VARIANT_TYPE(closestColEntry->attribute) == 0) {
+        if (hasInvisibleWallCollision && closestColEntry->variant() == 0) {
             hasRejectCollision = true;
             tangentOff = colInfo.wallNrm;
             state()->setNoSparkInvisibleWall(true);


### PR DESCRIPTION
From: https://vabold.github.io/Kinoko/docs/html/todo.html

Member [Field::CollisionDirector::setCurrentCollisionTrickable]
Member [Field::CollisionDirector::setCurrentCollisionVariant]
Attributes should be represented as a bitfield. We can use a union. We will accomplish this in a future PR.

Changes:
- Created eCollisionAttribute enum class, which allows all 16 attribute bits to be directly accessible through the attribute var, while allowing individual bit access
- Added helpers to get multi bit members
- Removed KCL_VARIANT_TYPE and KCL_ATTRIBUTE_TYPE macros where possible for clarity

Notes:
Did not modify attribute that is part of CourseColMgr.cc. Updating this attribute would require edits to https://github.com/jacobop2/Kinoko/blob/main/source/game/field/CourseColMgr.hh#L19, which would be challenging. Plus, attribute is only ever used with KCL_SOFT_WALL_MASK, so don't think making it a union is worthwhile