### PR TITLE
Fix missing KartAction::start call when shrink activates

### DIFF
--- a/source/game/kart/KartMove.cc
+++ b/source/game/kart/KartMove.cc
@@ -2290,6 +2290,7 @@ void KartMove::applyShrink(u16 timer) {
         return;
     }
 
+    action()->start(Action::UNK_15);
     Item::ItemDirector::Instance()->kartItem(0).clear();
     status.setBit(eStatus::Shocked);
 


### PR DESCRIPTION
Even though hitting the KC propeller laser triggers `KartCollide::handleReactSpinShrink` which starts `Kart::Action::UNK_15`, we actually need `KartMove::applyShrink` to start the action AGAIN.