### PR TITLE
Make Random copy constructor explicit

### DIFF
--- a/source/game/system/Random.hh
+++ b/source/game/system/Random.hh
@@ -10,6 +10,8 @@ class Random {
 public:
     Random(u32 seed) : m_x(seed), m_seed(seed) {}
 
+    explicit Random(const Random &rhs) = default;
+
     ~Random() = default;
 
     void next() {


### PR DESCRIPTION
This will avoid instances where we accidentally get a copy instead of a reference. This has been the cause of a few desyncs during development.

e.g.:

```cpp
// This will cause a copy accidentally
auto rand = System::RaceManager::Instance()->random();

// This will not update the RNG state in the singleton
rand->getF32();
```