### PR TITLE
Rework StateManager

### DIFF
--- a/source/game/field/StateManager.hh
+++ b/source/game/field/StateManager.hh
@@ -17,30 +17,60 @@ struct StateManagerEntry {
 };
 
 template <typename T>
-class StateManagerBase {
+class StateManager {
 public:
-    StateManagerBase() : m_currentStateId(0), m_nextStateId(-1), m_currentFrame(0), m_obj(nullptr) {
-        // Concepts don't work here due to CRTP causing incomplete class type use.
-        STATIC_ASSERT((std::is_base_of_v<ObjectBase, T>));
+    StateManager(T *obj);
+
+    virtual ~StateManager() {
+        delete[] m_entryIds.data();
     }
 
-    virtual ~StateManagerBase() {}
-
 protected:
+    void calc() {
+        if (m_nextStateId >= 0) {
+            m_currentStateId = m_nextStateId;
+            m_nextStateId = -1;
+            m_currentFrame = 0;
+
+            auto enterFunc = m_entries[m_entryIds[m_currentStateId]].onEnter;
+            (m_obj->*enterFunc)();
+        } else {
+            ++m_currentFrame;
+        }
+
+        auto calcFunc = m_entries[m_entryIds[m_currentStateId]].onCalc;
+        (m_obj->*calcFunc)();
+    }
+
     u16 m_currentStateId;
     s32 m_nextStateId;
     u32 m_currentFrame;
     std::span<u16> m_entryIds;
     std::span<const StateManagerEntry<T>> m_entries;
-    const T *m_obj;
+    T *m_obj;
 };
 
-// Keep the constructor from above
+/// @brief Defined outside of the class declaration so that typename T will be a complete type.
 template <typename T>
-class StateManager : public StateManagerBase<T> {
-public:
-    StateManager() = default;
-    ~StateManager() = default;
-};
+StateManager<T>::StateManager(T *obj)
+    : m_currentStateId(0), m_nextStateId(-1), m_currentFrame(0), m_obj(obj) {
+    // Concepts don't work here due to CRTP causing incomplete class type use.
+    STATIC_ASSERT((std::is_base_of_v<ObjectBase, T>));
+    STATIC_ASSERT((std::is_same_v<decltype(T::STATE_ENTRIES),
+            const std::array<StateManagerEntry<T>, T::STATE_ENTRIES.size()>>));
+
+    m_entryIds = std::span(new u16[T::STATE_ENTRIES.size()], T::STATE_ENTRIES.size());
+
+    // The base game initializes all entries to 0xffff, possibly to avoid an uninitialized value
+    for (auto &id : m_entryIds) {
+        id = 0xffff;
+    }
+
+    for (size_t i = 0; i < m_entryIds.size(); ++i) {
+        m_entryIds[T::STATE_ENTRIES[i].id] = i;
+    }
+
+    m_entries = std::span<const StateManagerEntry<T>>(T::STATE_ENTRIES);
+}
 
 } // namespace Field

--- a/source/game/field/obj/ObjectCarTGE.hh
+++ b/source/game/field/obj/ObjectCarTGE.hh
@@ -10,16 +10,6 @@ namespace Field {
 class ObjectCarTGE;
 class ObjectHighwayManager;
 
-template <>
-class StateManager<ObjectCarTGE> : public StateManagerBase<ObjectCarTGE> {
-public:
-    StateManager(ObjectCarTGE *obj);
-    ~StateManager() override;
-
-private:
-    static const std::array<StateManagerEntry<ObjectCarTGE>, 3> STATE_ENTRIES;
-};
-
 class ObjectCarTGE : public ObjectCollidable, public StateManager<ObjectCarTGE> {
     friend StateManager<ObjectCarTGE>;
 
@@ -97,6 +87,12 @@ private:
     bool m_squashed;
     bool m_hasAuxCollision;
     f32 m_hitAngle;
+
+    static constexpr std::array<StateManagerEntry<ObjectCarTGE>, 3> STATE_ENTRIES = {{
+            {0, &ObjectCarTGE::enterStateStub, &ObjectCarTGE::calcStateStub},
+            {1, &ObjectCarTGE::enterStateStub, &ObjectCarTGE::calcState1},
+            {2, &ObjectCarTGE::enterStateStub, &ObjectCarTGE::calcState2},
+    }};
 };
 
 } // namespace Field

--- a/source/game/field/obj/ObjectChoropu.cc
+++ b/source/game/field/obj/ObjectChoropu.cc
@@ -101,19 +101,7 @@ void ObjectChoropu::calc() {
         m_railMat = RailOrthonormalBasis(*m_railInterpolator);
     }
 
-    if (m_nextStateId >= 0) {
-        m_currentStateId = m_nextStateId;
-        m_nextStateId = -1;
-        m_currentFrame = 0;
-
-        auto enterFunc = m_entries[m_entryIds[m_currentStateId]].onEnter;
-        (this->*enterFunc)();
-    } else {
-        ++m_currentFrame;
-    }
-
-    auto calcFunc = m_entries[m_entryIds[m_currentStateId]].onCalc;
-    (this->*calcFunc)();
+    StateManager::calc();
 
     m_objHoll->setScale(EGG::Vector3f(1.0f, m_objHoll->scale().y, 1.0f));
 }
@@ -306,36 +294,6 @@ EGG::Matrix34f ObjectChoropu::calcInterpolatedPose(f32 t) const {
     EGG::Matrix34f mat = OrthonormalBasis(curTanDir);
     mat.setBase(3, curDir);
     return mat;
-}
-
-const std::array<StateManagerEntry<ObjectChoropu>, 5> StateManager<ObjectChoropu>::STATE_ENTRIES = {
-        {
-                {0, &ObjectChoropu::enterDigging, &ObjectChoropu::calcDigging},
-                {1, &ObjectChoropu::enterPeeking, &ObjectChoropu::calcPeeking},
-                {2, &ObjectChoropu::enterStateStub, &ObjectChoropu::calcStateStub},
-                {3, &ObjectChoropu::enterJumping, &ObjectChoropu::calcJumping},
-                {4, &ObjectChoropu::enterStateStub, &ObjectChoropu::calcStateStub},
-        }};
-
-StateManager<ObjectChoropu>::StateManager(ObjectChoropu *obj) {
-    constexpr size_t ENTRY_COUNT = 5;
-
-    m_obj = obj;
-    m_entries = std::span{STATE_ENTRIES};
-    m_entryIds = std::span(new u16[ENTRY_COUNT], ENTRY_COUNT);
-
-    // The base game initializes all entries to 0xffff, possibly to avoid an uninitialized value
-    for (auto &id : m_entryIds) {
-        id = 0xffff;
-    }
-
-    for (size_t i = 0; i < m_entryIds.size(); ++i) {
-        m_entryIds[STATE_ENTRIES[i].id] = i;
-    }
-}
-
-StateManager<ObjectChoropu>::~StateManager() {
-    delete[] m_entryIds.data();
 }
 
 /// @addr{0x806B8F94}

--- a/source/game/field/obj/ObjectChoropu.hh
+++ b/source/game/field/obj/ObjectChoropu.hh
@@ -14,16 +14,6 @@ class ObjectChoropu;
 class ObjectChoropuGround;
 class ObjectChoropuHoll;
 
-template <>
-class StateManager<ObjectChoropu> : public StateManagerBase<ObjectChoropu> {
-public:
-    StateManager(ObjectChoropu *obj);
-    ~StateManager() override;
-
-private:
-    static const std::array<StateManagerEntry<ObjectChoropu>, 5> STATE_ENTRIES;
-};
-
 /// @brief Represents the MMM and rPG monty moles.
 /// @details Each mole has an associated "holl" [sic]. Moles which move around (MMM) also have an
 /// associated "ground" (the dirt trail).
@@ -71,6 +61,14 @@ private:
 
     static constexpr f32 RADIUS = 300.0f;
     static constexpr f32 MAX_GROUND_LEN = 3000.0f; ///< Max length of the dirt trail
+
+    static constexpr std::array<StateManagerEntry<ObjectChoropu>, 5> STATE_ENTRIES = {{
+            {0, &ObjectChoropu::enterDigging, &ObjectChoropu::calcDigging},
+            {1, &ObjectChoropu::enterPeeking, &ObjectChoropu::calcPeeking},
+            {2, &ObjectChoropu::enterStateStub, &ObjectChoropu::calcStateStub},
+            {3, &ObjectChoropu::enterJumping, &ObjectChoropu::calcJumping},
+            {4, &ObjectChoropu::enterStateStub, &ObjectChoropu::calcStateStub},
+    }};
 };
 
 class ObjectChoropuGround : public ObjectCollidable {

--- a/source/game/field/obj/ObjectCow.cc
+++ b/source/game/field/obj/ObjectCow.cc
@@ -129,19 +129,7 @@ void ObjectCowLeader::calc() {
     u32 t = System::RaceManager::Instance()->timer();
 
     if (t >= m_startFrame) {
-        if (m_nextStateId >= 0) {
-            m_currentStateId = m_nextStateId;
-            m_nextStateId = -1;
-            m_currentFrame = 0;
-
-            auto enterFunc = m_entries[m_entryIds[m_currentStateId]].onEnter;
-            (this->*enterFunc)();
-        } else {
-            ++m_currentFrame;
-        }
-
-        auto calcFunc = m_entries[m_entryIds[m_currentStateId]].onCalc;
-        (this->*calcFunc)();
+        StateManager::calc();
     }
 
     calcPos();
@@ -262,34 +250,6 @@ void ObjectCowLeader::calcRoam() {
     setTarget(m_railInterpolator->curPos() + m_railInterpolator->curTangentDir() * 10.0f);
 }
 
-const std::array<StateManagerEntry<ObjectCowLeader>, 3>
-        StateManager<ObjectCowLeader>::STATE_ENTRIES = {{
-                {0, &ObjectCowLeader::enterWait, &ObjectCowLeader::calcWait},
-                {1, &ObjectCowLeader::enterEat, &ObjectCowLeader::calcEat},
-                {2, &ObjectCowLeader::enterRoam, &ObjectCowLeader::calcRoam},
-        }};
-
-StateManager<ObjectCowLeader>::StateManager(ObjectCowLeader *obj) {
-    constexpr size_t ENTRY_COUNT = 3;
-
-    m_obj = obj;
-    m_entries = std::span{STATE_ENTRIES};
-    m_entryIds = std::span(new u16[ENTRY_COUNT], ENTRY_COUNT);
-
-    // The base game initializes all entries to 0xffff, possibly to avoid an uninitialized value
-    for (auto &id : m_entryIds) {
-        id = 0xffff;
-    }
-
-    for (size_t i = 0; i < m_entryIds.size(); ++i) {
-        m_entryIds[STATE_ENTRIES[i].id] = i;
-    }
-}
-
-StateManager<ObjectCowLeader>::~StateManager() {
-    delete[] m_entryIds.data();
-}
-
 /// @addr{0x806BDD48}
 ObjectCowFollower::ObjectCowFollower(const System::MapdataGeoObj &params, const EGG::Vector3f &pos,
         f32 rot)
@@ -334,19 +294,7 @@ void ObjectCowFollower::calc() {
 
         setTarget(m_pos + m_posOffset * 2.0f);
     } else {
-        if (m_nextStateId >= 0) {
-            m_currentStateId = m_nextStateId;
-            m_nextStateId = -1;
-            m_currentFrame = 0;
-
-            auto enterFunc = m_entries[m_entryIds[m_currentStateId]].onEnter;
-            (this->*enterFunc)();
-        } else {
-            ++m_currentFrame;
-        }
-
-        auto calcFunc = m_entries[m_entryIds[m_currentStateId]].onCalc;
-        (this->*calcFunc)();
+        StateManager::calc();
     }
 
     calcPos();
@@ -478,34 +426,6 @@ void ObjectCowFollower::calcFollowLeader() {
     if (dist < DIST_THRESHOLD) {
         m_bStopping = true;
     }
-}
-
-const std::array<StateManagerEntry<ObjectCowFollower>, 3>
-        StateManager<ObjectCowFollower>::STATE_ENTRIES = {{
-                {0, &ObjectCowFollower::enterWait, &ObjectCowFollower::calcWait},
-                {1, &ObjectCowFollower::enterFreeRoam, &ObjectCowFollower::calcFreeRoam},
-                {2, &ObjectCowFollower::enterFollowLeader, &ObjectCowFollower::calcFollowLeader},
-        }};
-
-StateManager<ObjectCowFollower>::StateManager(ObjectCowFollower *obj) {
-    constexpr size_t ENTRY_COUNT = 3;
-
-    m_obj = obj;
-    m_entries = std::span{STATE_ENTRIES};
-    m_entryIds = std::span(new u16[ENTRY_COUNT], ENTRY_COUNT);
-
-    // The base game initializes all entries to 0xffff, possibly to avoid an uninitialized value
-    for (auto &id : m_entryIds) {
-        id = 0xffff;
-    }
-
-    for (size_t i = 0; i < m_entryIds.size(); ++i) {
-        m_entryIds[STATE_ENTRIES[i].id] = i;
-    }
-}
-
-StateManager<ObjectCowFollower>::~StateManager() {
-    delete[] m_entryIds.data();
 }
 
 /// @addr{0x806BEB54}

--- a/source/game/field/obj/ObjectCow.hh
+++ b/source/game/field/obj/ObjectCow.hh
@@ -47,16 +47,6 @@ protected:
 
 class ObjectCowLeader;
 
-template <>
-class StateManager<ObjectCowLeader> : public StateManagerBase<ObjectCowLeader> {
-public:
-    StateManager(ObjectCowLeader *obj);
-    ~StateManager() override;
-
-private:
-    static const std::array<StateManagerEntry<ObjectCowLeader>, 3> STATE_ENTRIES;
-};
-
 /// @brief A cow who its own rail and whose position is not influenced by the path of the others.
 class ObjectCowLeader final : public ObjectCow, public StateManager<ObjectCowLeader> {
     friend class ObjectCowHerd;
@@ -95,19 +85,15 @@ private:
     bool m_endedRailSegment;
     AnmType m_state1AnmType;
     u16 m_eatFrames; ///< Length of the state 1 eat animation
+
+    static constexpr std::array<StateManagerEntry<ObjectCowLeader>, 3> STATE_ENTRIES = {{
+            {0, &ObjectCowLeader::enterWait, &ObjectCowLeader::calcWait},
+            {1, &ObjectCowLeader::enterEat, &ObjectCowLeader::calcEat},
+            {2, &ObjectCowLeader::enterRoam, &ObjectCowLeader::calcRoam},
+    }};
 };
 
 class ObjectCowFollower;
-
-template <>
-class StateManager<ObjectCowFollower> : public StateManagerBase<ObjectCowFollower> {
-public:
-    StateManager(ObjectCowFollower *obj);
-    ~StateManager() override;
-
-private:
-    static const std::array<StateManagerEntry<ObjectCowFollower>, 3> STATE_ENTRIES;
-};
 
 /// @brief A cow that follows a leader by sharing the same rail.
 class ObjectCowFollower final : public ObjectCow, public StateManager<ObjectCowFollower> {
@@ -150,6 +136,12 @@ private:
 
     /// @brief Distance at which a cow is considered close enough to the rail to stop moving.
     static constexpr f32 DIST_THRESHOLD = 200.0f;
+
+    static constexpr std::array<StateManagerEntry<ObjectCowFollower>, 3> STATE_ENTRIES = {{
+            {0, &ObjectCowFollower::enterWait, &ObjectCowFollower::calcWait},
+            {1, &ObjectCowFollower::enterFreeRoam, &ObjectCowFollower::calcFreeRoam},
+            {2, &ObjectCowFollower::enterFollowLeader, &ObjectCowFollower::calcFollowLeader},
+    }};
 };
 
 /// @brief The manager class that controls a group of cows.

--- a/source/game/field/obj/ObjectKuribo.cc
+++ b/source/game/field/obj/ObjectKuribo.cc
@@ -38,19 +38,7 @@ void ObjectKuribo::init() {
 void ObjectKuribo::calc() {
     m_animTimer = ::fmodf(static_cast<f32>(m_frameCount) * m_animStep, m_maxAnimTimer);
 
-    if (m_nextStateId >= 0) {
-        m_currentStateId = m_nextStateId;
-        m_nextStateId = -1;
-        m_currentFrame = 0;
-
-        auto enterFunc = m_entries[m_entryIds[m_currentStateId]].onEnter;
-        (this->*enterFunc)();
-    } else {
-        ++m_currentFrame;
-    }
-
-    auto calcFunc = m_entries[m_entryIds[m_currentStateId]].onCalc;
-    (this->*calcFunc)();
+    StateManager::calc();
 
     ++m_frameCount;
 }
@@ -166,34 +154,6 @@ void ObjectKuribo::checkSphereFull() {
 EGG::Vector3f ObjectKuribo::interpolate(f32 scale, const EGG::Vector3f &v0,
         const EGG::Vector3f &v1) const {
     return v0 + (v1 - v0) * scale;
-}
-
-const std::array<StateManagerEntry<ObjectKuribo>, 4> StateManager<ObjectKuribo>::STATE_ENTRIES = {{
-        {0, &ObjectKuribo::enterStateStub, &ObjectKuribo::calcStateReroute},
-        {1, &ObjectKuribo::enterStateStub, &ObjectKuribo::calcStateWalk},
-        {2, &ObjectKuribo::enterStateStub, &ObjectKuribo::calcStateStub},
-        {3, &ObjectKuribo::enterStateStub, &ObjectKuribo::calcStateStub},
-}};
-
-StateManager<ObjectKuribo>::StateManager(ObjectKuribo *obj) {
-    constexpr size_t ENTRY_COUNT = 4;
-
-    m_obj = obj;
-    m_entries = std::span{STATE_ENTRIES};
-    m_entryIds = std::span(new u16[ENTRY_COUNT], ENTRY_COUNT);
-
-    // The base game initializes all entries to 0xffff, possibly to avoid an uninitialized value
-    for (auto &id : m_entryIds) {
-        id = 0xffff;
-    }
-
-    for (size_t i = 0; i < m_entryIds.size(); ++i) {
-        m_entryIds[STATE_ENTRIES[i].id] = i;
-    }
-}
-
-StateManager<ObjectKuribo>::~StateManager() {
-    delete[] m_entryIds.data();
 }
 
 } // namespace Field

--- a/source/game/field/obj/ObjectKuribo.hh
+++ b/source/game/field/obj/ObjectKuribo.hh
@@ -7,16 +7,6 @@ namespace Field {
 
 class ObjectKuribo;
 
-template <>
-class StateManager<ObjectKuribo> : public StateManagerBase<ObjectKuribo> {
-public:
-    StateManager(ObjectKuribo *obj);
-    ~StateManager() override;
-
-private:
-    static const std::array<StateManagerEntry<ObjectKuribo>, 4> STATE_ENTRIES;
-};
-
 class ObjectKuribo : public ObjectCollidable, public StateManager<ObjectKuribo> {
     friend StateManager<ObjectKuribo>;
 
@@ -54,6 +44,13 @@ private:
     EGG::Vector3f m_rot;
     EGG::Vector3f m_floorNrm;
     f32 m_animTimer;
+
+    static constexpr std::array<StateManagerEntry<ObjectKuribo>, 4> STATE_ENTRIES = {{
+            {0, &ObjectKuribo::enterStateStub, &ObjectKuribo::calcStateReroute},
+            {1, &ObjectKuribo::enterStateStub, &ObjectKuribo::calcStateWalk},
+            {2, &ObjectKuribo::enterStateStub, &ObjectKuribo::calcStateStub},
+            {3, &ObjectKuribo::enterStateStub, &ObjectKuribo::calcStateStub},
+    }};
 };
 
 } // namespace Field


### PR DESCRIPTION
I've simplified the StateManager infrastructure we use to remove the need for the middleman templated class. Now, the m_entryIds and m_entries can be created entirely in the base templated class's constructor.

It is now the responsibility of the object class, rather than the middleman class, to own a STATE_ENTRIES std::array of StateManagerEntry<T>.

I've also moved commonly re-used state calc logic into its own calc() function within StateManager.