### PR TITLE
Migrate EGG heap to custom new and delete functions

### DIFF
--- a/include/Types.hh
+++ b/include/Types.hh
@@ -2,6 +2,8 @@
 
 #include <Logger.hh>
 
+#include <egg/core/Heap.hh>
+
 #include <cstdint>
 #include <span>
 #include <type_traits>
@@ -32,18 +34,19 @@ public:
     owning_span() : m_data(nullptr), m_size(0) {}
 
     /// @brief Allocates a buffer of T elements. Does not initialize any elements.
-    owning_span(size_t count) : m_data(new T[count]), m_size(count) {}
+    owning_span(size_t count) : m_data(EGG::egg_new_array<T>(count)), m_size(count) {}
 
     /// @brief Performs a deep copy from a std::span of const T
     /// @details Will compile to a memcpy for trivially copyable types
-    owning_span(const std::span<const T> &span) : m_data(new T[span.size()]), m_size(span.size()) {
+    owning_span(const std::span<const T> &span)
+        : m_data(EGG::egg_new_array<T>(span.size())), m_size(span.size()) {
         std::copy(span.begin(), span.end(), m_data);
     }
 
     /// @brief Copy constructor
     /// @details Performs a deep copy
     owning_span(const owning_span &rhs) : m_size(rhs.m_size) {
-        m_data = new T[m_size];
+        m_data = EGG::egg_new_array<T>(m_size);
         std::copy(rhs.begin(), rhs.end(), m_data);
     }
 
@@ -61,9 +64,9 @@ public:
     /// @details Deletes the existing buffer and performs a deep copy
     owning_span &operator=(const owning_span &rhs) {
         if (this != &rhs) {
-            delete[] m_data;
+            EGG::egg_delete_array(m_data, m_size);
             m_size = rhs.m_size;
-            m_data = new T[m_size];
+            m_data = EGG::egg_new_array<T>(m_size);
             std::copy(rhs.begin(), rhs.end(), m_data);
         }
 
@@ -74,7 +77,7 @@ public:
     /// @details Transfers ownership of the buffer and leaves rhs in an invalid state
     owning_span &operator=(owning_span &&rhs) {
         if (this != &rhs) {
-            delete[] m_data;
+            EGG::egg_delete_array(m_data, m_size);
             m_data = rhs.m_data;
             rhs.m_data = nullptr;
             m_size = rhs.m_size;
@@ -86,7 +89,7 @@ public:
 
     /// @brief Destroys the underlying buffer on teardown
     ~owning_span() {
-        delete[] m_data;
+        EGG::egg_delete_array(m_data, m_size);
     }
 
     /// @brief Indexes into the underlying buffer

--- a/source/abstract/File.cc
+++ b/source/abstract/File.cc
@@ -1,5 +1,7 @@
 #include "File.hh"
 
+#include <egg/core/Heap.hh>
+
 #include <fstream>
 
 namespace Kinoko::Abstract::File {
@@ -21,7 +23,7 @@ u8 *Load(const char *path, size_t &size) {
     size = file.tellg();
     file.seekg(0, std::ios::beg);
 
-    u8 *buffer = new u8[size];
+    u8 *buffer = static_cast<u8 *>(EGG::egg_alloc(size, 4));
     file.read(reinterpret_cast<char *>(buffer), size);
 
     return buffer;

--- a/source/egg/core/Allocator.hh
+++ b/source/egg/core/Allocator.hh
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "egg/core/Heap.hh"
+
+namespace Kinoko::EGG {
+
+template <typename T>
+struct Allocator {
+    using value_type = T;
+
+    Allocator() = default;
+    template <typename U>
+    constexpr Allocator(const Allocator<U> &) noexcept {}
+
+    [[nodiscard]] T *allocate(size_t n) {
+        return static_cast<T *>(egg_alloc(n * sizeof(T), static_cast<s32>(alignof(T))));
+    }
+
+    void deallocate(T *ptr, size_t) noexcept {
+        egg_free(ptr);
+    }
+};
+
+template <typename T, typename U>
+constexpr bool operator==(const Allocator<T> &, const Allocator<U> &) noexcept {
+    return true;
+}
+
+} // namespace Kinoko::EGG

--- a/source/egg/core/Archive.cc
+++ b/source/egg/core/Archive.cc
@@ -15,7 +15,7 @@ Archive::~Archive() {
 /// @addr{0x8020fa38}
 void Archive::unmount() {
     if (--m_refCount <= 0) {
-        delete this;
+        egg_delete(this);
     }
 }
 
@@ -55,7 +55,7 @@ Archive *Archive::Mount(void *archiveStart) {
 
     if (!archive) {
         // Create a new archive and add it to the list
-        archive = new Archive(archiveStart);
+        archive = EGG::egg_new<Archive>(archiveStart);
         s_archiveList.append(archive);
     } else {
         // It already exists, increase the reference count

--- a/source/egg/core/Archive.hh
+++ b/source/egg/core/Archive.hh
@@ -26,6 +26,7 @@ class Archive : Disposer {
     friend class Host::Context;
 
 public:
+    Archive(void *archiveStart);
     ~Archive();
 
     void unmount();
@@ -36,8 +37,6 @@ public:
     [[nodiscard]] static Archive *Mount(void *archiveStart);
 
 private:
-    Archive(void *archiveStart);
-
     [[nodiscard]] static constexpr uintptr_t GetLinkOffset() {
         // offsetof doesn't work, so instead of hardcoding an offset, we derive it ourselves
         return reinterpret_cast<uintptr_t>(&reinterpret_cast<Archive *>(NULL)->m_link);

--- a/source/egg/core/Archive.hh
+++ b/source/egg/core/Archive.hh
@@ -26,9 +26,6 @@ class Archive : Disposer {
     friend class Host::Context;
 
 public:
-    Archive(void *archiveStart);
-    ~Archive();
-
     void unmount();
     [[nodiscard]] s32 convertPathToEntryId(const char *path) const;
     void *getFileFast(s32 entryId, Abstract::ArchiveHandle::FileInfo &info) const;
@@ -37,6 +34,11 @@ public:
     [[nodiscard]] static Archive *Mount(void *archiveStart);
 
 private:
+    EGG_NEW_DELETE_FRIEND
+
+    Archive(void *archiveStart);
+    ~Archive();
+
     [[nodiscard]] static constexpr uintptr_t GetLinkOffset() {
         // offsetof doesn't work, so instead of hardcoding an offset, we derive it ourselves
         return reinterpret_cast<uintptr_t>(&reinterpret_cast<Archive *>(NULL)->m_link);

--- a/source/egg/core/Heap.cc
+++ b/source/egg/core/Heap.cc
@@ -131,55 +131,15 @@ Heap *Heap::findContainHeap(const void *block) {
     return handle ? findHeap(handle) : nullptr;
 }
 
+void *egg_alloc(size_t size, s32 align, Heap *pHeap) {
+    return Heap::alloc(size, align, pHeap);
+}
+
+void egg_free(void *block, Heap *pHeap) {
+    Heap::free(block, pHeap);
+}
+
 } // namespace Kinoko::EGG
-
-/// @addr{0x80229DCC}
-void *operator new(size_t size) {
-    return EGG::Heap::alloc(size, 4, nullptr);
-}
-
-/// @addr{0x80229DD8}
-void *operator new(size_t size, int align) {
-    return EGG::Heap::alloc(size, align, nullptr);
-}
-
-/// @addr{0x80229DE0}
-void *operator new(size_t size, EGG::Heap *heap, int align) {
-    return EGG::Heap::alloc(size, align, heap);
-}
-
-/// @addr{0x80229DF0}
-void *operator new[](size_t size) {
-    return EGG::Heap::alloc(size, 4, nullptr);
-}
-
-/// @addr{0x80229DFC}
-void *operator new[](size_t size, int align) {
-    return EGG::Heap::alloc(size, align, nullptr);
-}
-
-/// @addr{0x80229E04}
-void *operator new[](size_t size, EGG::Heap *heap, int align) {
-    return EGG::Heap::alloc(size, align, heap);
-}
-
-/// @addr{0x80229E14}
-void operator delete(void *block) noexcept {
-    EGG::Heap::free(block, nullptr);
-}
-
-void operator delete(void *block, size_t /* size */) noexcept {
-    EGG::Heap::free(block, nullptr);
-}
-
-/// @addr{0x80229EE0}
-void operator delete[](void *block) noexcept {
-    EGG::Heap::free(block, nullptr);
-}
-
-void operator delete[](void *block, size_t /* size */) noexcept {
-    EGG::Heap::free(block, nullptr);
-}
 
 MEMList EGG::Heap::s_heapList = MEMList(EGG::Heap::getOffset()); ///< @addr{0x80384320}
 

--- a/source/egg/core/Heap.hh
+++ b/source/egg/core/Heap.hh
@@ -136,15 +136,42 @@ protected:
     static Heap *s_allocatableHeap;
 };
 
+[[nodiscard]] void *egg_alloc(size_t size, s32 align = 4, Heap *pHeap = nullptr);
+void egg_free(void *block, Heap *pHeap = nullptr);
+
+template <typename T, typename... Args>
+[[nodiscard]] T *egg_new(Args &&...args) {
+    return ::new (egg_alloc(sizeof(T), static_cast<s32>(alignof(T))))
+            T(std::forward<Args>(args)...);
+}
+
+template <typename T>
+void egg_delete(const T *ptr) {
+    if (ptr) {
+        ptr->~T();
+        egg_free(const_cast<T *>(ptr));
+    }
+}
+
+template <typename T>
+[[nodiscard]] T *egg_new_array(size_t count) {
+    T *p = static_cast<T *>(egg_alloc(sizeof(T) * count, static_cast<s32>(alignof(T))));
+    for (size_t i = 0; i < count; ++i) {
+        ::new (p + i) T();
+    }
+    return p;
+}
+
+template <typename T>
+void egg_delete_array(T *ptr, size_t count) {
+    if (ptr) {
+        for (size_t i = count; i-- > 0;) {
+            ptr[i].~T();
+        }
+        egg_free(ptr);
+    }
+}
+
 } // namespace EGG
 
 } // namespace Kinoko
-
-[[nodiscard]] void *operator new(size_t size);
-[[nodiscard]] void *operator new(size_t size, int align);
-[[nodiscard]] void *operator new(size_t size, Kinoko::EGG::Heap *heap, int align);
-[[nodiscard]] void *operator new[](size_t size);
-[[nodiscard]] void *operator new[](size_t size, int align);
-[[nodiscard]] void *operator new[](size_t size, Kinoko::EGG::Heap *heap, int align);
-void operator delete(void *block) noexcept;
-void operator delete[](void *block) noexcept;

--- a/source/egg/core/Heap.hh
+++ b/source/egg/core/Heap.hh
@@ -175,3 +175,11 @@ void egg_delete_array(T *ptr, size_t count) {
 } // namespace EGG
 
 } // namespace Kinoko
+
+/// @brief Grants Kinoko::EGG::egg_new and Kinoko::EGG::egg_delete access to a class' private
+/// constructors/destructor, without making them public.
+#define EGG_NEW_DELETE_FRIEND \
+    template <typename T, typename... Args> \
+    friend T *Kinoko::EGG::egg_new(Args &&...args); \
+    template <typename T> \
+    friend void Kinoko::EGG::egg_delete(const T *ptr);

--- a/source/egg/core/SceneManager.cc
+++ b/source/egg/core/SceneManager.cc
@@ -92,7 +92,7 @@ void SceneManager::destroyScene(Scene *scene) {
     // ADDED: The original library does not actually delete the scene, but we run into leaks
     // So, we delete the scene that's provided to the function
     auto *heap = scene->heap();
-    delete scene;
+    EGG::egg_delete(scene);
 
     m_currentScene = nullptr;
 

--- a/source/egg/util/Stream.cc
+++ b/source/egg/util/Stream.cc
@@ -1,5 +1,7 @@
 #include "Stream.hh"
 
+#include <cstring>
+
 namespace Kinoko::EGG {
 
 Stream::Stream() : m_endian(std::endian::big), m_index(0) {}
@@ -117,9 +119,9 @@ void RamStream::write(void *input, u32 size) {
 }
 
 // Expects a null-terminated char array, and moves the index past the null terminator
-std::string RamStream::read_string() {
-    std::string ret(reinterpret_cast<char *>(m_buffer + m_index));
-    m_index += ret.size() + 1;
+const char *RamStream::read_string() {
+    const char *ret = reinterpret_cast<char *>(m_buffer + m_index);
+    m_index += strlen(ret) + 1;
     ASSERT(!bad());
     return ret;
 }

--- a/source/egg/util/Stream.hh
+++ b/source/egg/util/Stream.hh
@@ -2,8 +2,6 @@
 
 #include <Common.hh>
 
-#include <string>
-
 namespace Kinoko::EGG {
 
 /// @brief A stream of data, abstracted to allow for continuous seeking.
@@ -101,7 +99,7 @@ public:
         return m_index > m_size;
     }
 
-    [[nodiscard]] std::string read_string();
+    [[nodiscard]] const char *read_string();
     [[nodiscard]] RamStream split(u32 size);
     void setBufferAndSize(void *buffer, u32 size);
 

--- a/source/game/field/BoxColManager.cc
+++ b/source/game/field/BoxColManager.cc
@@ -3,6 +3,8 @@
 #include "game/field/obj/ObjectCollidable.hh"
 #include "game/field/obj/ObjectDrivable.hh"
 
+#include <egg/core/Heap.hh>
+
 #include <numeric>
 
 namespace Kinoko::Field {
@@ -334,7 +336,7 @@ bool BoxColManager::isSphereInSpatialCache(f32 radius, const EGG::Vector3f &pos,
 /// @addr{0x807855DC}
 BoxColManager *BoxColManager::CreateInstance() {
     ASSERT(!s_instance);
-    s_instance = new BoxColManager;
+    s_instance = EGG::egg_new<BoxColManager>();
     return s_instance;
 }
 
@@ -343,7 +345,7 @@ void BoxColManager::DestroyInstance() {
     ASSERT(s_instance);
     auto *instance = s_instance;
     s_instance = nullptr;
-    delete instance;
+    EGG::egg_delete(instance);
 }
 
 BoxColManager *BoxColManager::Instance() {

--- a/source/game/field/CollisionDirector.cc
+++ b/source/game/field/CollisionDirector.cc
@@ -289,7 +289,7 @@ bool CollisionDirector::findClosestCollisionEntry(KCLTypeMask * /*typeMask*/, KC
 /// @addr{0x8078DFE8}
 CollisionDirector *CollisionDirector::CreateInstance() {
     ASSERT(!s_instance);
-    s_instance = new CollisionDirector;
+    s_instance = EGG::egg_new<CollisionDirector>();
     return s_instance;
 }
 
@@ -298,7 +298,7 @@ void CollisionDirector::DestroyInstance() {
     ASSERT(s_instance);
     auto *instance = s_instance;
     s_instance = nullptr;
-    delete instance;
+    EGG::egg_delete(instance);
 }
 
 /// @addr{0x8078E33C}

--- a/source/game/field/CollisionDirector.hh
+++ b/source/game/field/CollisionDirector.hh
@@ -111,10 +111,12 @@ public:
         return s_instance;
     }
 
+private:
+    EGG_NEW_DELETE_FRIEND
+
     CollisionDirector();
     ~CollisionDirector() override;
 
-private:
     const CollisionEntry *m_closestCollisionEntry;
     std::array<CollisionEntry, COLLISION_ARR_LENGTH> m_entries;
     size_t m_collisionEntryCount;

--- a/source/game/field/CollisionDirector.hh
+++ b/source/game/field/CollisionDirector.hh
@@ -111,10 +111,10 @@ public:
         return s_instance;
     }
 
-private:
     CollisionDirector();
     ~CollisionDirector() override;
 
+private:
     const CollisionEntry *m_closestCollisionEntry;
     std::array<CollisionEntry, COLLISION_ARR_LENGTH> m_entries;
     size_t m_collisionEntryCount;

--- a/source/game/field/CourseColMgr.cc
+++ b/source/game/field/CourseColMgr.cc
@@ -13,7 +13,7 @@ void CourseColMgr::init() {
     // In the base game, this file is loaded in CollisionDirector::CreateInstance and passed into
     // this function. It's simpler to just keep it here.
     void *file = LoadFile("course.kcl");
-    m_data = new KColData(file);
+    m_data = EGG::egg_new<KColData>(file);
 }
 
 /// @addr{0x807C293C}
@@ -368,7 +368,7 @@ void *CourseColMgr::LoadFile(const char *filename) {
 /// @addr{0x807C2824}
 CourseColMgr *CourseColMgr::CreateInstance() {
     ASSERT(!s_instance);
-    s_instance = new CourseColMgr;
+    s_instance = EGG::egg_new<CourseColMgr>();
     return s_instance;
 }
 
@@ -377,7 +377,7 @@ void CourseColMgr::DestroyInstance() {
     ASSERT(s_instance);
     auto *instance = s_instance;
     s_instance = nullptr;
-    delete instance;
+    EGG::egg_delete(instance);
 }
 
 /// @addr{0x807C29E4}
@@ -392,7 +392,7 @@ CourseColMgr::~CourseColMgr() {
     }
 
     ASSERT(m_data);
-    delete m_data;
+    EGG::egg_delete(m_data);
 }
 
 /// @addr{0x807C2BD8}

--- a/source/game/field/CourseColMgr.hh
+++ b/source/game/field/CourseColMgr.hh
@@ -125,10 +125,10 @@ public:
         return s_instance;
     }
 
-private:
     CourseColMgr();
     ~CourseColMgr() override;
 
+private:
     [[nodiscard]] bool doCheckWithPartialInfo(KColData *data, CollisionCheckFunc collisionCheckFunc,
             CollisionInfoPartial *info, KCLTypeMask *typeMask);
     [[nodiscard]] bool doCheckWithPartialInfoPush(KColData *data,

--- a/source/game/field/CourseColMgr.hh
+++ b/source/game/field/CourseColMgr.hh
@@ -125,10 +125,12 @@ public:
         return s_instance;
     }
 
+private:
+    EGG_NEW_DELETE_FRIEND
+
     CourseColMgr();
     ~CourseColMgr() override;
 
-private:
     [[nodiscard]] bool doCheckWithPartialInfo(KColData *data, CollisionCheckFunc collisionCheckFunc,
             CollisionInfoPartial *info, KCLTypeMask *typeMask);
     [[nodiscard]] bool doCheckWithPartialInfoPush(KColData *data,

--- a/source/game/field/ObjColMgr.cc
+++ b/source/game/field/ObjColMgr.cc
@@ -8,13 +8,13 @@ namespace Kinoko::Field {
 ObjColMgr::ObjColMgr(const void *file)
     : m_mtx(EGG::Matrix34f::ident), m_mtxInv(EGG::Matrix34f::ident), m_kclScale(1.0f),
       m_movingObjVel(EGG::Vector3f::zero) {
-    m_data = new KColData(file);
+    m_data = EGG::egg_new<KColData>(file);
 }
 
 /// @addr{0x807C4D6C}
 ObjColMgr::~ObjColMgr() {
     ASSERT(m_data);
-    delete m_data;
+    EGG::egg_delete(m_data);
 }
 
 /// @addr{0x807C4DC8}

--- a/source/game/field/ObjectCollisionKart.cc
+++ b/source/game/field/ObjectCollisionKart.cc
@@ -13,7 +13,7 @@ ObjectCollisionKart::ObjectCollisionKart() : m_kartObject(nullptr) {}
 
 /// @addr{0x8081E0E4}
 ObjectCollisionKart::~ObjectCollisionKart() {
-    delete m_hull;
+    EGG::egg_delete(m_hull);
 }
 
 /// @addr{0x8081D090}
@@ -26,7 +26,7 @@ void ObjectCollisionKart::init(u32 idx) {
     m_playerIdx = idx;
 
     auto vehicle = System::RaceConfig::Instance()->raceScenario().players[idx].vehicle;
-    m_hull = new ObjectCollisionConvexHull(GetVehicleVertices(vehicle));
+    m_hull = EGG::egg_new<ObjectCollisionConvexHull>(GetVehicleVertices(vehicle));
 }
 
 /// @addr{0x8081E170}

--- a/source/game/field/ObjectDirector.cc
+++ b/source/game/field/ObjectDirector.cc
@@ -125,7 +125,7 @@ f32 ObjectDirector::risingWaterKillPlaneHeight() const {
 /// @addr{0x8082A784}
 ObjectDirector *ObjectDirector::CreateInstance() {
     ASSERT(!s_instance);
-    s_instance = new ObjectDirector;
+    s_instance = EGG::egg_new<ObjectDirector>();
 
     ObjectDrivableDirector::CreateInstance();
 
@@ -139,7 +139,7 @@ void ObjectDirector::DestroyInstance() {
     ASSERT(s_instance);
     auto *instance = s_instance;
     s_instance = nullptr;
-    delete instance;
+    EGG::egg_delete(instance);
 
     ObjectDrivableDirector::DestroyInstance();
 }
@@ -157,7 +157,7 @@ ObjectDirector::~ObjectDirector() {
     }
 
     for (auto *&obj : m_objects) {
-        delete obj;
+        EGG::egg_delete(obj);
     }
 }
 
@@ -224,17 +224,17 @@ void ObjectDirector::createObjects() {
     }
 
     if (course == Course::Moonview_Highway) {
-        auto *highwayMgr = new ObjectHighwayManager;
+        auto *highwayMgr = EGG::egg_new<ObjectHighwayManager>();
         highwayMgr->load();
     }
 
     if (sun) {
-        auto *sunMgr = new ObjectSunManager;
+        auto *sunMgr = EGG::egg_new<ObjectSunManager>();
         sunMgr->load();
     }
 
     if (course == Course::GBA_Shy_Guy_Beach) {
-        auto *shipMgr = new ObjectHeyhoShipManager;
+        auto *shipMgr = EGG::egg_new<ObjectHeyhoShipManager>();
         shipMgr->load();
     }
 }
@@ -244,142 +244,142 @@ ObjectBase *ObjectDirector::createObject(const System::MapdataGeoObj &params) {
     ObjectId id = static_cast<ObjectId>(params.id());
     switch (id) {
     case ObjectId::Psea:
-        return new ObjectPsea(params);
+        return EGG::egg_new<ObjectPsea>(params);
     case ObjectId::Woodbox:
-        return new ObjectWoodbox(params);
+        return EGG::egg_new<ObjectWoodbox>(params);
     case ObjectId::WLWallGC:
-        return new ObjectWLWallGC(params);
+        return EGG::egg_new<ObjectWLWallGC>(params);
     case ObjectId::CarA1:
     case ObjectId::CarA2:
     case ObjectId::CarA3:
-        return new ObjectCarA(params);
+        return EGG::egg_new<ObjectCarA>(params);
     case ObjectId::Basabasa:
-        return new ObjectBasabasa(params);
+        return EGG::egg_new<ObjectBasabasa>(params);
     case ObjectId::HeyhoShipGBA:
-        return new ObjectHeyhoShip(params);
+        return EGG::egg_new<ObjectHeyhoShip>(params);
     case ObjectId::KartTruck:
     case ObjectId::CarBody:
-        return new ObjectCarTGE(params);
+        return EGG::egg_new<ObjectCarTGE>(params);
     case ObjectId::KoopaBall:
-        return new ObjectKoopaBall(params);
+        return EGG::egg_new<ObjectKoopaBall>(params);
     case ObjectId::W_Woodbox:
-        return new ObjectWoodboxW(params);
+        return EGG::egg_new<ObjectWoodboxW>(params);
     case ObjectId::SunDS:
-        return new ObjectSunDS(params);
+        return EGG::egg_new<ObjectSunDS>(params);
     case ObjectId::ItemboxLine:
-        return new ObjectItemboxLine(params);
+        return EGG::egg_new<ObjectItemboxLine>(params);
     case ObjectId::VolcanoBall:
-        return new ObjectVolcanoBallLauncher(params);
+        return EGG::egg_new<ObjectVolcanoBallLauncher>(params);
     case ObjectId::PenguinS:
-        return new ObjectPenguinS(params);
+        return EGG::egg_new<ObjectPenguinS>(params);
     case ObjectId::PenguinM:
-        return new ObjectPenguin(params);
+        return EGG::egg_new<ObjectPenguin>(params);
     case ObjectId::Dossunc:
-        return new ObjectDossunc(params);
+        return EGG::egg_new<ObjectDossunc>(params);
     case ObjectId::Boble:
-        return new ObjectBoble(params);
+        return EGG::egg_new<ObjectBoble>(params);
     case ObjectId::Hanachan:
-        return new ObjectHanachan(params);
+        return EGG::egg_new<ObjectHanachan>(params);
     case ObjectId::Seagull:
-        return new ObjectBird(params);
+        return EGG::egg_new<ObjectBird>(params);
     case ObjectId::Crab:
-        return new ObjectCrab(params);
+        return EGG::egg_new<ObjectCrab>(params);
     case ObjectId::Hwanwan:
-        return new ObjectHwanwanManager(params);
+        return EGG::egg_new<ObjectHwanwanManager>(params);
     case ObjectId::HeyhoBallGBA:
-        return new ObjectHeyhoBall(params);
+        return EGG::egg_new<ObjectHeyhoBall>(params);
     case ObjectId::DokanSFC:
-        return new ObjectDokan(params);
+        return EGG::egg_new<ObjectDokan>(params);
     case ObjectId::Pylon:
-        return new ObjectPylon(params);
+        return EGG::egg_new<ObjectPylon>(params);
     case ObjectId::OilSFC:
-        return new ObjectOilSFC(params);
+        return EGG::egg_new<ObjectOilSFC>(params);
     case ObjectId::ParasolR:
-        return new ObjectParasolR(params);
+        return EGG::egg_new<ObjectParasolR>(params);
     case ObjectId::KoopaFigure64:
-        return new ObjectKoopaFigure64(params);
+        return EGG::egg_new<ObjectKoopaFigure64>(params);
     case ObjectId::Kuribo:
-        return new ObjectKuribo(params);
+        return EGG::egg_new<ObjectKuribo>(params);
     case ObjectId::Choropu:
     case ObjectId::Choropu2:
-        return new ObjectChoropu(params);
+        return EGG::egg_new<ObjectChoropu>(params);
     case ObjectId::Cow:
-        return new ObjectCowHerd(params);
+        return EGG::egg_new<ObjectCowHerd>(params);
     case ObjectId::PakkunF:
-        return new ObjectPakkunF(params);
+        return EGG::egg_new<ObjectPakkunF>(params);
     case ObjectId::WLFirebarGC:
     case ObjectId::KoopaFirebar:
-        return new ObjectFirebar(params);
+        return EGG::egg_new<ObjectFirebar>(params);
     case ObjectId::Wanwan:
-        return new ObjectWanwan(params);
+        return EGG::egg_new<ObjectWanwan>(params);
     case ObjectId::Poihana:
-        return new ObjectPoihana(params);
+        return EGG::egg_new<ObjectPoihana>(params);
     case ObjectId::Propeller:
-        return new ObjectPropeller(params);
+        return EGG::egg_new<ObjectPropeller>(params);
     case ObjectId::DKRockGC:
-        return new ObjectRock(params);
+        return EGG::egg_new<ObjectRock>(params);
     case ObjectId::Sanbo:
-        return new ObjectSanbo(params);
+        return EGG::egg_new<ObjectSanbo>(params);
     case ObjectId::TruckWagon:
-        return new ObjectTruckWagon(params);
+        return EGG::egg_new<ObjectTruckWagon>(params);
     case ObjectId::Heyho:
-        return new ObjectHeyho(params);
+        return EGG::egg_new<ObjectHeyho>(params);
     case ObjectId::Press:
-        return new ObjectPress(params);
+        return EGG::egg_new<ObjectPress>(params);
     case ObjectId::WLFireRingGC:
-        return new ObjectFireRing(params);
+        return EGG::egg_new<ObjectFireRing>(params);
     case ObjectId::FireSnake:
-        return new ObjectFireSnake(params);
+        return EGG::egg_new<ObjectFireSnake>(params);
     case ObjectId::FireSnakeV:
-        return new ObjectFireSnakeV(params);
+        return EGG::egg_new<ObjectFireSnakeV>(params);
     case ObjectId::PuchiPakkun:
-        return new ObjectPuchiPakkun(params);
+        return EGG::egg_new<ObjectPuchiPakkun>(params);
     case ObjectId::KinokoUd:
-        return new ObjectKinokoUd(params);
+        return EGG::egg_new<ObjectKinokoUd>(params);
     case ObjectId::KinokoBend:
-        return new ObjectKinokoBend(params);
+        return EGG::egg_new<ObjectKinokoBend>(params);
     case ObjectId::VolcanoRock:
-        return new ObjectVolcanoRock(params);
+        return EGG::egg_new<ObjectVolcanoRock>(params);
     case ObjectId::BulldozerL:
     case ObjectId::BulldozerR:
-        return new ObjectBulldozer(params);
+        return EGG::egg_new<ObjectBulldozer>(params);
     case ObjectId::KinokoNm:
-        return new ObjectKinokoNm(params);
+        return EGG::egg_new<ObjectKinokoNm>(params);
     case ObjectId::Crane:
-        return new ObjectCrane(params);
+        return EGG::egg_new<ObjectCrane>(params);
     case ObjectId::VolcanoPiece:
-        return new ObjectVolcanoPiece(params);
+        return EGG::egg_new<ObjectVolcanoPiece>(params);
     case ObjectId::FlamePole:
-        return new ObjectFlamePoleFoot(params);
+        return EGG::egg_new<ObjectFlamePoleFoot>(params);
     case ObjectId::TwistedWay:
-        return new ObjectTwistedWay(params);
+        return EGG::egg_new<ObjectTwistedWay>(params);
     case ObjectId::TownBridge:
-        return new ObjectTownBridge(params);
+        return EGG::egg_new<ObjectTownBridge>(params);
     case ObjectId::DKShip64:
-        return new ObjectShip64(params);
+        return EGG::egg_new<ObjectShip64>(params);
     case ObjectId::Turibashi:
-        return new ObjectTuribashi(params);
+        return EGG::egg_new<ObjectTuribashi>(params);
     case ObjectId::Aurora:
-        return new ObjectAurora(params);
+        return EGG::egg_new<ObjectAurora>(params);
     case ObjectId::DCPillar:
-        return new ObjectPillar(params);
+        return EGG::egg_new<ObjectPillar>(params);
     case ObjectId::Sandcone:
-        return new ObjectSandcone(params);
+        return EGG::egg_new<ObjectSandcone>(params);
     case ObjectId::FlamePoleV:
     case ObjectId::FlamePoleVBig:
-        return new ObjectFlamePoleV(params);
+        return EGG::egg_new<ObjectFlamePoleV>(params);
     case ObjectId::Ami:
-        return new ObjectAmi(params);
+        return EGG::egg_new<ObjectAmi>(params);
     case ObjectId::BeltEasy:
-        return new ObjectBeltEasy(params);
+        return EGG::egg_new<ObjectBeltEasy>(params);
     case ObjectId::BeltCrossing:
-        return new ObjectBeltCrossing(params);
+        return EGG::egg_new<ObjectBeltCrossing>(params);
     case ObjectId::BeltCurveA:
-        return new ObjectBeltCurveA(params);
+        return EGG::egg_new<ObjectBeltCurveA>(params);
     case ObjectId::Escalator:
-        return new ObjectEscalator(params);
+        return EGG::egg_new<ObjectEscalator>(params);
     case ObjectId::EscalatorGroup:
-        return new ObjectEscalatorGroup(params);
+        return EGG::egg_new<ObjectEscalatorGroup>(params);
 
     // Non-specified objects are stock collidable objects by default
     // However, we need to specify an impl, so we don't use default
@@ -397,12 +397,12 @@ ObjectBase *ObjectDirector::createObject(const System::MapdataGeoObj &params) {
     case ObjectId::DKTreeB64c:
     case ObjectId::TownTreeDsc:
     case ObjectId::PakkunDokan:
-        return new ObjectCollidable(params);
+        return EGG::egg_new<ObjectCollidable>(params);
     case ObjectId::WLDokanGC:
     case ObjectId::Mdush:
-        return new ObjectKCL(params);
+        return EGG::egg_new<ObjectKCL>(params);
     default:
-        return new ObjectNoImpl(params);
+        return EGG::egg_new<ObjectNoImpl>(params);
     }
 }
 

--- a/source/game/field/ObjectDirector.hh
+++ b/source/game/field/ObjectDirector.hh
@@ -6,6 +6,8 @@
 #include "game/field/obj/ObjectCollidable.hh"
 #include "game/field/obj/ObjectNoImpl.hh"
 
+#include <egg/core/Allocator.hh>
+
 #include <vector>
 
 namespace Kinoko {
@@ -56,11 +58,13 @@ public:
         return m_hitDepths[idx];
     }
 
-    [[nodiscard]] std::vector<ObjectCollidable *> &managedObjects() {
+    [[nodiscard]] std::vector<ObjectCollidable *, EGG::Allocator<ObjectCollidable *>> &
+    managedObjects() {
         return m_managedObjects;
     }
 
-    [[nodiscard]] const std::vector<ObjectCollidable *> &managedObjects() const {
+    [[nodiscard]] const std::vector<ObjectCollidable *, EGG::Allocator<ObjectCollidable *>> &
+    managedObjects() const {
         return m_managedObjects;
     }
 
@@ -87,10 +91,10 @@ public:
         return s_instance;
     }
 
-private:
     ObjectDirector();
     ~ObjectDirector() override;
 
+private:
     void createObjects();
     [[nodiscard]] ObjectBase *createObject(const System::MapdataGeoObj &params);
 
@@ -98,9 +102,11 @@ private:
     ObjectHitTable m_hitTableKart;
     ObjectHitTable m_hitTableKartObject;
 
-    std::vector<ObjectBase *> m_objects;          ///< All objects live here
-    std::vector<ObjectBase *> m_calcObjects;      ///< Objects needing calc() live here too.
-    std::vector<ObjectBase *> m_collisionObjects; ///< Objects having collision live here too
+    std::vector<ObjectBase *, EGG::Allocator<ObjectBase *>> m_objects; ///< All objects live here
+    std::vector<ObjectBase *, EGG::Allocator<ObjectBase *>>
+            m_calcObjects; ///< Objects needing calc() live here too.
+    std::vector<ObjectBase *, EGG::Allocator<ObjectBase *>>
+            m_collisionObjects; ///< Objects having collision live here too
 
     static constexpr size_t MAX_UNIT_COUNT = 0x100;
 
@@ -109,7 +115,7 @@ private:
     std::array<EGG::Vector3f, MAX_UNIT_COUNT> m_hitDepths;
     std::array<Kart::Reaction, MAX_UNIT_COUNT> m_reactions;
     ObjectPsea *m_psea;
-    std::vector<ObjectCollidable *> m_managedObjects;
+    std::vector<ObjectCollidable *, EGG::Allocator<ObjectCollidable *>> m_managedObjects;
 
     static f32 s_wanwanMaxPitch; ///< @addr{0x808C70E8}
 

--- a/source/game/field/ObjectDirector.hh
+++ b/source/game/field/ObjectDirector.hh
@@ -91,10 +91,12 @@ public:
         return s_instance;
     }
 
+private:
+    EGG_NEW_DELETE_FRIEND
+
     ObjectDirector();
     ~ObjectDirector() override;
 
-private:
     void createObjects();
     [[nodiscard]] ObjectBase *createObject(const System::MapdataGeoObj &params);
 

--- a/source/game/field/ObjectDrivableDirector.cc
+++ b/source/game/field/ObjectDrivableDirector.cc
@@ -33,7 +33,7 @@ void ObjectDrivableDirector::addObject(ObjectDrivable *obj) {
 /// @brief Creates the rGV2 block manager. Also implicitly adds the block represented by params.
 void ObjectDrivableDirector::createObakeManager(const System::MapdataGeoObj &params) {
     ASSERT(!m_obakeManager);
-    m_obakeManager = new ObjectObakeManager(params);
+    m_obakeManager = EGG::egg_new<ObjectObakeManager>(params);
     m_obakeManager->load();
 }
 
@@ -209,7 +209,7 @@ void ObjectDrivableDirector::colNarScLocal(f32 radius, const EGG::Vector3f &pos,
 /// @addr{0x8081B428}
 ObjectDrivableDirector *ObjectDrivableDirector::CreateInstance() {
     ASSERT(!s_instance);
-    s_instance = new ObjectDrivableDirector;
+    s_instance = EGG::egg_new<ObjectDrivableDirector>();
     return s_instance;
 }
 
@@ -218,7 +218,7 @@ void ObjectDrivableDirector::DestroyInstance() {
     ASSERT(s_instance);
     auto *instance = s_instance;
     s_instance = nullptr;
-    delete instance;
+    EGG::egg_delete(instance);
 }
 
 /// @addr{0x8081B324}
@@ -232,7 +232,7 @@ ObjectDrivableDirector::~ObjectDrivableDirector() {
     }
 
     for (auto *&obj : m_objects) {
-        delete obj;
+        EGG::egg_delete(obj);
     }
 }
 

--- a/source/game/field/ObjectDrivableDirector.hh
+++ b/source/game/field/ObjectDrivableDirector.hh
@@ -4,6 +4,8 @@
 #include "game/field/obj/ObjectDrivable.hh"
 #include "game/field/obj/ObjectObakeManager.hh"
 
+#include <egg/core/Allocator.hh>
+
 #include <vector>
 
 namespace Kinoko {
@@ -59,13 +61,15 @@ public:
         return s_instance;
     }
 
-private:
     ObjectDrivableDirector();
     ~ObjectDrivableDirector() override;
 
-    std::vector<ObjectDrivable *> m_objects;     ///< All objects live here
-    std::vector<ObjectDrivable *> m_calcObjects; ///< Objects needing calc() live here too.
-    ObjectObakeManager *m_obakeManager;          ///< Manages rGV2 blocks and spatial indexing.
+private:
+    std::vector<ObjectDrivable *, EGG::Allocator<ObjectDrivable *>>
+            m_objects; ///< All objects live here
+    std::vector<ObjectDrivable *, EGG::Allocator<ObjectDrivable *>>
+            m_calcObjects;              ///< Objects needing calc() live here too.
+    ObjectObakeManager *m_obakeManager; ///< Manages rGV2 blocks and spatial indexing.
 
     static ObjectDrivableDirector *s_instance;
 };

--- a/source/game/field/ObjectDrivableDirector.hh
+++ b/source/game/field/ObjectDrivableDirector.hh
@@ -61,10 +61,12 @@ public:
         return s_instance;
     }
 
+private:
+    EGG_NEW_DELETE_FRIEND
+
     ObjectDrivableDirector();
     ~ObjectDrivableDirector() override;
 
-private:
     std::vector<ObjectDrivable *, EGG::Allocator<ObjectDrivable *>>
             m_objects; ///< All objects live here
     std::vector<ObjectDrivable *, EGG::Allocator<ObjectDrivable *>>

--- a/source/game/field/RailManager.cc
+++ b/source/game/field/RailManager.cc
@@ -8,7 +8,7 @@ namespace Kinoko::Field {
 /// @addr{0x806F09C8}
 RailManager *RailManager::CreateInstance() {
     ASSERT(!s_instance);
-    s_instance = new RailManager;
+    s_instance = EGG::egg_new<RailManager>();
     s_instance->createPaths();
     return s_instance;
 }
@@ -18,7 +18,7 @@ void RailManager::DestroyInstance() {
     ASSERT(s_instance);
     auto *instance = s_instance;
     s_instance = nullptr;
-    delete instance;
+    EGG::egg_delete(instance);
 }
 
 /// @addr{0x806F0A3C}
@@ -32,7 +32,7 @@ RailManager::~RailManager() {
     }
 
     for (auto *&rail : m_rails) {
-        delete rail;
+        EGG::egg_delete(rail);
     }
 }
 
@@ -57,9 +57,9 @@ void RailManager::createPaths() {
             }
 
             if (isSpline) {
-                m_rails.push_back(new RailSpline(i, pointInfo));
+                m_rails.push_back(EGG::egg_new<RailSpline>(i, pointInfo));
             } else {
-                m_rails.push_back(new RailLine(i, pointInfo));
+                m_rails.push_back(EGG::egg_new<RailLine>(i, pointInfo));
             }
 
             isObjectRoute = true;
@@ -71,9 +71,9 @@ void RailManager::createPaths() {
         }
 
         if (isSpline) {
-            m_rails.push_back(new RailSpline(i, pointInfo));
+            m_rails.push_back(EGG::egg_new<RailSpline>(i, pointInfo));
         } else {
-            m_rails.push_back(new RailLine(i, pointInfo));
+            m_rails.push_back(EGG::egg_new<RailLine>(i, pointInfo));
         }
     }
 }

--- a/source/game/field/RailManager.hh
+++ b/source/game/field/RailManager.hh
@@ -2,6 +2,8 @@
 
 #include "game/field/RailInterpolator.hh"
 
+#include <egg/core/Allocator.hh>
+
 #include <vector>
 
 namespace Kinoko {
@@ -38,13 +40,13 @@ public:
         return s_instance;
     }
 
-private:
     RailManager();
     ~RailManager();
 
+private:
     void createPaths();
 
-    std::vector<Rail *> m_rails;
+    std::vector<Rail *, EGG::Allocator<Rail *>> m_rails;
     u16 m_totalRails;
     u16 m_extraInterplatorCount;
     u16 m_pointCount;

--- a/source/game/field/RailManager.hh
+++ b/source/game/field/RailManager.hh
@@ -40,10 +40,12 @@ public:
         return s_instance;
     }
 
+private:
+    EGG_NEW_DELETE_FRIEND
+
     RailManager();
     ~RailManager();
 
-private:
     void createPaths();
 
     std::vector<Rail *, EGG::Allocator<Rail *>> m_rails;

--- a/source/game/field/StateManager.hh
+++ b/source/game/field/StateManager.hh
@@ -29,7 +29,8 @@ protected:
     StateManager(void *obj, const std::span<const StateManagerEntry> &entries)
         : m_currentStateId(0), m_nextStateId(-1), m_currentFrame(0), m_entries(entries),
           m_obj(obj) {
-        m_entryIds = std::span(new u16[m_entries.size()], m_entries.size());
+        m_entryIds = std::span(static_cast<u16 *>(EGG::egg_alloc(m_entries.size() * sizeof(u16))),
+                m_entries.size());
 
         // The base game initializes all entries to 0xffff, possibly to avoid an uninitialized value
         memset(m_entryIds.data(), 0xff, m_entryIds.size());
@@ -40,7 +41,7 @@ protected:
     }
 
     virtual ~StateManager() {
-        delete[] m_entryIds.data();
+        EGG::egg_free(m_entryIds.data());
     }
 
     void calc() {

--- a/source/game/field/jugem/JugemDirector.cc
+++ b/source/game/field/jugem/JugemDirector.cc
@@ -7,7 +7,7 @@ namespace Kinoko::Field {
 /// @addr{0x8071E270}
 JugemDirector *JugemDirector::CreateInstance() {
     ASSERT(!s_instance);
-    s_instance = new JugemDirector;
+    s_instance = EGG::egg_new<JugemDirector>();
     return s_instance;
 }
 
@@ -21,7 +21,7 @@ void JugemDirector::DestroyInstance() {
     ASSERT(s_instance);
     auto *instance = s_instance;
     s_instance = nullptr;
-    delete instance;
+    EGG::egg_delete(instance);
 }
 
 /// @addr{0x8071E330}
@@ -29,14 +29,14 @@ JugemDirector::JugemDirector() : m_unit(nullptr) {}
 
 /// @addr{0x8071E390}
 JugemDirector::~JugemDirector() {
-    delete m_unit;
+    EGG::egg_delete(m_unit);
 }
 
 /// @addr{0x8071E480}
 void JugemDirector::createUnits() {
     // Assumes one unit
     const auto *kartObj = Kart::KartObjectManager::Instance()->object(0);
-    m_unit = new JugemUnit(kartObj);
+    m_unit = EGG::egg_new<JugemUnit>(kartObj);
 
     m_unit->createSwitchRace();
 }

--- a/source/game/field/jugem/JugemDirector.hh
+++ b/source/game/field/jugem/JugemDirector.hh
@@ -24,10 +24,10 @@ public:
     [[nodiscard]] static JugemDirector *Instance();
     static void DestroyInstance();
 
-private:
     JugemDirector();
     ~JugemDirector();
 
+private:
     void createUnits();
 
     JugemUnit *m_unit; ///< Assumes 1 Lakitu because 1 player

--- a/source/game/field/jugem/JugemDirector.hh
+++ b/source/game/field/jugem/JugemDirector.hh
@@ -24,10 +24,12 @@ public:
     [[nodiscard]] static JugemDirector *Instance();
     static void DestroyInstance();
 
+private:
+    EGG_NEW_DELETE_FRIEND
+
     JugemDirector();
     ~JugemDirector();
 
-private:
     void createUnits();
 
     JugemUnit *m_unit; ///< Assumes 1 Lakitu because 1 player

--- a/source/game/field/jugem/JugemUnit.cc
+++ b/source/game/field/jugem/JugemUnit.cc
@@ -12,15 +12,15 @@ namespace Kinoko::Field {
 /// @addr{0x80721514}
 JugemUnit::JugemUnit(const Kart::KartObject *kartObj)
     : StateManager(this, STATE_ENTRIES), m_kartObj(kartObj), m_switchReverse(nullptr) {
-    m_move = new JugemMove(kartObj);
-    m_interp = new JugemInterp(2);
+    m_move = EGG::egg_new<JugemMove>(kartObj);
+    m_interp = EGG::egg_new<JugemInterp>(2);
 }
 
 /// @addr{0x80721D2C}
 JugemUnit::~JugemUnit() {
-    delete m_switchReverse;
-    delete m_move;
-    delete m_interp;
+    EGG::egg_delete(m_switchReverse);
+    EGG::egg_delete(m_move);
+    EGG::egg_delete(m_interp);
 }
 
 /// @addr{0x807221C4}

--- a/source/game/field/jugem/JugemUnit.hh
+++ b/source/game/field/jugem/JugemUnit.hh
@@ -116,7 +116,7 @@ public:
 
     /// @addr{0x80721EC0}
     void createSwitchRace() {
-        m_switchReverse = new JugemSwitchReverse;
+        m_switchReverse = EGG::egg_new<JugemSwitchReverse>();
     }
 
     /// @addr{0x80722100}

--- a/source/game/field/obj/ObjectBasabasa.cc
+++ b/source/game/field/obj/ObjectBasabasa.cc
@@ -80,7 +80,7 @@ ObjectBasabasa::ObjectBasabasa(const System::MapdataGeoObj &params)
     m_bats = owning_span<ObjectBasabasaDummy *>(batCount);
 
     for (auto *&bat : m_bats) {
-        bat = new ObjectBasabasaDummy(params);
+        bat = EGG::egg_new<ObjectBasabasaDummy>(params);
         bat->load();
     }
 

--- a/source/game/field/obj/ObjectBase.cc
+++ b/source/game/field/obj/ObjectBase.cc
@@ -31,9 +31,9 @@ ObjectBase::ObjectBase(const char *name, const EGG::Vector3f &pos, const EGG::Ve
 
 /// @addr{0x8067E3C4}
 ObjectBase::~ObjectBase() {
-    delete m_resFile;
-    delete m_drawMdl;
-    delete m_railInterpolator;
+    EGG::egg_delete(m_resFile);
+    EGG::egg_delete(m_drawMdl);
+    EGG::egg_delete(m_railInterpolator);
 }
 
 /// @addr{0x808217B8}
@@ -62,8 +62,8 @@ void ObjectBase::loadGraphics() {
     auto *resMgr = System::ResourceManager::Instance();
     const void *resFile = resMgr->getFile(filename, nullptr, System::ArchiveId::Course);
     if (resFile) {
-        m_resFile = new Abstract::g3d::ResFile(resFile);
-        m_drawMdl = new Render::DrawMdl;
+        m_resFile = EGG::egg_new<Abstract::g3d::ResFile>(resFile);
+        m_drawMdl = EGG::egg_new<Render::DrawMdl>();
     }
 }
 
@@ -83,9 +83,9 @@ void ObjectBase::loadRail() {
     f32 speed = static_cast<f32>(m_mapObj->setting(0));
 
     if (point->setting(0) == 0) {
-        m_railInterpolator = new RailLinearInterpolator(speed, pathId);
+        m_railInterpolator = EGG::egg_new<RailLinearInterpolator>(speed, pathId);
     } else {
-        m_railInterpolator = new RailSmoothInterpolator(speed, pathId);
+        m_railInterpolator = EGG::egg_new<RailSmoothInterpolator>(speed, pathId);
     }
 }
 

--- a/source/game/field/obj/ObjectBird.cc
+++ b/source/game/field/obj/ObjectBird.cc
@@ -8,7 +8,7 @@ namespace Kinoko::Field {
 
 /// @addr{0x8077BD80}
 ObjectBird::ObjectBird(const System::MapdataGeoObj &params) : ObjectCollidable(params) {
-    m_leader = new ObjectBirdLeader(params, this);
+    m_leader = EGG::egg_new<ObjectBirdLeader>(params, this);
     m_leader->load();
 
     u32 count = params.setting(1);
@@ -19,7 +19,7 @@ ObjectBird::ObjectBird(const System::MapdataGeoObj &params) : ObjectCollidable(p
     m_followers = owning_span<ObjectBirdFollower *>(count);
 
     for (u32 i = 0; i < count; ++i) {
-        auto *bird = new ObjectBirdFollower(params, this, i);
+        auto *bird = EGG::egg_new<ObjectBirdFollower>(params, this, i);
         m_followers[i] = bird;
         bird->load();
     }

--- a/source/game/field/obj/ObjectCarA.cc
+++ b/source/game/field/obj/ObjectCarA.cc
@@ -57,7 +57,7 @@ void ObjectCarA::createCollision() {
     constexpr f32 RADIUS = 210.0f;
     constexpr f32 HEIGHT = 200.0f;
 
-    m_collision = new ObjectCollisionCylinder(RADIUS, HEIGHT, collisionCenter());
+    m_collision = EGG::egg_new<ObjectCollisionCylinder>(RADIUS, HEIGHT, collisionCenter());
 }
 
 /// @addr{0x806B7BC4}

--- a/source/game/field/obj/ObjectCarTGE.cc
+++ b/source/game/field/obj/ObjectCarTGE.cc
@@ -98,7 +98,7 @@ ObjectCarTGE::ObjectCarTGE(const System::MapdataGeoObj &params)
 
 /// @addr{0x806D691C}
 ObjectCarTGE::~ObjectCarTGE() {
-    delete m_auxCollision;
+    EGG::egg_delete(m_auxCollision);
 }
 
 /// @addr{0x806D6B14}
@@ -174,7 +174,7 @@ void ObjectCarTGE::createCollision() {
     f32 radius = isTruck ? TRUCK_RADIUS : NORMAL_RADIUS;
     f32 height = isTruck ? TRUCK_HEIGHT : NORMAL_HEIGHT;
 
-    m_auxCollision = new ObjectCollisionCylinder(radius, height, collisionCenter());
+    m_auxCollision = EGG::egg_new<ObjectCollisionCylinder>(radius, height, collisionCenter());
 }
 
 /// @addr{0x806D7BF8}

--- a/source/game/field/obj/ObjectChoropu.cc
+++ b/source/game/field/obj/ObjectChoropu.cc
@@ -34,7 +34,7 @@ ObjectChoropu::ObjectChoropu(const System::MapdataGeoObj &params)
         m_groundObjs = owning_span<ObjectChoropuGround *>(groundCount);
 
         for (auto *&obj : m_groundObjs) {
-            obj = new ObjectChoropuGround(pos(), rot(), scale());
+            obj = EGG::egg_new<ObjectChoropuGround>(pos(), rot(), scale());
             obj->load();
             obj->resize(RADIUS, MAX_SPEED);
         }
@@ -42,7 +42,7 @@ ObjectChoropu::ObjectChoropu(const System::MapdataGeoObj &params)
         m_groundHeight = m_groundObjs.front()->height();
     }
 
-    m_objHoll = new ObjectChoropuHoll(params);
+    m_objHoll = EGG::egg_new<ObjectChoropuHoll>(params);
     m_objHoll->load();
 }
 

--- a/source/game/field/obj/ObjectChoropu.hh
+++ b/source/game/field/obj/ObjectChoropu.hh
@@ -125,7 +125,7 @@ public:
 
     /// @addr{0x806B9428}
     void createCollision() override {
-        m_collision = new ObjectCollisionSphere(RADIUS, EGG::Vector3f::zero);
+        m_collision = EGG::egg_new<ObjectCollisionSphere>(RADIUS, EGG::Vector3f::zero);
     }
 
     /// @addr{0x806BBE40}

--- a/source/game/field/obj/ObjectCollidable.cc
+++ b/source/game/field/obj/ObjectCollidable.cc
@@ -20,7 +20,7 @@ ObjectCollidable::ObjectCollidable(const char *name, const EGG::Vector3f &pos,
 
 /// @addr{0x8067E384}
 ObjectCollidable::~ObjectCollidable() {
-    delete m_collision;
+    EGG::egg_delete(m_collision);
 }
 
 /// @addr{0x8081F0A0}
@@ -110,15 +110,16 @@ void ObjectCollidable::createCollision() {
 
     switch (static_cast<CollisionMode>(parse<s16>(collisionSet->mode))) {
     case CollisionMode::Sphere:
-        m_collision = new ObjectCollisionSphere(parse<s16>(collisionSet->params.sphere.radius),
-                collisionCenter());
+        m_collision = EGG::egg_new<ObjectCollisionSphere>(
+                parse<s16>(collisionSet->params.sphere.radius), collisionCenter());
         break;
     case CollisionMode::Cylinder:
-        m_collision = new ObjectCollisionCylinder(parse<s16>(collisionSet->params.cylinder.radius),
+        m_collision = EGG::egg_new<ObjectCollisionCylinder>(
+                parse<s16>(collisionSet->params.cylinder.radius),
                 parse<s16>(collisionSet->params.cylinder.height), collisionCenter());
         break;
     case CollisionMode::Box:
-        m_collision = new ObjectCollisionBox(parse<s16>(collisionSet->params.box.x),
+        m_collision = EGG::egg_new<ObjectCollisionBox>(parse<s16>(collisionSet->params.box.x),
                 parse<s16>(collisionSet->params.box.y), parse<s16>(collisionSet->params.box.z),
                 collisionCenter());
         break;

--- a/source/game/field/obj/ObjectCow.cc
+++ b/source/game/field/obj/ObjectCow.cc
@@ -427,7 +427,7 @@ ObjectCowHerd::ObjectCowHerd(const System::MapdataGeoObj &params) : ObjectCollid
 
     u8 followerCount = params.setting(0);
 
-    m_leader = new ObjectCowLeader(params);
+    m_leader = EGG::egg_new<ObjectCowLeader>(params);
     m_leader->load();
 
     m_followers = owning_span<ObjectCowFollower *>(followerCount);
@@ -439,7 +439,7 @@ ObjectCowHerd::ObjectCowHerd(const System::MapdataGeoObj &params) : ObjectCollid
         f32 x = EGG::Mathf::CosFIdx(RAD2FIDX * rot);
         EGG::Vector3f pos = EGG::Vector3f(x, 0.0f, z) * FOLLOWER_SPACING;
 
-        child = new ObjectCowFollower(params, pos, rot);
+        child = EGG::egg_new<ObjectCowFollower>(params, pos, rot);
         child->load();
     }
 

--- a/source/game/field/obj/ObjectDossunTsuibiHolder.cc
+++ b/source/game/field/obj/ObjectDossunTsuibiHolder.cc
@@ -10,7 +10,7 @@ ObjectDossunTsuibiHolder::ObjectDossunTsuibiHolder(const System::MapdataGeoObj &
       m_facingBackwards(false), m_forwardVel(static_cast<f32>(m_mapObj->setting(0))),
       m_stillDuration(static_cast<u32>(m_mapObj->setting(3))) {
     for (auto *&dossun : m_dossuns) {
-        dossun = new ObjectDossunTsuibi(params, this);
+        dossun = EGG::egg_new<ObjectDossunTsuibi>(params, this);
         dossun->load();
     }
 }

--- a/source/game/field/obj/ObjectDossunc.cc
+++ b/source/game/field/obj/ObjectDossunc.cc
@@ -13,19 +13,19 @@ namespace Kinoko::Field {
 ObjectDossunc::ObjectDossunc(const System::MapdataGeoObj &params) : ObjectCollidable(params) {
     switch (params.setting(1)) {
     case 0: {
-        auto *dossunNormal = new ObjectDossunNormal(params);
+        auto *dossunNormal = EGG::egg_new<ObjectDossunNormal>(params);
         dossunNormal->load();
     } break;
     case 1: {
-        auto *dossunSyuukai = new ObjectDossunSyuukai(params);
+        auto *dossunSyuukai = EGG::egg_new<ObjectDossunSyuukai>(params);
         dossunSyuukai->load();
     } break;
     case 2: {
-        auto *dossunTsuibi = new ObjectDossunTsuibiHolder(params);
+        auto *dossunTsuibi = EGG::egg_new<ObjectDossunTsuibiHolder>(params);
         dossunTsuibi->load();
     } break;
     case 3: {
-        auto *dossunYokoMove = new ObjectDossunYokoMove(params);
+        auto *dossunYokoMove = EGG::egg_new<ObjectDossunYokoMove>(params);
         dossunYokoMove->load();
     } break;
     default:

--- a/source/game/field/obj/ObjectEscalatorGroup.cc
+++ b/source/game/field/obj/ObjectEscalatorGroup.cc
@@ -18,8 +18,8 @@ ObjectEscalatorGroup::ObjectEscalatorGroup(const System::MapdataGeoObj &params)
     addPos(POS_OFFSET);
     setScale(SCALE);
 
-    m_rightEscalator = new ObjectEscalator(params, false);
-    m_leftEscalator = new ObjectEscalator(params, true);
+    m_rightEscalator = EGG::egg_new<ObjectEscalator>(params, false);
+    m_leftEscalator = EGG::egg_new<ObjectEscalator>(params, true);
 
     calcTransform();
     m_rightEscalator->m_initialPos = pos() + transform().multVector33(RIGHT_OFFSET);

--- a/source/game/field/obj/ObjectFireRing.cc
+++ b/source/game/field/obj/ObjectFireRing.cc
@@ -11,7 +11,7 @@ ObjectFireRing::ObjectFireRing(const System::MapdataGeoObj &params)
     f32 distance = 100.0f * static_cast<f32>(params.setting(3));
 
     for (size_t i = 0; i < fireballCount; ++i) {
-        m_fireballs[i] = new ObjectFireball(params);
+        m_fireballs[i] = EGG::egg_new<ObjectFireball>(params);
         m_fireballs[i]->load();
         m_fireballs[i]->setDistance(distance);
         m_fireballs[i]->setAngle(static_cast<f32>(i) * (360.0f / fireballCount));

--- a/source/game/field/obj/ObjectFireSnake.cc
+++ b/source/game/field/obj/ObjectFireSnake.cc
@@ -24,7 +24,7 @@ ObjectFireSnake::ObjectFireSnake(const System::MapdataGeoObj &params)
 
     for (u32 i = 0; i < 2; ++i) {
         auto *&kid = m_kids[i];
-        kid = new ObjectFireSnakeKid(params);
+        kid = EGG::egg_new<ObjectFireSnakeKid>(params);
         kid->load();
         f32 kidScale = (0.75f - 0.25f * static_cast<f32>(i)) * scale().y;
         kid->setScale(kidScale);

--- a/source/game/field/obj/ObjectFirebar.cc
+++ b/source/game/field/obj/ObjectFirebar.cc
@@ -11,7 +11,7 @@ ObjectFirebar::ObjectFirebar(const System::MapdataGeoObj &params) : ObjectCollid
     m_fireballs = owning_span<ObjectFireball *>(fireballCount);
 
     for (size_t i = 0; i < fireballCount; ++i) {
-        m_fireballs[i] = new ObjectFireball(params);
+        m_fireballs[i] = EGG::egg_new<ObjectFireball>(params);
         m_fireballs[i]->load();
 
         f32 ring = 1.0f + static_cast<f32>(i / m_spokes);

--- a/source/game/field/obj/ObjectFlamePoleFoot.cc
+++ b/source/game/field/obj/ObjectFlamePoleFoot.cc
@@ -21,7 +21,7 @@ ObjectFlamePoleFoot::ObjectFlamePoleFoot(const System::MapdataGeoObj &params)
         m_poleScale = 3.0f + static_cast<f32>(s_flamePoleCount % 3);
     }
 
-    m_pole = new ObjectFlamePole(params, pos(), rot(), scale());
+    m_pole = EGG::egg_new<ObjectFlamePole>(params, pos(), rot(), scale());
     m_pole->load();
 }
 

--- a/source/game/field/obj/ObjectHanachan.cc
+++ b/source/game/field/obj/ObjectHanachan.cc
@@ -111,8 +111,8 @@ ObjectHanachan::ObjectHanachan(const System::MapdataGeoObj &params)
     constexpr EGG::Vector3f SCALE_VEC = EGG::Vector3f(SCALE, SCALE, SCALE);
 
     auto *&head = headPart();
-    head = new ObjectHanachanHead("BossHanachanHead", EGG::Vector3f::zero, EGG::Vector3f::ez,
-            EGG::Vector3f::ez);
+    head = EGG::egg_new<ObjectHanachanHead>("BossHanachanHead", EGG::Vector3f::zero,
+            EGG::Vector3f::ez, EGG::Vector3f::ez);
     head->setScale(SCALE_VEC);
 
     const auto &mdlNames = ObjectHanachanBody::MDL_NAMES;
@@ -120,7 +120,7 @@ ObjectHanachan::ObjectHanachan(const System::MapdataGeoObj &params)
     auto parts = bodyParts();
     for (size_t i = 0; i < parts.size(); ++i) {
         auto *&part = parts[i];
-        part = new ObjectHanachanBody(params, mdlNames[i % mdlNameCount]);
+        part = EGG::egg_new<ObjectHanachanBody>(params, mdlNames[i % mdlNameCount]);
         part->setScale(SCALE_VEC);
     }
 

--- a/source/game/field/obj/ObjectHanachan.hh
+++ b/source/game/field/obj/ObjectHanachan.hh
@@ -108,7 +108,7 @@ public:
 
     /// @addr{0x806C818C}
     void createCollision() override {
-        m_collision = new ObjectCollisionSphere(150.0f, collisionCenter());
+        m_collision = EGG::egg_new<ObjectCollisionSphere>(150.0f, collisionCenter());
     }
 
     void calcCollisionTransform() override;

--- a/source/game/field/obj/ObjectHwanwan.cc
+++ b/source/game/field/obj/ObjectHwanwan.cc
@@ -85,7 +85,7 @@ void ObjectHwanwan::calcUp() {
 /// @addr{0x806C5354}
 ObjectHwanwanManager::ObjectHwanwanManager(const System::MapdataGeoObj &params)
     : ObjectCollidable(params) {
-    m_hwanwan = new ObjectHwanwan(params);
+    m_hwanwan = EGG::egg_new<ObjectHwanwan>(params);
     m_hwanwan->setScale(2.0f);
     m_hwanwan->load();
 }

--- a/source/game/field/obj/ObjectItemboxLine.cc
+++ b/source/game/field/obj/ObjectItemboxLine.cc
@@ -10,7 +10,7 @@ ObjectItemboxLine::ObjectItemboxLine(const System::MapdataGeoObj &params)
     : ObjectCollidable(params) {
     constexpr u32 DEFAULT_PRESS_COUNT = 5;
 
-    auto *senko = new ObjectPressSenko(params);
+    auto *senko = EGG::egg_new<ObjectPressSenko>(params);
     senko->load();
 
     u32 pressCount = params.setting(6);
@@ -21,7 +21,7 @@ ObjectItemboxLine::ObjectItemboxLine(const System::MapdataGeoObj &params)
     m_press = owning_span<ObjectItemboxPress *>(pressCount);
 
     for (auto *&press : m_press) {
-        press = new ObjectItemboxPress(params);
+        press = EGG::egg_new<ObjectItemboxPress>(params);
         press->load();
         press->setSenko(senko);
     }

--- a/source/game/field/obj/ObjectKCL.cc
+++ b/source/game/field/obj/ObjectKCL.cc
@@ -13,7 +13,7 @@ ObjectKCL::ObjectKCL(const System::MapdataGeoObj &params)
 
 /// @addr{0x8067EAFC}
 ObjectKCL::~ObjectKCL() {
-    delete m_objColMgr;
+    EGG::egg_delete(m_objColMgr);
 }
 
 /// @addr{0x8081AA58}
@@ -22,7 +22,8 @@ void ObjectKCL::createCollision() {
     snprintf(filepath, sizeof(filepath), "%s.kcl", getKclName());
 
     auto *resMgr = System::ResourceManager::Instance();
-    m_objColMgr = new ObjColMgr(resMgr->getFile(filepath, nullptr, System::ArchiveId::Course));
+    m_objColMgr =
+            EGG::egg_new<ObjColMgr>(resMgr->getFile(filepath, nullptr, System::ArchiveId::Course));
 }
 
 /// @addr{0x80681490}

--- a/source/game/field/obj/ObjectKoopaBall.cc
+++ b/source/game/field/obj/ObjectKoopaBall.cc
@@ -12,7 +12,7 @@ ObjectKoopaBall::ObjectKoopaBall(const System::MapdataGeoObj &params)
 
 /// @addr{0x80771F70}
 ObjectKoopaBall::~ObjectKoopaBall() {
-    delete m_bombCoreDrawMdl;
+    EGG::egg_delete(m_bombCoreDrawMdl);
 }
 
 /// @addr{0x807703D0}
@@ -38,7 +38,7 @@ void ObjectKoopaBall::init() {
     m_angSpeed = INITIAL_ANGULAR_SPEED;
     m_vel.y = INITIAL_Y_VEL;
 
-    m_bombCoreDrawMdl = new Render::DrawMdl;
+    m_bombCoreDrawMdl = EGG::egg_new<Render::DrawMdl>();
 
     auto *resMgr = System::ResourceManager::Instance();
     const void *file = resMgr->getFile("bombCore.brres", nullptr, System::ArchiveId::Core);

--- a/source/game/field/obj/ObjectObakeManager.cc
+++ b/source/game/field/obj/ObjectObakeManager.cc
@@ -13,8 +13,9 @@ ObjectObakeManager::ObjectObakeManager(const System::MapdataGeoObj &params)
     static constexpr f32 BLOCK_HEIGHT = 130.0f;
     static constexpr size_t MAX_FALLING_BLOCKS = 256;
 
-    m_colBox = new ObjectCollisionBox(BLOCK_WIDTH, BLOCK_HEIGHT, BLOCK_WIDTH, EGG::Vector3f::zero);
-    m_colSphere = new ObjectCollisionSphere(1.0f, EGG::Vector3f::zero);
+    m_colBox = EGG::egg_new<ObjectCollisionBox>(BLOCK_WIDTH, BLOCK_HEIGHT, BLOCK_WIDTH,
+            EGG::Vector3f::zero);
+    m_colSphere = EGG::egg_new<ObjectCollisionSphere>(1.0f, EGG::Vector3f::zero);
 
     addBlock(params);
 
@@ -24,11 +25,11 @@ ObjectObakeManager::ObjectObakeManager(const System::MapdataGeoObj &params)
 
 /// @addr{0x8080BEA4}
 ObjectObakeManager::~ObjectObakeManager() {
-    delete m_colBox;
-    delete m_colSphere;
+    EGG::egg_delete(m_colBox);
+    EGG::egg_delete(m_colSphere);
 
     for (auto *&block : m_blocks) {
-        delete block;
+        EGG::egg_delete(block);
     }
 }
 
@@ -162,7 +163,7 @@ bool ObjectObakeManager::checkSphereCachedFullPush(f32 radius, const EGG::Vector
 
 /// @addr{0x8080B244}
 void ObjectObakeManager::addBlock(const System::MapdataGeoObj &params) {
-    auto *block = new ObjectObakeBlock(params);
+    auto *block = EGG::egg_new<ObjectObakeBlock>(params);
     m_blocks.push_back(block);
     auto [spatialX, spatialZ] = SpatialIndex(block->pos());
     m_blockCache[spatialZ][spatialX] = block;

--- a/source/game/field/obj/ObjectObakeManager.hh
+++ b/source/game/field/obj/ObjectObakeManager.hh
@@ -7,6 +7,8 @@
 
 #include "game/system/map/MapdataGeoObj.hh"
 
+#include <egg/core/Allocator.hh>
+
 #include <vector>
 
 namespace Kinoko::Field {
@@ -115,8 +117,9 @@ private:
     /// Spatially-indexed array of blocks for faster collision lookups.
     std::array<std::array<ObjectObakeBlock *, CACHE_SIZE_X>, CACHE_SIZE_Z> m_blockCache;
 
-    std::vector<ObjectObakeBlock *> m_blocks;     ///< All blocks
-    std::vector<ObjectObakeBlock *> m_calcBlocks; ///< Actively falling blocks
+    std::vector<ObjectObakeBlock *, EGG::Allocator<ObjectObakeBlock *>> m_blocks; ///< All blocks
+    std::vector<ObjectObakeBlock *, EGG::Allocator<ObjectObakeBlock *>>
+            m_calcBlocks; ///< Actively falling blocks
 };
 
 } // namespace Kinoko::Field

--- a/source/game/field/obj/ObjectPillar.cc
+++ b/source/game/field/obj/ObjectPillar.cc
@@ -40,8 +40,8 @@ ObjectPillar::ObjectPillar(const System::MapdataGeoObj &params)
     : ObjectKCL(params), m_state(State::Upright), m_fallStart(static_cast<u32>(params.setting(0))),
       m_targetRotation(F_PI * static_cast<f32>(params.setting(1)) / 180.0f), m_initRot(rot().x),
       m_setupRot(EGG::Vector3f::zero) {
-    m_base = new ObjectPillarBase(params);
-    m_collidable = new ObjectPillarC(params);
+    m_base = EGG::egg_new<ObjectPillarBase>(params);
+    m_collidable = EGG::egg_new<ObjectPillarC>(params);
 
     m_base->load();
     m_collidable->load();

--- a/source/game/field/obj/ObjectPress.cc
+++ b/source/game/field/obj/ObjectPress.cc
@@ -106,7 +106,7 @@ void ObjectPress::createCollision() {
             EGG::Vector3f(-45.5f, 143.8f, 40.5f) * POINT_SCALE,
     }};
 
-    m_collision = new ObjectCollisionConvexHull(POINTS);
+    m_collision = EGG::egg_new<ObjectCollisionConvexHull>(POINTS);
 }
 
 /// @addr{0x807782D4}

--- a/source/game/field/obj/ObjectPropeller.cc
+++ b/source/game/field/obj/ObjectPropeller.cc
@@ -13,7 +13,7 @@ ObjectPropeller::ObjectPropeller(const System::MapdataGeoObj &params)
 /// @addr{0x80764E34}
 ObjectPropeller::~ObjectPropeller() {
     for (auto *&blade : m_blades) {
-        delete blade;
+        EGG::egg_delete(blade);
     }
 }
 
@@ -51,7 +51,7 @@ void ObjectPropeller::createCollision() {
     f32 height = static_cast<f32>(parse<s16>(params.height));
 
     for (auto *&blade : m_blades) {
-        blade = new ObjectCollisionCylinder(radius, height, colCenter);
+        blade = EGG::egg_new<ObjectCollisionCylinder>(radius, height, colCenter);
     }
 }
 

--- a/source/game/field/obj/ObjectShip64.cc
+++ b/source/game/field/obj/ObjectShip64.cc
@@ -7,7 +7,7 @@ ObjectShip64::ObjectShip64(const System::MapdataGeoObj &params) : ObjectCollidab
 
 /// @addr{0x80765DB0}
 ObjectShip64::~ObjectShip64() {
-    delete m_auxCollision;
+    EGG::egg_delete(m_auxCollision);
 }
 
 /// @addr{0x80765E30}
@@ -39,7 +39,7 @@ void ObjectShip64::createCollision() {
     constexpr f32 HEIGHT = 3500.0f;
 
     ObjectCollidable::createCollision();
-    m_auxCollision = new ObjectCollisionCylinder(RADIUS, HEIGHT, EGG::Vector3f::zero);
+    m_auxCollision = EGG::egg_new<ObjectCollisionCylinder>(RADIUS, HEIGHT, EGG::Vector3f::zero);
 }
 
 /// @addr{0x807668D4}

--- a/source/game/field/obj/ObjectTownBridge.cc
+++ b/source/game/field/obj/ObjectTownBridge.cc
@@ -22,15 +22,15 @@ ObjectTownBridge::~ObjectTownBridge() {
     // Whichever ObjColMgr is active will be destroyed naturally as part of ObjectKCL's destructor.
     // We need to destroy the other ones to avoid leaking. The base game does not bother doing this.
     if (m_flatColMgr != m_objColMgr) {
-        delete m_flatColMgr;
+        EGG::egg_delete(m_flatColMgr);
     }
 
     if (m_midColMgr != m_objColMgr) {
-        delete m_midColMgr;
+        EGG::egg_delete(m_midColMgr);
     }
 
     if (m_raisedColMgr != m_objColMgr) {
-        delete m_raisedColMgr;
+        EGG::egg_delete(m_raisedColMgr);
     }
 }
 
@@ -65,10 +65,12 @@ void ObjectTownBridge::createCollision() {
     char filepath[128];
 
     snprintf(filepath, sizeof(filepath), "%s2.kcl", name);
-    m_midColMgr = new ObjColMgr(resMgr->getFile(filepath, nullptr, System::ArchiveId::Course));
+    m_midColMgr =
+            EGG::egg_new<ObjColMgr>(resMgr->getFile(filepath, nullptr, System::ArchiveId::Course));
 
     snprintf(filepath, sizeof(filepath), "%s3.kcl", name);
-    m_flatColMgr = new ObjColMgr(resMgr->getFile(filepath, nullptr, System::ArchiveId::Course));
+    m_flatColMgr =
+            EGG::egg_new<ObjColMgr>(resMgr->getFile(filepath, nullptr, System::ArchiveId::Course));
 
     m_raisedColMgr = m_objColMgr;
 }

--- a/source/game/field/obj/ObjectTruckWagon.cc
+++ b/source/game/field/obj/ObjectTruckWagon.cc
@@ -208,7 +208,7 @@ ObjectTruckWagon::ObjectTruckWagon(const System::MapdataGeoObj &params)
     m_carts = owning_span<ObjectTruckWagonCart *>(CART_COUNT);
 
     for (auto *&cart : m_carts) {
-        cart = new ObjectTruckWagonCart(params);
+        cart = EGG::egg_new<ObjectTruckWagonCart>(params);
         cart->load();
     }
 

--- a/source/game/field/obj/ObjectVolcanoBallLauncher.cc
+++ b/source/game/field/obj/ObjectVolcanoBallLauncher.cc
@@ -44,7 +44,7 @@ ObjectVolcanoBallLauncher::ObjectVolcanoBallLauncher(const System::MapdataGeoObj
     m_balls = owning_span<ObjectVolcanoBall *>(ballCount);
 
     for (auto *&ball : m_balls) {
-        ball = new ObjectVolcanoBall(accel, finalVel, endPosY, params, vel);
+        ball = EGG::egg_new<ObjectVolcanoBall>(accel, finalVel, endPosY, params, vel);
         ball->load();
     }
 

--- a/source/game/field/obj/ObjectVolcanoPiece.cc
+++ b/source/game/field/obj/ObjectVolcanoPiece.cc
@@ -17,8 +17,8 @@ ObjectVolcanoPiece::ObjectVolcanoPiece(const System::MapdataGeoObj &params)
 
 /// @addr{0x80803DA8}
 ObjectVolcanoPiece::~ObjectVolcanoPiece() {
-    delete m_colMgrB;
-    delete m_colMgrC;
+    EGG::egg_delete(m_colMgrB);
+    EGG::egg_delete(m_colMgrC);
 }
 
 /// @addr{0x80819400}
@@ -43,7 +43,7 @@ void ObjectVolcanoPiece::createCollision() {
             System::ArchiveId::Course);
 
     if (file) {
-        m_colMgrB = new ObjColMgr(file);
+        m_colMgrB = EGG::egg_new<ObjColMgr>(file);
     }
 
     snprintf(filepath, sizeof(filepath), "%sc.kcl", getKclName());
@@ -51,7 +51,7 @@ void ObjectVolcanoPiece::createCollision() {
             System::ArchiveId::Course);
 
     if (file) {
-        m_colMgrC = new ObjColMgr(file);
+        m_colMgrC = EGG::egg_new<ObjColMgr>(file);
     }
 
     EGG::Matrix34f rtMat;

--- a/source/game/field/obj/ObjectWanwan.cc
+++ b/source/game/field/obj/ObjectWanwan.cc
@@ -34,7 +34,7 @@ ObjectWanwan::ObjectWanwan(const System::MapdataGeoObj &params)
         m_attackArc = 30.0f;
     }
 
-    auto *pile = new ObjectWanwanPile(pos(), rot(), scale());
+    auto *pile = EGG::egg_new<ObjectWanwanPile>(pos(), rot(), scale());
     pile->load();
 
     m_anchor = pos() + ANCHOR_OFFSET;

--- a/source/game/field/obj/ObjectWoodboxW.cc
+++ b/source/game/field/obj/ObjectWoodboxW.cc
@@ -19,7 +19,7 @@ ObjectWoodboxW::ObjectWoodboxW(const System::MapdataGeoObj &params) : ObjectColl
     m_boxes = owning_span<ObjectWoodboxWSub *>(boxCount);
 
     for (auto *&box : m_boxes) {
-        box = new ObjectWoodboxWSub(params);
+        box = EGG::egg_new<ObjectWoodboxWSub>(params);
         box->load();
     }
 }

--- a/source/game/item/ItemDirector.cc
+++ b/source/game/item/ItemDirector.cc
@@ -21,7 +21,7 @@ void ItemDirector::calc() {
 /// @addr{0x80799138}
 ItemDirector *ItemDirector::CreateInstance() {
     ASSERT(!s_instance);
-    s_instance = new ItemDirector;
+    s_instance = EGG::egg_new<ItemDirector>();
     return s_instance;
 }
 
@@ -30,7 +30,7 @@ void ItemDirector::DestroyInstance() {
     ASSERT(s_instance);
     auto *instance = s_instance;
     s_instance = nullptr;
-    delete instance;
+    EGG::egg_delete(instance);
 }
 
 /// @addr{0x807992D8}

--- a/source/game/item/ItemDirector.hh
+++ b/source/game/item/ItemDirector.hh
@@ -39,10 +39,10 @@ public:
         return s_instance;
     }
 
-private:
     ItemDirector();
     ~ItemDirector() override;
 
+private:
     owning_span<KartItem> m_karts;
 
     static ItemDirector *s_instance; ///< @addr{0x809C3618}

--- a/source/game/item/ItemDirector.hh
+++ b/source/game/item/ItemDirector.hh
@@ -39,10 +39,12 @@ public:
         return s_instance;
     }
 
+private:
+    EGG_NEW_DELETE_FRIEND
+
     ItemDirector();
     ~ItemDirector() override;
 
-private:
     owning_span<KartItem> m_karts;
 
     static ItemDirector *s_instance; ///< @addr{0x809C3618}

--- a/source/game/kart/CollisionGroup.cc
+++ b/source/game/kart/CollisionGroup.cc
@@ -43,7 +43,7 @@ Hitbox::Hitbox() : m_bspHitbox(nullptr), m_ownsBSP(false) {}
 /// @addr{0x805B8480}
 Hitbox::~Hitbox() {
     if (m_ownsBSP) {
-        delete m_bspHitbox;
+        EGG::egg_delete(m_bspHitbox);
     }
 }
 
@@ -163,7 +163,7 @@ void CollisionGroup::createSingleHitbox(f32 radius, const EGG::Vector3f &relPos)
     // And how exactly will we identify to free the BSP::Hitbox on destruction?
     for (auto &hitbox : m_hitboxes) {
         hitbox.reset();
-        BSP::Hitbox *bspHitbox = new BSP::Hitbox;
+        BSP::Hitbox *bspHitbox = EGG::egg_new<BSP::Hitbox>();
         hitbox.setBspHitbox(bspHitbox, true);
         bspHitbox->position = relPos;
         bspHitbox->radius = radius;

--- a/source/game/kart/KartBody.cc
+++ b/source/game/kart/KartBody.cc
@@ -47,7 +47,7 @@ KartBodyKart::KartBodyKart(KartPhysics *physics) : KartBody(physics) {}
 
 /// @addr{0x8056E494}
 KartBodyKart::~KartBodyKart() {
-    delete m_physics;
+    EGG::egg_delete(m_physics);
 }
 
 /// @addr{0x8056D858}
@@ -55,7 +55,7 @@ KartBodyBike::KartBodyBike(KartPhysics *physics) : KartBody(physics) {}
 
 /// @addr{0x8056E2BC}
 KartBodyBike::~KartBodyBike() {
-    delete m_physics;
+    EGG::egg_delete(m_physics);
 }
 
 /// @addr{0x8056DD54}

--- a/source/game/kart/KartMove.cc
+++ b/source/game/kart/KartMove.cc
@@ -52,16 +52,16 @@ KartMove::KartMove() : m_smoothedUp(EGG::Vector3f::ey), m_scale(1.0f, 1.0f, 1.0f
 
 /// @addr{0x80587B78}
 KartMove::~KartMove() {
-    delete m_jump;
-    delete m_halfPipe;
-    delete m_kartScale;
+    EGG::egg_delete(m_jump);
+    EGG::egg_delete(m_halfPipe);
+    EGG::egg_delete(m_kartScale);
 }
 
 /// @addr{0x8057821C}
 void KartMove::createSubsystems(const KartParam::Stats &stats) {
-    m_jump = new KartJump(this);
-    m_halfPipe = new KartHalfPipe;
-    m_kartScale = new KartScale(stats);
+    m_jump = EGG::egg_new<KartJump>(this);
+    m_halfPipe = EGG::egg_new<KartHalfPipe>();
+    m_kartScale = EGG::egg_new<KartScale>(stats);
 }
 
 /// @stage All
@@ -2501,9 +2501,9 @@ void KartMoveBike::cancelWheelie() {
 
 /// @addr{0x80587BB8}
 void KartMoveBike::createSubsystems(const KartParam::Stats &stats) {
-    m_jump = new KartJumpBike(this);
-    m_halfPipe = new KartHalfPipe;
-    m_kartScale = new KartScale(stats);
+    m_jump = EGG::egg_new<KartJumpBike>(this);
+    m_halfPipe = EGG::egg_new<KartHalfPipe>();
+    m_kartScale = EGG::egg_new<KartScale>(stats);
 }
 
 /// @stage All

--- a/source/game/kart/KartObject.cc
+++ b/source/game/kart/KartObject.cc
@@ -21,18 +21,18 @@ KartObject::KartObject(KartParam *param) {
 
 /// @addr{0x8058DEF0}
 KartObject::~KartObject() {
-    delete m_pointers.param;
-    delete m_pointers.body;
-    delete m_pointers.sub;
-    delete m_pointers.model;
-    delete m_pointers.objectCollisionKart;
+    EGG::egg_delete(m_pointers.param);
+    EGG::egg_delete(m_pointers.body);
+    EGG::egg_delete(m_pointers.sub);
+    EGG::egg_delete(m_pointers.model);
+    EGG::egg_delete(m_pointers.objectCollisionKart);
 
     for (auto *susp : m_pointers.suspensions) {
-        delete susp;
+        EGG::egg_delete(susp);
     }
 
     for (auto *tire : m_pointers.tires) {
-        delete tire;
+        EGG::egg_delete(tire);
     }
 }
 
@@ -65,9 +65,9 @@ void KartObject::createTires() {
         u16 bspWheelIdx = BSP_WHEEL_INDICES[i];
         KartSuspensionPhysics::TireType tireType = X_MIRRORED_TIRE[i];
 
-        KartSuspension *sus = new KartSuspension;
-        KartTire *tire = (bspWheelIdx == 0) ? new KartTireFront(tireType, bspWheelIdx) :
-                                              new KartTire(tireType, bspWheelIdx);
+        KartSuspension *sus = EGG::egg_new<KartSuspension>();
+        KartTire *tire = (bspWheelIdx == 0) ? EGG::egg_new<KartTireFront>(tireType, bspWheelIdx) :
+                                              EGG::egg_new<KartTire>(tireType, bspWheelIdx);
 
         m_pointers.suspensions.push_back(sus);
         m_pointers.tires.push_back(tire);
@@ -78,7 +78,7 @@ void KartObject::createTires() {
 
 /// @addr{0x8058E5F8}
 KartBody *KartObject::createBody(KartPhysics *physics) {
-    return new KartBodyKart(physics);
+    return EGG::egg_new<KartBodyKart>(physics);
 }
 
 /// @addr{0x8058E22C}
@@ -92,7 +92,7 @@ void KartObject::init() {
     for (u16 tireIdx = 0; tireIdx < m_pointers.param->tireCount(); ++tireIdx) {
         m_pointers.tires[tireIdx]->init(tireIdx);
     }
-    m_pointers.objectCollisionKart = new Field::ObjectCollisionKart();
+    m_pointers.objectCollisionKart = EGG::egg_new<Field::ObjectCollisionKart>();
 }
 
 /// @addr{0x8058E188}
@@ -139,7 +139,7 @@ void KartObject::prepareTiresAndSuspensions() {
 
 /// @addr{0x8058E724}
 void KartObject::createSub() {
-    m_pointers.sub = new KartSub;
+    m_pointers.sub = EGG::egg_new<KartSub>();
     m_pointers.sub->createSubsystems(m_pointers.param->isBike(), m_pointers.param->stats());
 }
 
@@ -148,9 +148,9 @@ void KartObject::createModel() {
     s_proxyList.clear();
 
     if (isBike()) {
-        m_pointers.model = new Render::KartModelBike;
+        m_pointers.model = EGG::egg_new<Render::KartModelBike>();
     } else {
-        m_pointers.model = new Render::KartModelKart;
+        m_pointers.model = EGG::egg_new<Render::KartModelKart>();
     }
 
     ApplyAll(&m_pointers);
@@ -177,13 +177,13 @@ const KartAccessor *KartObject::accessor() const {
 KartObject *KartObject::Create(Character character, Vehicle vehicle, u8 playerIdx) {
     s_proxyList.clear();
 
-    KartParam *param = new KartParam(character, vehicle, playerIdx);
+    KartParam *param = EGG::egg_new<KartParam>(character, vehicle, playerIdx);
 
     KartObject *object = nullptr;
     if (vehicle < Vehicle::Standard_Bike_S) {
-        object = new KartObject(param);
+        object = EGG::egg_new<KartObject>(param);
     } else {
-        object = new KartObjectBike(param);
+        object = EGG::egg_new<KartObjectBike>(param);
     }
 
     object->init();
@@ -212,9 +212,9 @@ KartObjectBike::~KartObjectBike() = default;
 /// @addr{0x8058F260}
 KartBody *KartObjectBike::createBody(KartPhysics *physics) {
     if (m_pointers.param->isVehicleRelativeBike()) {
-        return new KartBodyQuacker(physics);
+        return EGG::egg_new<KartBodyQuacker>(physics);
     } else {
-        return new KartBodyBike(physics);
+        return EGG::egg_new<KartBodyBike>(physics);
     }
 }
 
@@ -225,11 +225,11 @@ void KartObjectBike::createTires() {
         KartTire *tire = nullptr;
 
         if (wheelIdx == 0 || wheelIdx == 2) {
-            sus = new KartSuspensionFrontBike;
-            tire = new KartTireFrontBike(KartSuspensionPhysics::TireType::Bike, 0);
+            sus = EGG::egg_new<KartSuspensionFrontBike>();
+            tire = EGG::egg_new<KartTireFrontBike>(KartSuspensionPhysics::TireType::Bike, 0);
         } else {
-            sus = new KartSuspensionRearBike;
-            tire = new KartTireRearBike(KartSuspensionPhysics::TireType::Bike, 1);
+            sus = EGG::egg_new<KartSuspensionRearBike>();
+            tire = EGG::egg_new<KartTireRearBike>(KartSuspensionPhysics::TireType::Bike, 1);
         }
 
         m_pointers.suspensions.push_back(sus);

--- a/source/game/kart/KartObjectManager.cc
+++ b/source/game/kart/KartObjectManager.cc
@@ -34,7 +34,7 @@ void KartObjectManager::calc() {
 /// @addr{0x8058FAA8}
 KartObjectManager *KartObjectManager::CreateInstance() {
     ASSERT(!s_instance);
-    s_instance = new KartObjectManager;
+    s_instance = EGG::egg_new<KartObjectManager>();
     return s_instance;
 }
 
@@ -43,14 +43,14 @@ void KartObjectManager::DestroyInstance() {
     ASSERT(s_instance);
     auto *instance = s_instance;
     s_instance = nullptr;
-    delete instance;
+    EGG::egg_delete(instance);
 }
 
 /// @addr{0x8058FB2C}
 KartObjectManager::KartObjectManager() {
     const auto &raceScenario = System::RaceConfig::Instance()->raceScenario();
     m_count = raceScenario.playerCount;
-    m_objects = new KartObject *[m_count];
+    m_objects = static_cast<KartObject **>(EGG::egg_alloc(m_count * sizeof(KartObject *)));
     KartParamFileManager::CreateInstance();
 
     loadScaleAnimations();
@@ -73,14 +73,14 @@ KartObjectManager::~KartObjectManager() {
     KartParamFileManager::DestroyInstance();
 
     for (size_t i = 0; i < m_count; ++i) {
-        delete m_objects[i];
+        EGG::egg_delete(m_objects[i]);
     }
 
-    delete[] m_objects;
+    EGG::egg_free(m_objects);
 
-    delete s_thunderScaleUpAnmChr;
-    delete s_thunderScaleDownAnmChr;
-    delete s_pressScaleUpAnmChr;
+    EGG::egg_delete(s_thunderScaleUpAnmChr);
+    EGG::egg_delete(s_thunderScaleDownAnmChr);
+    EGG::egg_delete(s_pressScaleUpAnmChr);
 
     // If the proxy list is not cleared when we're done with the KartObjectManager, the list's
     // destructor calls delete on all of the links remaining in the list. Since the heaps are
@@ -96,11 +96,11 @@ void KartObjectManager::loadScaleAnimations() {
 
     // Copy construct onto the heap
     auto resAnmChr = Abstract::g3d::ResFile(file).resAnmChr("thunder_scale_up");
-    s_thunderScaleUpAnmChr = new Abstract::g3d::ResAnmChr(resAnmChr);
+    s_thunderScaleUpAnmChr = EGG::egg_new<Abstract::g3d::ResAnmChr>(resAnmChr);
     resAnmChr = Abstract::g3d::ResFile(file).resAnmChr("thunder_scale_down");
-    s_thunderScaleDownAnmChr = new Abstract::g3d::ResAnmChr(resAnmChr);
+    s_thunderScaleDownAnmChr = EGG::egg_new<Abstract::g3d::ResAnmChr>(resAnmChr);
     resAnmChr = Abstract::g3d::ResFile(file).resAnmChr("press_scale_up");
-    s_pressScaleUpAnmChr = new Abstract::g3d::ResAnmChr(resAnmChr);
+    s_pressScaleUpAnmChr = EGG::egg_new<Abstract::g3d::ResAnmChr>(resAnmChr);
 }
 
 Abstract::g3d::ResAnmChr *KartObjectManager::s_thunderScaleUpAnmChr = nullptr;

--- a/source/game/kart/KartObjectManager.hh
+++ b/source/game/kart/KartObjectManager.hh
@@ -51,10 +51,12 @@ public:
         return s_instance;
     }
 
+private:
+    EGG_NEW_DELETE_FRIEND
+
     KartObjectManager();
     ~KartObjectManager() override;
 
-private:
     void loadScaleAnimations();
 
     size_t m_count;

--- a/source/game/kart/KartObjectManager.hh
+++ b/source/game/kart/KartObjectManager.hh
@@ -51,10 +51,10 @@ public:
         return s_instance;
     }
 
-private:
     KartObjectManager();
     ~KartObjectManager() override;
 
+private:
     void loadScaleAnimations();
 
     size_t m_count;

--- a/source/game/kart/KartObjectProxy.cc
+++ b/source/game/kart/KartObjectProxy.cc
@@ -471,6 +471,7 @@ void KartObjectProxy::ApplyAll(const KartAccessor *pointers) {
     }
 }
 
-std::list<KartObjectProxy *> KartObjectProxy::s_proxyList; ///< @addr{0x809C1900}
+std::list<KartObjectProxy *, EGG::Allocator<KartObjectProxy *>>
+        KartObjectProxy::s_proxyList; ///< @addr{0x809C1900}
 
 } // namespace Kinoko::Kart

--- a/source/game/kart/KartObjectProxy.hh
+++ b/source/game/kart/KartObjectProxy.hh
@@ -7,6 +7,7 @@
 
 #include "game/system/KPadController.hh"
 
+#include <egg/core/Allocator.hh>
 #include <egg/math/Matrix.hh>
 
 #include <list>
@@ -61,8 +62,8 @@ struct KartAccessor {
     Field::ObjectCollisionKart *objectCollisionKart;
     KartState *state;
 
-    std::vector<KartSuspension *> suspensions;
-    std::vector<KartTire *> tires;
+    std::vector<KartSuspension *, EGG::Allocator<KartSuspension *>> suspensions;
+    std::vector<KartTire *, EGG::Allocator<KartTire *>> tires;
 
     Field::BoxColUnit *boxColUnit;
 };
@@ -169,7 +170,8 @@ public:
     [[nodiscard]] s32 hopStickX() const;
     [[nodiscard]] KartParam::Stats::DriftType vehicleType() const;
 
-    [[nodiscard]] static std::list<KartObjectProxy *> &proxyList() {
+    [[nodiscard]] static std::list<KartObjectProxy *, EGG::Allocator<KartObjectProxy *>> &
+    proxyList() {
         return s_proxyList;
     }
     /// @endGetters
@@ -182,7 +184,8 @@ private:
 
     const KartAccessor *m_accessor;
 
-    static std::list<KartObjectProxy *> s_proxyList; ///< List of all KartObjectProxy children.
+    static std::list<KartObjectProxy *, EGG::Allocator<KartObjectProxy *>>
+            s_proxyList; ///< List of all KartObjectProxy children.
 };
 
 } // namespace Kart

--- a/source/game/kart/KartParamFileManager.cc
+++ b/source/game/kart/KartParamFileManager.cc
@@ -135,7 +135,7 @@ EGG::RamStream KartParamFileManager::getKartCameraStream(Character character) co
 
 KartParamFileManager *KartParamFileManager::CreateInstance() {
     ASSERT(!s_instance);
-    s_instance = new KartParamFileManager;
+    s_instance = EGG::egg_new<KartParamFileManager>();
     return s_instance;
 }
 
@@ -143,7 +143,7 @@ void KartParamFileManager::DestroyInstance() {
     ASSERT(s_instance);
     auto *instance = s_instance;
     s_instance = nullptr;
-    delete instance;
+    EGG::egg_delete(instance);
 }
 
 KartParamFileManager::KartParamFileManager() {

--- a/source/game/kart/KartParamFileManager.hh
+++ b/source/game/kart/KartParamFileManager.hh
@@ -59,9 +59,11 @@ private:
         size_t size;
     };
 
+public:
     KartParamFileManager();
     ~KartParamFileManager() override;
 
+private:
     [[nodiscard]] bool validate() const;
 
     FileInfo m_kartParam;       // kartParam.bin

--- a/source/game/kart/KartParamFileManager.hh
+++ b/source/game/kart/KartParamFileManager.hh
@@ -59,11 +59,11 @@ private:
         size_t size;
     };
 
-public:
+    EGG_NEW_DELETE_FRIEND
+
     KartParamFileManager();
     ~KartParamFileManager() override;
 
-private:
     [[nodiscard]] bool validate() const;
 
     FileInfo m_kartParam;       // kartParam.bin

--- a/source/game/kart/KartPhysics.cc
+++ b/source/game/kart/KartPhysics.cc
@@ -7,15 +7,16 @@ namespace Kinoko::Kart {
 /// @addr{0x8059F5BC}
 KartPhysics::KartPhysics(bool isBike) {
     m_pose = EGG::Matrix34f::ident;
-    m_dynamics = isBike ? new KartDynamicsBike : new KartDynamics;
-    m_hitboxGroup = new CollisionGroup;
+    m_dynamics = isBike ? static_cast<KartDynamics *>(EGG::egg_new<KartDynamicsBike>()) :
+                          EGG::egg_new<KartDynamics>();
+    m_hitboxGroup = EGG::egg_new<CollisionGroup>();
     m_fc = 50.0f; // set immediately after in KartPhysics::Create()
 }
 
 /// @addr{0x8059F6F8}
 KartPhysics::~KartPhysics() {
-    delete m_dynamics;
-    delete m_hitboxGroup;
+    EGG::egg_delete(m_dynamics);
+    EGG::egg_delete(m_hitboxGroup);
 }
 
 /// @addr{0x8059F7C8}
@@ -82,7 +83,7 @@ void KartPhysics::shiftDecayMovingRoadVel(const EGG::Vector3f &v, f32 maxPullSpe
 
 /// @addr{0x805A04A0}
 KartPhysics *KartPhysics::Create(const KartParam &param) {
-    KartPhysics *physics = new KartPhysics(param.isBike());
+    KartPhysics *physics = EGG::egg_new<KartPhysics>(param.isBike());
 
     const BSP &bsp = param.bsp();
 

--- a/source/game/kart/KartSub.cc
+++ b/source/game/kart/KartSub.cc
@@ -23,19 +23,20 @@ KartSub::KartSub() = default;
 
 /// @addr{0x80598AC8}
 KartSub::~KartSub() {
-    delete m_collide;
-    delete m_state;
-    delete m_move;
-    delete m_action;
+    EGG::egg_delete(m_collide);
+    EGG::egg_delete(m_state);
+    EGG::egg_delete(m_move);
+    EGG::egg_delete(m_action);
 }
 
 /// @addr{0x80595D48}
 void KartSub::createSubsystems(bool isBike, const KartParam::Stats &stats) {
-    m_move = isBike ? new KartMoveBike : new KartMove;
-    m_action = new KartAction;
+    m_move = isBike ? static_cast<KartMove *>(EGG::egg_new<KartMoveBike>()) :
+                      EGG::egg_new<KartMove>();
+    m_action = EGG::egg_new<KartAction>();
     m_move->createSubsystems(stats);
-    m_state = new KartState;
-    m_collide = new KartCollide;
+    m_state = EGG::egg_new<KartState>();
+    m_collide = EGG::egg_new<KartCollide>();
 }
 
 /// @brief Called during static construction of KartObject to synchronize the pointers.

--- a/source/game/kart/KartSuspension.cc
+++ b/source/game/kart/KartSuspension.cc
@@ -7,12 +7,12 @@ KartSuspension::KartSuspension() = default;
 
 /// @addr{0x8058F52C}
 KartSuspension::~KartSuspension() {
-    delete m_physics;
+    EGG::egg_delete(m_physics);
 }
 
 /// @addr{0x80598B60}
 void KartSuspension::init(u16 wheelIdx, KartSuspensionPhysics::TireType tireType, u16 bspWheelIdx) {
-    m_physics = new KartSuspensionPhysics(wheelIdx, tireType, bspWheelIdx);
+    m_physics = EGG::egg_new<KartSuspensionPhysics>(wheelIdx, tireType, bspWheelIdx);
 }
 
 /// @addr{0x80598BD4}

--- a/source/game/kart/KartSuspensionPhysics.cc
+++ b/source/game/kart/KartSuspensionPhysics.cc
@@ -17,12 +17,12 @@ WheelPhysics::WheelPhysics(u16 wheelIdx, u16 bspWheelIdx)
 
 /// @addr{0x8059A9C4}
 WheelPhysics::~WheelPhysics() {
-    delete m_hitboxGroup;
+    EGG::egg_delete(m_hitboxGroup);
 }
 
 /// @addr{0x80599470}
 void WheelPhysics::init() {
-    m_hitboxGroup = new CollisionGroup;
+    m_hitboxGroup = EGG::egg_new<CollisionGroup>();
     m_hitboxGroup->createSingleHitbox(10.0f, EGG::Vector3f::zero);
 }
 

--- a/source/game/kart/KartTire.cc
+++ b/source/game/kart/KartTire.cc
@@ -8,12 +8,12 @@ KartTire::KartTire(KartSuspensionPhysics::TireType tireType, u16 bspWheelIdx)
 
 /// @addr{0x8058EC08}
 KartTire::~KartTire() {
-    delete m_wheelPhysics;
+    EGG::egg_delete(m_wheelPhysics);
 }
 
 /// @addr{0x8059AB14}
 void KartTire::createPhysics(u16 tireIdx) {
-    m_wheelPhysics = new WheelPhysics(tireIdx, 1);
+    m_wheelPhysics = EGG::egg_new<WheelPhysics>(tireIdx, 1);
 }
 
 /// @addr{0x8059AAB0}
@@ -36,7 +36,7 @@ KartTireFront::~KartTireFront() = default;
 
 /// @addr{0x8059AC1C}
 void KartTireFront::createPhysics(u16 tireIdx) {
-    m_wheelPhysics = new WheelPhysics(tireIdx, 0);
+    m_wheelPhysics = EGG::egg_new<WheelPhysics>(tireIdx, 0);
 }
 
 KartTireFrontBike::KartTireFrontBike(KartSuspensionPhysics::TireType tireType, u16 bspWheelIdx)
@@ -47,7 +47,7 @@ KartTireFrontBike::~KartTireFrontBike() = default;
 
 /// @addr{0x8059B038}
 void KartTireFrontBike::createPhysics(u16 tireIdx) {
-    m_wheelPhysics = new WheelPhysics(tireIdx, 0);
+    m_wheelPhysics = EGG::egg_new<WheelPhysics>(tireIdx, 0);
 }
 
 KartTireRearBike::KartTireRearBike(KartSuspensionPhysics::TireType tireType, u16 bspWheelIdx)
@@ -58,7 +58,7 @@ KartTireRearBike::~KartTireRearBike() = default;
 
 /// @addr{0x8059B1FC}
 void KartTireRearBike::createPhysics(u16 tireIdx) {
-    m_wheelPhysics = new WheelPhysics(tireIdx, 1);
+    m_wheelPhysics = EGG::egg_new<WheelPhysics>(tireIdx, 1);
 }
 
 } // namespace Kinoko::Kart

--- a/source/game/render/AnmMgr.hh
+++ b/source/game/render/AnmMgr.hh
@@ -4,6 +4,8 @@
 
 #include <abstract/g3d/ResFile.hh>
 
+#include <egg/core/Allocator.hh>
+
 namespace Kinoko::Render {
 
 class DrawMdl;
@@ -55,7 +57,7 @@ public:
 
 private:
     [[maybe_unused]] DrawMdl *m_parent;
-    std::list<AnmNodeChr> m_anmList;
+    std::list<AnmNodeChr, EGG::Allocator<AnmNodeChr>> m_anmList;
     std::array<AnmNodeChr *, static_cast<size_t>(AnmType::Max) - 1> m_activeAnims;
 };
 

--- a/source/game/render/DrawMdl.cc
+++ b/source/game/render/DrawMdl.cc
@@ -6,7 +6,7 @@ namespace Kinoko::Render {
 void DrawMdl::linkAnims(size_t idx, const Abstract::g3d::ResFile *resFile, const char *name,
         AnmType anmType) {
     if (!m_anmMgr) {
-        m_anmMgr = new AnmMgr(this);
+        m_anmMgr = EGG::egg_new<AnmMgr>(this);
     }
 
     m_anmMgr->linkAnims(idx, resFile, name, anmType);

--- a/source/game/render/DrawMdl.hh
+++ b/source/game/render/DrawMdl.hh
@@ -9,7 +9,7 @@ public:
     DrawMdl() : m_anmMgr(nullptr) {}
 
     ~DrawMdl() {
-        delete m_anmMgr;
+        EGG::egg_delete(m_anmMgr);
     }
 
     void linkAnims(size_t idx, const Abstract::g3d::ResFile *resFile, const char *name,

--- a/source/game/render/KartCamera.cc
+++ b/source/game/render/KartCamera.cc
@@ -31,7 +31,7 @@ void KartCamera::calc() {
 
 KartCamera *KartCamera::CreateInstance() {
     ASSERT(!s_instance);
-    s_instance = new KartCamera;
+    s_instance = EGG::egg_new<KartCamera>();
     return s_instance;
 }
 
@@ -39,7 +39,7 @@ void KartCamera::DestroyInstance() {
     ASSERT(s_instance);
     auto *instance = s_instance;
     s_instance = nullptr;
-    delete instance;
+    EGG::egg_delete(instance);
 }
 
 /// @addr{0x805A1D10}

--- a/source/game/render/KartCamera.hh
+++ b/source/game/render/KartCamera.hh
@@ -54,6 +54,9 @@ public:
 
     void calc();
 
+    KartCamera();
+    ~KartCamera();
+
     static KartCamera *CreateInstance();
     static void DestroyInstance();
 
@@ -62,9 +65,6 @@ public:
     }
 
 private:
-    KartCamera();
-    ~KartCamera();
-
     /// @addr{0x805A2B84}
     void calcForward(f32 t, const Kart::KartObjectProxy *proxy) {
         m_forward = Interpolate(t, m_forward, proxy->move()->smoothedForward());

--- a/source/game/scene/GameScene.cc
+++ b/source/game/scene/GameScene.cc
@@ -89,7 +89,7 @@ void GameScene::calcCamera() {
 
 /// @addr{0x8051AA58}
 void GameScene::appendResource(System::MultiDvdArchive *archive, s32 id) {
-    m_resources.push_back(new Resource(archive, id));
+    m_resources.push_back(EGG::egg_new<Resource>(archive, id));
 }
 
 /// @addr{Inlined in 0x8051AA58}
@@ -123,7 +123,7 @@ void GameScene::unmountResources() {
         Resource *resource = *iter;
         resourceManager->unmount(resource->archive);
         iter = m_resources.erase(iter);
-        delete resource;
+        EGG::egg_delete(resource);
     }
 }
 

--- a/source/game/scene/GameScene.hh
+++ b/source/game/scene/GameScene.hh
@@ -2,6 +2,7 @@
 
 #include "game/system/MultiDvdArchive.hh"
 
+#include <egg/core/Allocator.hh>
 #include <egg/core/ExpHeap.hh>
 #include <egg/core/Scene.hh>
 
@@ -57,7 +58,8 @@ private:
 #endif // BUILD_DEBUG
 
     EGG::ExpHeap::GroupSizeRecord m_groupSizeRecord;
-    std::list<Resource *> m_resources; ///< List of all active resources in the scene.
+    std::list<Resource *, EGG::Allocator<Resource *>>
+            m_resources; ///< List of all active resources in the scene.
     int m_nextSceneId;
 
     [[maybe_unused]] size_t m_totalMemoryUsed;

--- a/source/game/system/CourseMap.cc
+++ b/source/game/system/CourseMap.cc
@@ -7,8 +7,8 @@ namespace Kinoko::System {
 /// @addr{0x805127EC}
 void CourseMap::init() {
     void *buffer = LoadFile("course.kmp");
-    m_course =
-            new MapdataFileAccessor(reinterpret_cast<const MapdataFileAccessor::SData *>(buffer));
+    m_course = EGG::egg_new<MapdataFileAccessor>(
+            reinterpret_cast<const MapdataFileAccessor::SData *>(buffer));
 
     constexpr u32 AREA_SIGNATURE = 0x41524541;
     constexpr u32 CANNON_POINT_SIGNATURE = 0x434e5054;
@@ -209,7 +209,7 @@ s16 CourseMap::getCurrentAreaID(s16 i, const EGG::Vector3f &pos, MapdataAreaBase
 /// @addr{0x80512694}
 CourseMap *CourseMap::CreateInstance() {
     ASSERT(!s_instance);
-    s_instance = new CourseMap;
+    s_instance = EGG::egg_new<CourseMap>();
     return s_instance;
 }
 
@@ -218,7 +218,7 @@ void CourseMap::DestroyInstance() {
     ASSERT(s_instance);
     auto *instance = s_instance;
     s_instance = nullptr;
-    delete instance;
+    EGG::egg_delete(instance);
 }
 
 /// @addr{0x8051276C}
@@ -233,16 +233,16 @@ CourseMap::~CourseMap() {
         WARN("CourseMap instance not explicitly handled!");
     }
 
-    delete m_course;
-    delete m_startPoint;
-    delete m_checkPath;
-    delete m_checkPoint;
-    delete m_pointInfo;
-    delete m_geoObj;
-    delete m_area;
-    delete m_jugemPoint;
-    delete m_cannonPoint;
-    delete m_stageInfo;
+    EGG::egg_delete(m_course);
+    EGG::egg_delete(m_startPoint);
+    EGG::egg_delete(m_checkPath);
+    EGG::egg_delete(m_checkPoint);
+    EGG::egg_delete(m_pointInfo);
+    EGG::egg_delete(m_geoObj);
+    EGG::egg_delete(m_area);
+    EGG::egg_delete(m_jugemPoint);
+    EGG::egg_delete(m_cannonPoint);
+    EGG::egg_delete(m_stageInfo);
 }
 
 s16 CourseMap::findSectorBetweenSides(const EGG::Vector3f &pos, MapdataCheckPoint *checkpoint,

--- a/source/game/system/CourseMap.hh
+++ b/source/game/system/CourseMap.hh
@@ -41,7 +41,7 @@ public:
     template <MapdataDerived T>
     [[nodiscard]] T *parseMapdata(u32 sectionName) const {
         const MapSectionHeader *sectionPtr = m_course->findSection(sectionName);
-        return sectionPtr ? new T(sectionPtr) : nullptr;
+        return sectionPtr ? EGG::egg_new<T>(sectionPtr) : nullptr;
     }
 
     [[nodiscard]] s16 findSector(const EGG::Vector3f &pos, u16 checkpointIdx, f32 &distanceRatio);
@@ -184,10 +184,10 @@ public:
         return s_instance;
     }
 
-private:
     CourseMap();
     ~CourseMap() override;
 
+private:
     [[nodiscard]] s16 findSectorBetweenSides(const EGG::Vector3f &pos,
             MapdataCheckPoint *checkpoint, f32 &distanceRatio);
     [[nodiscard]] s16 findSectorOutsideSector(const EGG::Vector3f &pos,

--- a/source/game/system/CourseMap.hh
+++ b/source/game/system/CourseMap.hh
@@ -184,10 +184,12 @@ public:
         return s_instance;
     }
 
+private:
+    EGG_NEW_DELETE_FRIEND
+
     CourseMap();
     ~CourseMap() override;
 
-private:
     [[nodiscard]] s16 findSectorBetweenSides(const EGG::Vector3f &pos,
             MapdataCheckPoint *checkpoint, f32 &distanceRatio);
     [[nodiscard]] s16 findSectorOutsideSector(const EGG::Vector3f &pos,

--- a/source/game/system/DvdArchive.cc
+++ b/source/game/system/DvdArchive.cc
@@ -19,7 +19,7 @@ DvdArchive::~DvdArchive() {
 /// @addr{0x80519508}
 void DvdArchive::decompress() {
     m_archiveSize = EGG::Decomp::GetExpandSize(reinterpret_cast<u8 *>(m_fileStart));
-    m_archiveStart = new u8[m_archiveSize];
+    m_archiveStart = static_cast<u8 *>(EGG::egg_alloc(m_archiveSize));
     EGG::Decomp::DecodeSZS(reinterpret_cast<u8 *>(m_fileStart),
             reinterpret_cast<u8 *>(m_archiveStart));
     m_state = State::Decompressed;
@@ -131,7 +131,7 @@ void DvdArchive::clearArchive() {
         return;
     }
 
-    delete[] static_cast<u8 *>(m_archiveStart);
+    EGG::egg_free(static_cast<u8 *>(m_archiveStart));
     m_archiveStart = nullptr;
     m_archiveSize = 0;
 }
@@ -142,7 +142,7 @@ void DvdArchive::clearFile() {
         return;
     }
 
-    delete[] static_cast<u8 *>(m_fileStart);
+    EGG::egg_free(static_cast<u8 *>(m_fileStart));
     m_fileStart = nullptr;
     m_fileSize = 0;
 }

--- a/source/game/system/KPadController.cc
+++ b/source/game/system/KPadController.cc
@@ -14,9 +14,9 @@ void KPadController::calc() {
 
 /// @addr{0x80520730}
 KPadGhostController::KPadGhostController() : m_acceptingInputs(false) {
-    m_buttonsStreams[0] = new KPadGhostFaceButtonsStream;
-    m_buttonsStreams[1] = new KPadGhostDirectionButtonsStream;
-    m_buttonsStreams[2] = new KPadGhostTrickButtonsStream;
+    m_buttonsStreams[0] = EGG::egg_new<KPadGhostFaceButtonsStream>();
+    m_buttonsStreams[1] = EGG::egg_new<KPadGhostDirectionButtonsStream>();
+    m_buttonsStreams[2] = EGG::egg_new<KPadGhostTrickButtonsStream>();
 }
 
 /// @addr{0x80520924}

--- a/source/game/system/KPadDirector.cc
+++ b/source/game/system/KPadDirector.cc
@@ -41,7 +41,7 @@ void KPadDirector::setHostPad(bool driftIsAuto) {
 /// @addr{0x8052313C}
 KPadDirector *KPadDirector::CreateInstance() {
     ASSERT(!s_instance);
-    return s_instance = new KPadDirector;
+    return s_instance = EGG::egg_new<KPadDirector>();
 }
 
 /// @addr{0x8052318C}
@@ -49,13 +49,13 @@ void KPadDirector::DestroyInstance() {
     ASSERT(s_instance);
     auto *instance = s_instance;
     s_instance = nullptr;
-    delete instance;
+    EGG::egg_delete(instance);
 }
 
 /// @addr{0x805232F0}
 KPadDirector::KPadDirector() {
-    m_ghostController = new KPadGhostController;
-    m_hostController = new KPadHostController;
+    m_ghostController = EGG::egg_new<KPadGhostController>();
+    m_hostController = EGG::egg_new<KPadHostController>();
 }
 
 /// @addr{0x805231DC}

--- a/source/game/system/KPadDirector.hh
+++ b/source/game/system/KPadDirector.hh
@@ -46,10 +46,12 @@ public:
         return s_instance;
     }
 
+private:
+    EGG_NEW_DELETE_FRIEND
+
     KPadDirector();
     ~KPadDirector() override;
 
-private:
     KPadPlayer m_playerInput;
     KPadGhostController *m_ghostController;
     KPadHostController *m_hostController;

--- a/source/game/system/KPadDirector.hh
+++ b/source/game/system/KPadDirector.hh
@@ -46,10 +46,10 @@ public:
         return s_instance;
     }
 
-private:
     KPadDirector();
     ~KPadDirector() override;
 
+private:
     KPadPlayer m_playerInput;
     KPadGhostController *m_ghostController;
     KPadHostController *m_hostController;

--- a/source/game/system/MultiDvdArchive.cc
+++ b/source/game/system/MultiDvdArchive.cc
@@ -8,16 +8,16 @@ static size_t SUFFIX_SIZE = 8;
 
 /// @addr{0x8052A538}
 MultiDvdArchive::MultiDvdArchive(u16 archiveCount) : m_archiveCount(archiveCount) {
-    m_archives = new DvdArchive[archiveCount];
-    m_fileStarts = new void *[archiveCount];
-    m_fileSizes = new size_t[archiveCount];
-    m_suffixes = new char *[archiveCount];
-    m_formats = new Format[archiveCount];
+    m_archives = EGG::egg_new_array<DvdArchive>(archiveCount);
+    m_fileStarts = static_cast<void **>(EGG::egg_alloc(archiveCount * sizeof(void *)));
+    m_fileSizes = static_cast<size_t *>(EGG::egg_alloc(archiveCount * sizeof(size_t)));
+    m_suffixes = static_cast<char **>(EGG::egg_alloc(archiveCount * sizeof(char *)));
+    m_formats = EGG::egg_new_array<Format>(archiveCount);
 
     for (u16 i = 0; i < m_archiveCount; i++) {
         m_fileStarts[i] = nullptr;
         m_fileSizes[i] = 0;
-        m_suffixes[i] = new char[SUFFIX_SIZE];
+        m_suffixes[i] = static_cast<char *>(EGG::egg_alloc(SUFFIX_SIZE));
         strncpy(m_suffixes[i], SZS_EXTENSION, SUFFIX_SIZE);
         m_formats[i] = Format::Double;
     }
@@ -25,13 +25,13 @@ MultiDvdArchive::MultiDvdArchive(u16 archiveCount) : m_archiveCount(archiveCount
 
 /// @addr{0x8052A6DC}
 MultiDvdArchive::~MultiDvdArchive() {
-    delete[] m_archives;
+    EGG::egg_delete_array(m_archives, m_archiveCount);
     // WARN: Could lead to a memory leak if this is the only reference to the file!
-    delete[] m_fileStarts;
-    delete[] m_fileSizes;
+    EGG::egg_free(m_fileStarts);
+    EGG::egg_free(m_fileSizes);
     // WARN: Could lead to a memory leak if the pointer is not static!
-    delete[] m_suffixes;
-    delete[] m_formats;
+    EGG::egg_free(m_suffixes);
+    EGG::egg_delete_array(m_formats, m_archiveCount);
 }
 
 /// @addr{0x8052A760}

--- a/source/game/system/RaceConfig.cc
+++ b/source/game/system/RaceConfig.cc
@@ -59,7 +59,7 @@ void RaceConfig::initGhost() {
 /// @addr{0x8052FE58}
 RaceConfig *RaceConfig::CreateInstance() {
     ASSERT(!s_instance);
-    s_instance = new RaceConfig;
+    s_instance = EGG::egg_new<RaceConfig>();
     return s_instance;
 }
 
@@ -68,7 +68,7 @@ void RaceConfig::DestroyInstance() {
     ASSERT(s_instance);
     auto *instance = s_instance;
     s_instance = nullptr;
-    delete instance;
+    EGG::egg_delete(instance);
 }
 
 /// @addr{0x8053015C}

--- a/source/game/system/RaceConfig.hh
+++ b/source/game/system/RaceConfig.hh
@@ -83,10 +83,12 @@ public:
         return s_instance;
     }
 
+private:
+    EGG_NEW_DELETE_FRIEND
+
     RaceConfig();
     ~RaceConfig() override;
 
-private:
     Scenario m_raceScenario;
     RawGhostFile m_ghost;
 

--- a/source/game/system/RaceConfig.hh
+++ b/source/game/system/RaceConfig.hh
@@ -83,10 +83,10 @@ public:
         return s_instance;
     }
 
-private:
     RaceConfig();
     ~RaceConfig() override;
 
+private:
     Scenario m_raceScenario;
     RawGhostFile m_ghost;
 

--- a/source/game/system/RaceManager.cc
+++ b/source/game/system/RaceManager.cc
@@ -76,7 +76,7 @@ MapdataJugemPoint *RaceManager::jugemPoint() const {
 /// @addr{0x80532084}
 RaceManager *RaceManager::CreateInstance() {
     ASSERT(!s_instance);
-    s_instance = new RaceManager;
+    s_instance = EGG::egg_new<RaceManager>();
     return s_instance;
 }
 
@@ -85,7 +85,7 @@ void RaceManager::DestroyInstance() {
     ASSERT(s_instance);
     auto *instance = s_instance;
     s_instance = nullptr;
-    delete instance;
+    EGG::egg_delete(instance);
 }
 
 /// @addr{0x805327A0}

--- a/source/game/system/RaceManager.hh
+++ b/source/game/system/RaceManager.hh
@@ -154,10 +154,10 @@ public:
         return s_instance;
     }
 
-private:
     RaceManager();
     ~RaceManager() override;
 
+private:
     Random m_random;
     Player m_player;
     TimerManager m_timerManager;

--- a/source/game/system/RaceManager.hh
+++ b/source/game/system/RaceManager.hh
@@ -154,10 +154,12 @@ public:
         return s_instance;
     }
 
+private:
+    EGG_NEW_DELETE_FRIEND
+
     RaceManager();
     ~RaceManager() override;
 
-private:
     Random m_random;
     Player m_player;
     TimerManager m_timerManager;

--- a/source/game/system/ResourceManager.cc
+++ b/source/game/system/ResourceManager.cc
@@ -59,7 +59,7 @@ void ResourceManager::unmount(MultiDvdArchive *archive) {
 /// @addr{0x8053FC4C}
 ResourceManager *ResourceManager::CreateInstance() {
     ASSERT(!s_instance);
-    s_instance = new ResourceManager;
+    s_instance = EGG::egg_new<ResourceManager>();
     return s_instance;
 }
 
@@ -68,12 +68,13 @@ void ResourceManager::DestroyInstance() {
     ASSERT(s_instance);
     auto *instance = s_instance;
     s_instance = nullptr;
-    delete instance;
+    EGG::egg_delete(instance);
 }
 
 /// @addr{0x8053FCEC}
 ResourceManager::ResourceManager() {
-    m_archives = new MultiDvdArchive *[ARCHIVE_COUNT];
+    m_archives = static_cast<MultiDvdArchive **>(
+            EGG::egg_alloc(ARCHIVE_COUNT * sizeof(MultiDvdArchive *)));
     for (u8 i = 0; i < ARCHIVE_COUNT; i++) {
         m_archives[i] = Create(i);
     }
@@ -91,7 +92,7 @@ ResourceManager::~ResourceManager() {
 MultiDvdArchive *ResourceManager::Create(u8 i) {
     switch (i) {
     default:
-        return new MultiDvdArchive;
+        return EGG::egg_new<MultiDvdArchive>();
     }
 }
 

--- a/source/game/system/ResourceManager.hh
+++ b/source/game/system/ResourceManager.hh
@@ -43,10 +43,10 @@ public:
         return s_instance;
     }
 
-private:
     ResourceManager();
     ~ResourceManager() override;
 
+private:
     // 0: Core archive
     // 1: Course archive
     MultiDvdArchive **m_archives;

--- a/source/game/system/ResourceManager.hh
+++ b/source/game/system/ResourceManager.hh
@@ -43,10 +43,12 @@ public:
         return s_instance;
     }
 
+private:
+    EGG_NEW_DELETE_FRIEND
+
     ResourceManager();
     ~ResourceManager() override;
 
-private:
     // 0: Core archive
     // 1: Course archive
     MultiDvdArchive **m_archives;

--- a/source/game/system/map/MapdataAccessorBase.hh
+++ b/source/game/system/map/MapdataAccessorBase.hh
@@ -2,6 +2,8 @@
 
 #include <Common.hh>
 
+#include <egg/core/Heap.hh>
+
 namespace Kinoko::System {
 
 struct MapSectionHeader {
@@ -20,11 +22,10 @@ public:
     virtual ~MapdataAccessorBase() {
         if (m_entries) {
             for (size_t i = 0; i < m_entryCount; ++i) {
-                delete m_entries[i];
+                EGG::egg_delete(m_entries[i]);
             }
+            EGG::egg_free(m_entries);
         }
-
-        delete[] m_entries;
     }
 
     [[nodiscard]] T *get(u16 i) const {
@@ -42,11 +43,11 @@ public:
     void init(const TData *start, u16 count) {
         if (count != 0) {
             m_entryCount = count;
-            m_entries = new T *[count];
+            m_entries = static_cast<T **>(EGG::egg_alloc(count * sizeof(T *)));
         }
 
         for (u16 i = 0; i < count; ++i) {
-            m_entries[i] = new T(&start[i]);
+            m_entries[i] = EGG::egg_new<T>(&start[i]);
         }
     }
 

--- a/source/game/system/map/MapdataArea.cc
+++ b/source/game/system/map/MapdataArea.cc
@@ -136,7 +136,8 @@ MapdataAreaAccessor::~MapdataAreaAccessor() = default;
 void MapdataAreaAccessor::init(const MapdataAreaBase::SData *start, u16 count) {
     if (count != 0) {
         m_entryCount = count;
-        m_entries = new MapdataAreaBase *[count];
+        m_entries =
+                static_cast<MapdataAreaBase **>(EGG::egg_alloc(count * sizeof(MapdataAreaBase *)));
     }
 
     for (u16 i = 0; i < count; ++i) {
@@ -152,10 +153,10 @@ void MapdataAreaAccessor::init(const MapdataAreaBase::SData *start, u16 count) {
 
         switch (shape) {
         case MapdataAreaBase::Shape::Box:
-            m_entries[i] = new MapdataAreaBox(data, i);
+            m_entries[i] = EGG::egg_new<MapdataAreaBox>(data, i);
             break;
         case MapdataAreaBase::Shape::Cylinder:
-            m_entries[i] = new MapdataAreaCylinder(data, i);
+            m_entries[i] = EGG::egg_new<MapdataAreaCylinder>(data, i);
             break;
         default:
             PANIC("Invalid area shape!");

--- a/source/game/system/map/MapdataPointInfo.cc
+++ b/source/game/system/map/MapdataPointInfo.cc
@@ -45,13 +45,15 @@ MapdataPointInfoAccessor::~MapdataPointInfoAccessor() = default;
 void MapdataPointInfoAccessor::init(const MapdataPointInfo::SData *start, u16 count) {
     if (count != 0) {
         m_entryCount = count;
-        m_entries = new MapdataPointInfo *[count];
+        m_entries = static_cast<MapdataPointInfo **>(
+                EGG::egg_alloc(count * sizeof(MapdataPointInfo *)));
     }
 
     uintptr_t data = reinterpret_cast<uintptr_t>(start);
 
     for (u16 i = 0; i < count; ++i) {
-        m_entries[i] = new MapdataPointInfo(reinterpret_cast<MapdataPointInfo::SData *>(data));
+        m_entries[i] =
+                EGG::egg_new<MapdataPointInfo>(reinterpret_cast<MapdataPointInfo::SData *>(data));
         data += m_entries[i]->pointCount() * sizeof(MapdataPointInfo::Point) +
                 offsetof(MapdataPointInfo::SData, points);
     }

--- a/source/host/KReplaySystem.cc
+++ b/source/host/KReplaySystem.cc
@@ -4,6 +4,7 @@
 #include "host/SceneCreatorDynamic.hh"
 
 #include <abstract/File.hh>
+#include <egg/core/Heap.hh>
 
 #include <game/system/RaceManager.hh>
 
@@ -17,8 +18,8 @@ void KReplaySystem::init() {
     ASSERT(m_currentRawGhost);
     ASSERT(m_currentGhost);
 
-    auto *sceneCreator = new Host::SceneCreatorDynamic;
-    m_sceneMgr = new EGG::SceneManager(sceneCreator);
+    auto *sceneCreator = EGG::egg_new<Host::SceneCreatorDynamic>();
+    m_sceneMgr = EGG::egg_new<EGG::SceneManager>(sceneCreator);
 
     System::RaceConfig::RegisterInitCallback(OnInit, nullptr);
     Abstract::File::Remove("results.txt");
@@ -73,7 +74,7 @@ void KReplaySystem::parseOptions(int argc, char **argv) {
             // Creating the raw ghost file validates it
             System::RawGhostFile file = System::RawGhostFile(m_currentRawGhost);
 
-            m_currentGhost = new System::GhostFile(file);
+            m_currentGhost = EGG::egg_new<System::GhostFile>(file);
             ASSERT(m_currentGhost);
         } break;
         case Host::EOption::Invalid:
@@ -86,7 +87,7 @@ void KReplaySystem::parseOptions(int argc, char **argv) {
 
 KReplaySystem *KReplaySystem::CreateInstance() {
     ASSERT(!s_instance);
-    s_instance = new KReplaySystem;
+    s_instance = EGG::egg_new<KReplaySystem>();
     return static_cast<KReplaySystem *>(s_instance);
 }
 
@@ -94,7 +95,7 @@ void KReplaySystem::DestroyInstance() {
     ASSERT(s_instance);
     auto *instance = s_instance;
     s_instance = nullptr;
-    delete instance;
+    EGG::egg_delete(instance);
 }
 
 KReplaySystem::KReplaySystem()
@@ -107,9 +108,9 @@ KReplaySystem::~KReplaySystem() {
         WARN("KReplaySystem instance not explicitly handled!");
     }
 
-    delete m_sceneMgr;
-    delete m_currentGhost;
-    delete m_currentRawGhost;
+    EGG::egg_delete(m_sceneMgr);
+    EGG::egg_delete(m_currentGhost);
+    EGG::egg_free(const_cast<u8 *>(m_currentRawGhost));
 }
 
 /// @brief Determines whether or not the ghost simulation should end.

--- a/source/host/KReplaySystem.hh
+++ b/source/host/KReplaySystem.hh
@@ -23,13 +23,14 @@ public:
         return static_cast<KReplaySystem *>(s_instance);
     }
 
+    KReplaySystem();
+    ~KReplaySystem() override;
+
 private:
     typedef std::pair<const System::Timer &, const System::Timer &> DesyncingTimerPair;
 
-    KReplaySystem();
     KReplaySystem(const KReplaySystem &) = delete;
     KReplaySystem(KReplaySystem &&) = delete;
-    ~KReplaySystem() override;
 
     bool calcEnd() const;
     void reportFail(const std::string &msg) const;

--- a/source/host/KTestSystem.cc
+++ b/source/host/KTestSystem.cc
@@ -2,6 +2,8 @@
 
 #include "host/SceneCreatorDynamic.hh"
 
+#include <egg/core/Heap.hh>
+
 #include <game/kart/KartObjectManager.hh>
 #include <game/system/RaceManager.hh>
 
@@ -31,8 +33,8 @@ struct TestHeader {
 
 /// @brief Initializes the system.
 void KTestSystem::init() {
-    auto *sceneCreator = new Host::SceneCreatorDynamic;
-    m_sceneMgr = new EGG::SceneManager(sceneCreator);
+    auto *sceneCreator = EGG::egg_new<Host::SceneCreatorDynamic>();
+    m_sceneMgr = EGG::egg_new<EGG::SceneManager>(sceneCreator);
 
     System::RaceConfig::RegisterInitCallback(OnInit, nullptr);
     Abstract::File::Remove("results.txt");
@@ -235,7 +237,7 @@ void KTestSystem::parseOptions(int argc, char **argv) {
 
 KTestSystem *KTestSystem::CreateInstance() {
     ASSERT(!s_instance);
-    s_instance = new KTestSystem;
+    s_instance = EGG::egg_new<KTestSystem>();
     return static_cast<KTestSystem *>(s_instance);
 }
 
@@ -243,7 +245,7 @@ void KTestSystem::DestroyInstance() {
     ASSERT(s_instance);
     auto *instance = s_instance;
     s_instance = nullptr;
-    delete instance;
+    EGG::egg_delete(instance);
 }
 
 KTestSystem::KTestSystem() : m_testMode(Host::EOption::Invalid) {}
@@ -296,7 +298,7 @@ void KTestSystem::startNextTestCase() {
 bool KTestSystem::popTestCase() {
     ASSERT(m_testCases.size() > 0);
     m_testCases.pop();
-    delete[] m_stream.data();
+    EGG::egg_free(m_stream.data());
 
     return !m_testCases.empty();
 }
@@ -467,7 +469,7 @@ void KTestSystem::OnInit(System::RaceConfig *config, void * /* arg */) {
     size_t size;
     u8 *rkg = Abstract::File::Load(Instance()->getCurrentTestCase().rkgPath.data(), size);
     config->setGhost(rkg);
-    delete[] rkg;
+    EGG::egg_free(rkg);
 
     config->raceScenario().players[0].type = System::RaceConfig::Player::Type::Ghost;
 }

--- a/source/host/KTestSystem.hh
+++ b/source/host/KTestSystem.hh
@@ -3,6 +3,7 @@
 #include "host/KSystem.hh"
 #include "host/Option.hh"
 
+#include <egg/core/Allocator.hh>
 #include <egg/core/SceneManager.hh>
 #include <egg/math/Quat.hh>
 
@@ -55,10 +56,13 @@ private:
         u8 jugemId;
     };
 
+public:
     KTestSystem();
+    ~KTestSystem() override;
+
+private:
     KTestSystem(const KTestSystem &) = delete;
     KTestSystem(KTestSystem &&) = delete;
-    ~KTestSystem() override;
 
     template <IntegralType T>
     void checkDesync(const T &t0, const T &t1, const char *name) {
@@ -143,7 +147,7 @@ private:
 
     EGG::SceneManager *m_sceneMgr;
     EGG::RamStream m_stream;
-    std::queue<TestCase> m_testCases;
+    std::queue<TestCase, std::deque<TestCase, EGG::Allocator<TestCase>>> m_testCases;
     Host::EOption m_testMode; ///< Differentiates between test suite and ghost+krkg
 
     u16 m_versionMajor;

--- a/source/host/KTestSystem.hh
+++ b/source/host/KTestSystem.hh
@@ -56,11 +56,11 @@ private:
         u8 jugemId;
     };
 
-public:
+    EGG_NEW_DELETE_FRIEND
+
     KTestSystem();
     ~KTestSystem() override;
 
-private:
     KTestSystem(const KTestSystem &) = delete;
     KTestSystem(KTestSystem &&) = delete;
 

--- a/source/host/SceneCreatorDynamic.cc
+++ b/source/host/SceneCreatorDynamic.cc
@@ -1,5 +1,7 @@
 #include "SceneCreatorDynamic.hh"
 
+#include <egg/core/Heap.hh>
+
 #include <game/scene/RaceScene.hh>
 #include <game/scene/RootScene.hh>
 
@@ -17,9 +19,9 @@ void SceneCreatorDynamic::destroy(int sceneId) const {
 EGG::Scene *SceneCreatorDynamic::create(SceneId sceneId) const {
     switch (sceneId) {
     case SceneId::Root:
-        return new Scene::RootScene;
+        return EGG::egg_new<Scene::RootScene>();
     case SceneId::Race:
-        return new Scene::RaceScene;
+        return EGG::egg_new<Scene::RaceScene>();
     default:
         PANIC("Unreachable scene creation!");
     }


### PR DESCRIPTION
Avoids all dependent projects' `operator new` into being forced into EGG::HEAP allocation