### PR TITLE
Skip object factory function for rGV2 ObakeBlock objects

### DIFF
--- a/source/game/field/ObjectDirector.cc
+++ b/source/game/field/ObjectDirector.cc
@@ -213,12 +213,12 @@ void ObjectDirector::createObjects() {
             default:
                 break;
             }
+        } else {
+            ObjectBase *object = createObject(*pObj);
+            object->load();
         }
 
-        ObjectBase *object = createObject(*pObj);
-        object->load();
-
-        if (object->id() == ObjectId::SunDS) {
+        if (static_cast<ObjectId>(pObj->id()) == ObjectId::SunDS) {
             sun = true;
         }
     }


### PR DESCRIPTION
In the base game, the SNES Ghost Valley 2 `obakeblockSFCc`, `obakeblock2SFCc`, and `obakeblock3SFCc` objects are constructed through the `ObjectObakeManager`. We currently match that functionality, but we were accidentally ALSO passing the object to the `createObject` factory function afterwards. To match the base game, we need to skip over the factory function call for these objects.