### PR TITLE
Fix hard-coded heap fill flag

### DIFF
--- a/source/egg/core/SceneManager.cc
+++ b/source/egg/core/SceneManager.cc
@@ -214,7 +214,7 @@ void SceneManager::setupNextSceneId() {
 }
 
 Heap *SceneManager::s_heapForCreateScene = nullptr;
-u16 SceneManager::s_heapOptionFlg = 2;
+u16 SceneManager::s_heapOptionFlg = DEFAULT_OPT;
 
 Heap *SceneManager::s_rootHeap = nullptr;
 


### PR DESCRIPTION
This was causing release builds to fill our memory arena bytes with `0xf3` because the flag was hard-coded to a u16 that corresponds with `DebugFillAlloc`.