### PR TITLE
Clean up remaining memory leaks and subscripts

### DIFF
--- a/source/game/field/BoxColManager.cc
+++ b/source/game/field/BoxColManager.cc
@@ -150,7 +150,7 @@ void BoxColManager::calc() {
 
     // Reorganize the low points
     for (size_t i = 1; i < static_cast<size_t>(m_unitCount); ++i) {
-        for (size_t j = i; m_lowPoints[j - 1].z > m_lowPoints[j].z && j >= 1; --j) {
+        for (size_t j = i; j >= 1 && m_lowPoints[j - 1].z > m_lowPoints[j].z; --j) {
             BoxColLowPoint &upper = m_lowPoints[j];
             BoxColLowPoint &lower = m_lowPoints[j - 1];
 

--- a/source/game/field/ObjectDirector.cc
+++ b/source/game/field/ObjectDirector.cc
@@ -55,7 +55,7 @@ void ObjectDirector::addObject(ObjectCollidable *obj) {
     m_objects.push_back(obj);
 }
 
-void ObjectDirector::addObjectNoImpl(ObjectNoImpl *obj) {
+void ObjectDirector::addObjectNoImpl(ObjectBase *obj) {
     m_objects.push_back(obj);
 }
 

--- a/source/game/field/ObjectDirector.hh
+++ b/source/game/field/ObjectDirector.hh
@@ -25,7 +25,7 @@ public:
     void init();
     void calc();
     void addObject(ObjectCollidable *obj);
-    void addObjectNoImpl(ObjectNoImpl *obj);
+    void addObjectNoImpl(ObjectBase *obj);
     void addManagedObject(ObjectCollidable *obj);
 
     size_t checkKartObjectCollision(Kart::KartObject *kartObj,

--- a/source/game/field/obj/ObjectBase.cc
+++ b/source/game/field/obj/ObjectBase.cc
@@ -35,6 +35,7 @@ ObjectBase::ObjectBase(const char *name, const EGG::Vector3f &pos, const EGG::Ve
 ObjectBase::~ObjectBase() {
     delete m_resFile;
     delete m_drawMdl;
+    delete m_railInterpolator;
 }
 
 /// @addr{0x808217B8}

--- a/source/game/field/obj/ObjectDossunc.cc
+++ b/source/game/field/obj/ObjectDossunc.cc
@@ -5,6 +5,8 @@
 #include "game/field/obj/ObjectDossunTsuibiHolder.hh"
 #include "game/field/obj/ObjectDossunYokoMove.hh"
 
+#include "game/field/ObjectDirector.hh"
+
 namespace Field {
 
 /// @addr{0x8075EAFC}
@@ -33,5 +35,10 @@ ObjectDossunc::ObjectDossunc(const System::MapdataGeoObj &params) : ObjectCollid
 
 /// @addr{0x80764B08}
 ObjectDossunc::~ObjectDossunc() = default;
+
+/// @addr{0x80764A38}
+void ObjectDossunc::load() {
+    ObjectDirector::Instance()->addObjectNoImpl(this);
+}
 
 } // namespace Field

--- a/source/game/field/obj/ObjectDossunc.hh
+++ b/source/game/field/obj/ObjectDossunc.hh
@@ -11,7 +11,7 @@ public:
     ~ObjectDossunc() override;
 
     /// @addr{0x80764A38}
-    void load() override {}
+    void load() override;
 };
 
 } // namespace Field

--- a/source/game/field/obj/ObjectObakeManager.hh
+++ b/source/game/field/obj/ObjectObakeManager.hh
@@ -113,7 +113,7 @@ private:
     ObjectCollisionSphere *m_colSphere; ///< Represents a kart hitbox
 
     /// Spatially-indexed array of blocks for faster collision lookups.
-    std::array<std::array<ObjectObakeBlock *, CACHE_SIZE_Z>, CACHE_SIZE_X> m_blockCache;
+    std::array<std::array<ObjectObakeBlock *, CACHE_SIZE_X>, CACHE_SIZE_Z> m_blockCache;
 
     std::vector<ObjectObakeBlock *> m_blocks;     ///< All blocks
     std::vector<ObjectObakeBlock *> m_calcBlocks; ///< Actively falling blocks

--- a/source/game/field/obj/ObjectShip64.cc
+++ b/source/game/field/obj/ObjectShip64.cc
@@ -6,7 +6,9 @@ namespace Field {
 ObjectShip64::ObjectShip64(const System::MapdataGeoObj &params) : ObjectCollidable(params) {}
 
 /// @addr{0x80765DB0}
-ObjectShip64::~ObjectShip64() = default;
+ObjectShip64::~ObjectShip64() {
+    delete m_auxCollision;
+}
 
 /// @addr{0x80765E30}
 void ObjectShip64::init() {

--- a/source/game/kart/KartObjectManager.cc
+++ b/source/game/kart/KartObjectManager.cc
@@ -78,6 +78,8 @@ KartObjectManager::~KartObjectManager() {
 
     delete[] m_objects;
 
+    delete s_thunderScaleUpAnmChr;
+    delete s_thunderScaleDownAnmChr;
     delete s_pressScaleUpAnmChr;
 
     // If the proxy list is not cleared when we're done with the KartObjectManager, the list's


### PR DESCRIPTION
To provide a handle for ObjectDirector to manage the Dossunc object, I extended the functionality we built for ObjectNoImpl so it could clean up correctly.