### PR TITLE
Allow specifying framecount in Ghost mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,12 @@ To update the test binary after making changes to `testCases.json`, be sure to r
 If you just want to test a single ghost, you can run:
 
 ```
-./kinoko test -g pathTo.rkg -k pathTo.krkg
+./kinoko test -g pathTo.rkg -k pathTo.krkg [-f <target>]
 ```
 
-In this scenario, Kinoko will validate the entire ghost, only passing the test if the entire ghost syncs.
+In this scenario, Kinoko will validate the ghost to the specified *target* framecount. If no *target* is specified, the entire ghost will be validated.
+
+**NOTE:** If the *target* is 0 or larger than the total number of frames in the run then the entire ghost will be validated.
 
 ## Interfacing
 

--- a/source/host/Option.cc
+++ b/source/host/Option.cc
@@ -26,6 +26,10 @@ std::optional<EOption> CheckFlag(const char *arg) {
             return EOption::KRKG;
         }
 
+        if (strcmp(verbose_arg, "framecount") == 0) {
+            return EOption::TargetFrame;
+        }
+
         return EOption::Invalid;
     } else {
         switch (arg[1]) {
@@ -38,6 +42,9 @@ std::optional<EOption> CheckFlag(const char *arg) {
         case 'K':
         case 'k':
             return EOption::KRKG;
+        case 'F':
+        case 'f':
+            return EOption::TargetFrame;
         default:
             return EOption::Invalid;
         }

--- a/source/host/Option.hh
+++ b/source/host/Option.hh
@@ -12,6 +12,7 @@ enum class EOption {
     Suite,
     Ghost,
     KRKG,
+    TargetFrame,
 };
 
 namespace Option {


### PR DESCRIPTION
I found it inconvenient that I couldn't specify a frame count to target for just a single ghost