### PR TITLE
Fix rSGB desyncs

### DIFF
--- a/source/game/field/obj/ObjectCrab.hh
+++ b/source/game/field/obj/ObjectCrab.hh
@@ -31,8 +31,14 @@ private:
         End = 2,
     };
 
-    void calcRail();
-    void calcState();
+    enum class StateResult {
+        Walking = 0,
+        Middle = 1,
+        BeginWalking = 2,
+    };
+
+    bool calcRail();
+    StateResult calcState();
 
     void calcCurRot(const EGG::Vector3f &rot);
     void calcTransMat(const EGG::Vector3f &rot);

--- a/source/game/kart/KartAction.cc
+++ b/source/game/kart/KartAction.cc
@@ -410,7 +410,7 @@ bool KartAction::calcLargeFlipAction() {
     bool decayingRot = false;
     bool stuntRot = false;
 
-    if (m_flags.onBit(eFlags::Rotating)) {
+    if (m_flags.onBit(eFlags::LargeFlip)) {
         ++m_framesFlipping;
     } else {
         if (m_deltaPitch < TOTAL_DELTA_PITCH) {
@@ -457,14 +457,14 @@ bool KartAction::calcLargeFlipAction() {
         }
 
         if (m_frame <= 120) {
-            if (m_flags.onBit(eFlags::Rotating)) {
+            if (m_flags.onBit(eFlags::LargeFlip)) {
                 if (m_framesFlipping > 30) {
                     actionEnded = true;
                 }
             } else {
                 if (m_frame >= 40 && m_frame <= 80) {
                     decayingRot = true;
-                    m_flags.setBit(eFlags::Rotating);
+                    m_flags.setBit(eFlags::LargeFlip);
                     status.resetBit(eStatus::LargeFlipHit);
                 }
             }

--- a/source/game/kart/KartAction.hh
+++ b/source/game/kart/KartAction.hh
@@ -26,6 +26,7 @@ class KartAction : KartObjectProxy {
 public:
     enum class eFlags {
         Landing = 0,
+        LargeFlip = 2,
         Rotating = 3,
         LandingFromFlip = 5,
     };

--- a/source/game/kart/KartCollide.cc
+++ b/source/game/kart/KartCollide.cc
@@ -867,7 +867,7 @@ void KartCollide::applySomeFloorMoment(f32 down, f32 rate, CollisionGroup *hitbo
     }
 
     f32 dVar5 = rate * EGG::Mathf::abs(scalar);
-    if (dVar5 < EGG::Mathf::abs(rejNorm)) {
+    if (EGG::Mathf::abs(rejNorm) > dVar5) {
         rejNorm_ = dVar5;
         if (rejNorm < 0.0f) {
             rejNorm_ = -rate * EGG::Mathf::abs(scalar);

--- a/source/game/kart/KartMove.cc
+++ b/source/game/kart/KartMove.cc
@@ -1423,7 +1423,9 @@ void KartMove::calcAcceleration() {
     m_lastSpeed = m_speed;
     auto &status = KartObjectProxy::status();
 
-    dynamics()->setKillExtVelY(status.onBit(eStatus::RespawnKillY));
+    if (status.offBit(eStatus::InAction)) {
+        dynamics()->setKillExtVelY(status.onBit(eStatus::RespawnKillY));
+    }
 
     if (status.onBit(eStatus::Burnout)) {
         m_speed = 0.0f;


### PR DESCRIPTION
- There was a missing `KartAction::m_flag` that was distinct from `eFlags::Rotating`
- `ObjectCrab::calc` was not branching properly in certain scenarios. In order to match the expected behavior, I had to introduce a new enum class type for the `calcState` return. This is really ugly but it works
- `KartCollide::applySomeFloorMoment` had comparison operands in the wrong order