### PR TITLE
Make KColData CollisionCheckType a template parameter

### DIFF
--- a/source/game/field/KColData.hh
+++ b/source/game/field/KColData.hh
@@ -121,8 +121,10 @@ private:
     void preloadNormals();
     void preloadVertices();
 
+    template <CollisionCheckType Type>
     [[nodiscard]] bool checkCollision(const KCollisionPrism &prism, f32 *distOut,
-            EGG::Vector3f *fnrmOut, u16 *flagsOut, CollisionCheckType type);
+            EGG::Vector3f *fnrmOut, u16 *flagsOut);
+
     [[nodiscard]] bool checkPointCollision(const KCollisionPrism &prism, f32 *distOut,
             EGG::Vector3f *fnrmOut, u16 *flagsOut, bool movement);
     [[nodiscard]] bool checkSphereMovement(f32 *distOut, EGG::Vector3f *fnrmOut, u16 *attributeOut);


### PR DESCRIPTION
This introduces a ~5% performance improvement by splitting out the `CollisionCheckType` argument into a template argument. This allows us to make use of `if constexpr`, which will decay away when each template specialization is compiled.